### PR TITLE
feat: omp-style HUDs for tasks/subagents/workflows + working-indicator gradient + blocked-task notifications

### DIFF
--- a/.obsidian/app.json
+++ b/.obsidian/app.json
@@ -1,0 +1,4 @@
+{
+  "useMarkdownLinks": true,
+  "newLinkFormat": "shortest"
+}

--- a/.obsidian/appearance.json
+++ b/.obsidian/appearance.json
@@ -1,0 +1,4 @@
+{
+  "baseFontSize": 14,
+  "theme": "obsidian"
+}

--- a/docs/knowledge-base/README.md
+++ b/docs/knowledge-base/README.md
@@ -1,0 +1,16 @@
+# openpi-dev 知识库
+
+> openpi 本地开发库（clone from github.com/tt-a1i/openpi）。
+> 目标：commit→tasks 自动同步 hook 尝试 + openpi 架构理解。
+
+## 结构
+- `architecture/` — openpi 整体架构（extension 系统 / pi.on 事件 / 工具注册）
+- `extensions/` — 各 extension 分析（tasks / post-edit / plan-mode / sessions 等）
+- `hook-design/` — commit→tasks hook 设计文档
+- `tasks-mechanism/` — tasks 残留根因分析 + 机制改进
+- `decisions/` — 开发决策记录
+
+## 起因
+批次二完成后 tasks 残留（4 次：T3/T1/T4/T6 状态没同步 commit 完成事实）。
+根因：openpi tasks 无自动同步 hook（纯手动 tasks_update）→ 遗忘必然。
+改进：commit→tasks hook（PostToolUse bash commit → tasks 残留提示）。

--- a/docs/knowledge-base/hook-design/commit-task-sync-design.md
+++ b/docs/knowledge-base/hook-design/commit-task-sync-design.md
@@ -1,0 +1,21 @@
+# commit→tasks hook 设计
+
+## 范本
+post-edit extension（`extensions/post-edit/index.ts`）：
+- 监听 `agent_settled`（turn 结束 debounce）
+- `MUTATING_TOOLS = Set(["write","edit"])` 检测工具成功
+- tool_result 翻标志 → agent_settled 时 pi.exec（fire-and-forget）
+
+## 设计
+新 extension `commit-task-sync`：
+1. 监听 `message_end`：检查 bash tool_result 含 `git commit` + exit 0 → 标志
+2. 下轮 context injection：committedThisTurn + in_progress tasks → 提示
+3. 最小侵入（提示 agent，不自动改 tasks）
+
+## pi.on 可用事件
+session_start/shutdown, model_select, agent_start/settled, message_start/update/end, turn_end, session_compact, session_tree
+
+## 约束
+- 不阻塞 tool pipeline（fire-and-forget，仿 post-edit）
+- 不自动改 tasks（提示 agent 决策——agent 知道哪个 task 对应哪个 commit）
+- 最小信任面（检测 commit 字符串，不执行任意命令）

--- a/docs/knowledge-base/hook-design/commit-task-sync-implementation.md
+++ b/docs/knowledge-base/hook-design/commit-task-sync-implementation.md
@@ -1,41 +1,77 @@
-# commit-task-sync extension 实现
+# commit-task-sync extension 实现 + 验证
 
-> openpi tasks 残留根治尝试。2026-08-11。
+> openpi tasks 残留根治尝试。2026-08-11/12。
+> **状态：PR 已提交**（tt-a1i/openpi#6），双通道验证通过。
 
 ## 问题
 openpi tasks（session 级跟踪）无自动同步——commit/reviewer/授权后 tasks_update 靠 agent 手动记忆 → 遗忘必然（4 次复发：批次一 T3 + 批次二 T1/T4/T6）。
 
-## 方案
-仿 post-edit extension（`pi.on("tool_result")` + `pi.on("agent_settled")`），检测 bash `git commit` 成功 → `agent_settled` 时 `ctx.ui.notify` 提示 agent 同步 tasks。
+## 演进：v1 → v2（dual-channel）
 
-## 实现
-- 文件：`extensions/commit-task-sync/index.ts`（3957B）
-- 核心：
-  - `pi.on("tool_result")`：检测 `event.toolName === "bash"` + `!event.isError` + command 含 `git commit` → 翻标志 `committedThisTurn`（hot path，不阻塞 pipeline）
-  - `pi.on("agent_settled")`：标志为 true → `ctx.ui.notify("⚠️ git commit 检测到 — 请检查 tasks 状态同步")`（fire-and-forget，TUI only）
-  - `pi.on("session_start/shutdown")`：重置标志
-- 设计原则：
-  - **不自动改 tasks**（agent 决策哪个 task 对应哪个 commit）
-  - **不阻塞 pipeline**（tool_result 只翻标志，agent_settled fire-and-forget）
-  - **最小信任面**（检测 `git commit` 字符串 + exit 0，不执行命令）
-  - **TUI only**（仿 post-edit，headless RPC 不触发）
+### v1：ui.notify（TUI 提示，建议性）
+- `pi.on("tool_result")`：检测 bash `git commit` 成功 → 翻标志
+- `pi.on("agent_settled")`：`ctx.ui.notify("⚠️ git commit 检测到")` TUI 警告
+- **局限**：ui.notify 是建议性（agent 可能在对话中忽略 TUI 提示）
 
-## 验证
-- tsc：`npx tsc -p tsconfig.json --noEmit` → exit 0（类型通过，含 commit-task-sync）
-- 注册：自动（tsconfig `include: ["extensions/**/*.ts"]` + package.json `extensions: ["./extensions"]`）
+### v2：context injection（对话注入，强制）——增强
+- 加 `pi.on("context")`：commit 检测后下轮注入 `<commit-task-sync>` 块到 messages
+- **仿 `injectTaskProjection`**（tasks/index.ts:483 `pi.on("context") return { messages }`）
+- **agent 不能忽略**（在对话上下文，不是 TUI 建议性）
+- 注入后 reset（仅提醒一次/commit）
 
-## 测试计划（下一步）
-1. **pi install local**：`pi install /home/umax/work/openpi-dev`（加载 commit-task-sync extension）
-2. **模拟 commit**：在 pi session 中执行 `git commit`（bash 工具）→ 验证 `agent_settled` 时 `ui.notify` 触发「⚠️ git commit 检测到」
-3. **单元测试**（可选）：`extensions/commit-task-sync/index.test.ts`，仿 `post-edit/index.test.ts`（mock pi.on + 模拟 tool_result event + 验证 notify 调用）
+## 双通道设计（v2 最终形态）
 
-## 局限 + 未来增强
-- **ui.notify 是建议性**（agent 可能忽略）：更强版本用 context injection（injectTaskProjection 或 system prompt 注入「⚠️ commit 检测到，有 in_progress tasks 未同步」）
-- **command 提取**（extractCommand）：尝试 event.input/params 多字段（pi event 结构版本差异），可能需适配
-- **不检测 push**（只 commit）：push 是远端操作（无 tool_result 钩子，或 bash push 检测）
-- **不区分仓**（任何 git commit 触发）：可配置只检测特定仓（cwd 匹配）
+| 通道 | 事件 | 效果 | 强度 |
+|---|---|---|---|
+| 1 ui.notify | `agent_settled` | TUI 警告（user 看到） | 建议性 |
+| 2 context injection | `context` | `<commit-task-sync>` 块注入下轮 messages（agent 看到） | **强制** |
 
-## openpi hook 机制发现（本次调查）
-- openpi **有 `pi.on("tool_result")` 事件**（PostToolUse 等价）——之前 rg `PostToolUse` 没命中是因为事件名是 `tool_result`
-- pi.on 可用事件：`tool_result` / `agent_settled` / `session_start/shutdown` / `model_select` / `agent_start` / `message_start/update/end` / `turn_end` / `session_compact` / `session_tree`
-- post-edit extension 是最佳 hook 范本（tool_result 翻标志 + agent_settled 执行 + fire-and-forget）
+**为什么双通道**：ui.notify alone agent 可能忽略；context injection alone user 看不到。双通道 = user + agent 都不可忽略，无盲区。
+
+## Pattern（遵循 openpi 既有 extension 规范）
+- `pi.on("tool_result")`：hot path，boolean flag only（no await/exec）—— same as post-edit's MUTATING_TOOLS
+- `pi.on("agent_settled")`：debounce commit burst → single notify —— same as post-edit
+- `pi.on("context")`：inject reminder → reset flag（remind once per commit）—— same as injectTaskProjection
+- Trust surface: detect `git commit` regex + `!event.isError`；不执行命令，不自动改 tasks（agent decides）
+- TUI only for notify（headless RPC skipped，like post-edit）
+
+## 验证记录（2026-08-12）
+
+### tsc
+- v1: `npx tsc -p tsconfig.json --noEmit` → exit 0（类型通过）
+- v2: 初版 TS2769（pi.on("context") overload 不匹配显式 event 类型）→ 修复（去掉显式 event 类型，仿 tasks:483 推断）→ exit 0
+
+### v1 ui.notify 验证 ✅
+- pi 重启加载 commit-task-sync（settings.json `"../../work/openpi-dev"` extension path）
+- 执行 `echo "git commit test"`（bash 含 git commit + exit 0）
+- **user 确认 TUI 看到**：「⚠️ git commit 检测到 — 请检查 tasks 状态同步」
+
+### v2 context injection 验证 ✅
+- pi 重启加载 v2
+- 执行 `echo "git commit context injection test"`（触发 tool_result → commitDetected=true）
+- **agent 确认下轮上下文看到 `<commit-task-sync>` 块**（在 messages 里，agent 不能忽略）
+- tasks_list 响应提醒 → 无 items（session 重启后空，无残留——正确）
+
+## openpi hook 机制发现（本次调查关键）
+
+| 发现 | 意义 |
+|---|---|
+| openpi **有 `pi.on("tool_result")`** | PostToolUse 等价（之前 rg `PostToolUse` 没命中因事件名不同）|
+| openpi **有 `pi.on("context")`** | context injection 入口（`return { messages }` 替换上下文）|
+| **post-edit extension** 是最佳 hook 范本 | tool_result 翻标志 + agent_settled 执行 + fire-and-forget |
+| **injectTaskProjection**（tasks:483）是 context injection 范本 | `pi.on("context") return { messages }` |
+
+## pi.on 可用事件清单（本次整理）
+`tool_result` / `agent_settled` / `context` / `session_start/shutdown` / `model_select` / `agent_start` / `message_start/update/end` / `turn_end` / `session_compact` / `session_tree`
+
+## PR
+- **tt-a1i/openpi#6**：https://github.com/tt-a1i/openpi/pull/6
+- fork: agnitum2009/openpi:feat/commit-task-sync → tt-a1i/openpi:main
+- 等上游 review/merge
+
+## 文件
+- `extensions/commit-task-sync/index.ts`（5557B，dual-channel）
+- `docs/knowledge-base/`（obsidian vault: 本文件 + residual-root-cause + design + README）
+
+## 结论
+tasks 残留从「靠 agent 记忆力（4 次复发）」变「**机制强制提醒**（commit → 下轮 context 注入 `<commit-task-sync>` 块，agent 不能忽略）」。机制补强（PostToolUse hook），不靠 agent 完美记忆。

--- a/docs/knowledge-base/hook-design/commit-task-sync-implementation.md
+++ b/docs/knowledge-base/hook-design/commit-task-sync-implementation.md
@@ -1,0 +1,41 @@
+# commit-task-sync extension 实现
+
+> openpi tasks 残留根治尝试。2026-08-11。
+
+## 问题
+openpi tasks（session 级跟踪）无自动同步——commit/reviewer/授权后 tasks_update 靠 agent 手动记忆 → 遗忘必然（4 次复发：批次一 T3 + 批次二 T1/T4/T6）。
+
+## 方案
+仿 post-edit extension（`pi.on("tool_result")` + `pi.on("agent_settled")`），检测 bash `git commit` 成功 → `agent_settled` 时 `ctx.ui.notify` 提示 agent 同步 tasks。
+
+## 实现
+- 文件：`extensions/commit-task-sync/index.ts`（3957B）
+- 核心：
+  - `pi.on("tool_result")`：检测 `event.toolName === "bash"` + `!event.isError` + command 含 `git commit` → 翻标志 `committedThisTurn`（hot path，不阻塞 pipeline）
+  - `pi.on("agent_settled")`：标志为 true → `ctx.ui.notify("⚠️ git commit 检测到 — 请检查 tasks 状态同步")`（fire-and-forget，TUI only）
+  - `pi.on("session_start/shutdown")`：重置标志
+- 设计原则：
+  - **不自动改 tasks**（agent 决策哪个 task 对应哪个 commit）
+  - **不阻塞 pipeline**（tool_result 只翻标志，agent_settled fire-and-forget）
+  - **最小信任面**（检测 `git commit` 字符串 + exit 0，不执行命令）
+  - **TUI only**（仿 post-edit，headless RPC 不触发）
+
+## 验证
+- tsc：`npx tsc -p tsconfig.json --noEmit` → exit 0（类型通过，含 commit-task-sync）
+- 注册：自动（tsconfig `include: ["extensions/**/*.ts"]` + package.json `extensions: ["./extensions"]`）
+
+## 测试计划（下一步）
+1. **pi install local**：`pi install /home/umax/work/openpi-dev`（加载 commit-task-sync extension）
+2. **模拟 commit**：在 pi session 中执行 `git commit`（bash 工具）→ 验证 `agent_settled` 时 `ui.notify` 触发「⚠️ git commit 检测到」
+3. **单元测试**（可选）：`extensions/commit-task-sync/index.test.ts`，仿 `post-edit/index.test.ts`（mock pi.on + 模拟 tool_result event + 验证 notify 调用）
+
+## 局限 + 未来增强
+- **ui.notify 是建议性**（agent 可能忽略）：更强版本用 context injection（injectTaskProjection 或 system prompt 注入「⚠️ commit 检测到，有 in_progress tasks 未同步」）
+- **command 提取**（extractCommand）：尝试 event.input/params 多字段（pi event 结构版本差异），可能需适配
+- **不检测 push**（只 commit）：push 是远端操作（无 tool_result 钩子，或 bash push 检测）
+- **不区分仓**（任何 git commit 触发）：可配置只检测特定仓（cwd 匹配）
+
+## openpi hook 机制发现（本次调查）
+- openpi **有 `pi.on("tool_result")` 事件**（PostToolUse 等价）——之前 rg `PostToolUse` 没命中是因为事件名是 `tool_result`
+- pi.on 可用事件：`tool_result` / `agent_settled` / `session_start/shutdown` / `model_select` / `agent_start` / `message_start/update/end` / `turn_end` / `session_compact` / `session_tree`
+- post-edit extension 是最佳 hook 范本（tool_result 翻标志 + agent_settled 执行 + fire-and-forget）

--- a/docs/knowledge-base/hook-design/multi-signal-sync-implementation.md
+++ b/docs/knowledge-base/hook-design/multi-signal-sync-implementation.md
@@ -1,0 +1,58 @@
+# multi-signal-sync extension 实现 + 验证（MECE 完整方案）
+
+> openpi tasks 残留根治，MECE 五类完成信号。2026-08-12。
+> **状态：PR #6（tt-a1i/openpi），A/B/C 信号验证通过。**
+
+## 第一性原理
+tasks 状态（in_progress/blocked → done）应由**真实完成信号**驱动，非 agent 记忆。
+
+## MECE 五类完成信号
+
+| 信号 | 完成事件 | 信号来源 | 触发机制 | 验证 |
+|---|---|---|---|---|
+| A commit | git commit exit 0 | tool_result | COMMIT_PATTERNS 检测 | ✅ |
+| B verify | tsc/test/verify PASS | tool_result | VERIFY_PATTERNS 检测 | ✅ |
+| C authorization | 业主授权/裁定 | context user message | AUTHORIZATION_PATTERNS 检测 | ✅ |
+| D 无变更完成 | 分析/设计结论 | 无信号 | 收口审计纪律 | ✅ 设计 |
+| E 取消/吸收 | dropped/superseded | 无信号 | 收口审计纪律（agent 决策）| ✅ 设计 |
+
+## 演进（commit-task-sync → multi-signal-sync）
+
+- **v1 commit-task-sync**：A commit 单信号，ui.notify（瞬时）
+- **v2 commit-task-sync**：+ context injection（`<commit-task-sync>` 块，agent 不可忽略）
+- **v3 multi-signal-sync**：MECE A/B/C 三信号（tool_result + context），dual-channel
+- **v4 修复**：分离 signals（context 注入）vs pendingNotify（agent_settled notify）——context 注入 reset signals 导致 notify 不触发的 bug
+- **v5 驻留**：notify → footer setStatus（Persistent Status Indicator，跨 render 驻留显示）
+
+## 验证记录（2026-08-12）
+
+### A commit（v2 commit-task-sync 验证）
+- 用户确认 TUI notify「⚠️ git commit 检测到」
+- agent 确认 `<commit-task-sync>` 块注入（context injection）
+
+### B verify + C authorization（v4 multi-signal-sync 验证）
+- 用户发「授权」→ context 检测 → authorization 信号
+- **用户确认 notify「检测到完成信号（commit + 验证通过 + 业主授权）」—— A/B/C 三信号同时触发**
+
+### v5 驻留（footer setStatus）
+- 瞬时 notify → footer setStatus（`ctx.ui.setStatus("multi-signal-sync", ...)`）
+- 跨 render 驻留显示（tui.md Pattern 4: Persistent Status Indicator）
+- 下轮无新信号清除（`setStatus(undefined)`）
+- **待重启加载验证 footer 驻留**
+
+## 关键机制发现（openpi）
+
+| 发现 | 意义 |
+|---|---|
+| `pi.on("tool_result")` | PostToolUse 等价（检测工具成功）|
+| `pi.on("context")` return { messages } | context injection（注入 agent 上下文）|
+| `ctx.ui.setStatus(ext, text)` | footer 驻留状态（跨 render，非瞬时 notify）|
+| `emitter.on(channel, safeHandler)` | EventEmitter 多 handler（多 extension 不冲突）|
+| `ctx.ui.setWidget(key, ...)` | 驻留面板（tasks 的 session-tasks-panel）|
+
+## PR
+- **tt-a1i/openpi#6**（feat/commit-task-sync，含 multi-signal-sync v5）
+- fork: agnitum2009/openpi → tt-a1i/openpi
+
+## 结论
+tasks 残留从「靠 agent 记忆力（4 次复发）」变「**机制强制提醒（MECE 三信号：commit/验证/授权）+ 驻留显示（footer setStatus）+ context 注入（agent 不可忽略）**」。

--- a/docs/knowledge-base/tasks-mechanism/residual-root-cause.md
+++ b/docs/knowledge-base/tasks-mechanism/residual-root-cause.md
@@ -1,0 +1,21 @@
+# tasks 残留根因分析
+
+## 现象
+- 批次一 T3（刀6 申诉）：commit 264af92 + sa-1 复核，但漏标 done
+- 批次二 T1（刀1）：note 更新但 status pending（半同步）
+- 批次二 T4（刀4）：blocked→业主授权落码 2c933d9，但 T4 仍 blocked
+- 批次二 T6（刀6）：blocked→ADR-0009 落地 b9a9341，但 T6 仍 blocked
+
+## 根因（双重）
+1. **遗忘（直接）**：commit/reviewer/授权后没 tasks_update
+2. **机制不全（根本）**：openpi tasks 无自动同步 hook → 遗忘必然 + 无兜底
+
+## 机制缺口（5 点）
+1. 无 commit→tasks 自动同步 hook
+2. 无 tasks 使用规范文档
+3. session 级不持久（compaction 重置）
+4. batch 关闭清空不可追溯
+5. 无完成证据约束（status 转换无 commit SHA 强制）
+
+## 改进方向
+commit→tasks hook（仿 post-edit extension，agent_settled 检测 git commit → 残留提示）

--- a/extensions/commit-task-sync/index.ts
+++ b/extensions/commit-task-sync/index.ts
@@ -1,0 +1,117 @@
+/**
+ * commit-task-sync: detect successful `git commit` → remind agent to sync tasks.
+ *
+ * **Problem**: openpi tasks are session-scoped intent tracking with no auto-sync.
+ * When an agent commits + pushes (real progress) but forgets `tasks_update`,
+ * tasks drift from reality (e.g., T4 blocked→done by owner authorization,
+ * but task still shows blocked).
+ *
+ * **Pattern**: post-edit extension (`pi.on("tool_result")` + `pi.on("agent_settled")`).
+ * - `tool_result` handler: hot path, only flips a boolean flag (no await/exec).
+ * - `agent_settled`: debounces a turn's commit burst into ONE reminder.
+ * - Fire-and-forget: `ctx.ui.notify` is best-effort, never blocks the pipeline.
+ *
+ * **Trust surface**: detect `git commit` string in bash command + `!event.isError`.
+ * Does NOT execute commands, does NOT auto-modify tasks (agent decides).
+ *
+ * **Limitation**: `ui.notify` is advisory (agent may miss it). A stronger version
+ * would inject a system-prompt or context hint on the next turn, but that requires
+ * the context-injection hook (see injectTaskProjection in tasks/index.ts).
+ * This first version uses notify — minimal, safe, non-blocking.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+/** Bash commands that indicate a commit happened. */
+const COMMIT_PATTERNS = [
+  /\bgit\s+commit\b/,
+];
+
+export default function commitTaskSync(pi: ExtensionAPI) {
+  let committedThisTurn = false;
+  let generation = 0;
+
+  /**
+   * tool_result: hot path. Only flip a boolean.
+   * Detects bash tool success with `git commit` in the command.
+   */
+  pi.on(
+    "tool_result",
+    (event: { toolName: string; isError?: boolean; input?: unknown; params?: unknown }) => {
+      if (event.isError) return;
+      if (event.toolName !== "bash") return;
+
+      // Extract command string from event (field name varies by pi version;
+      // try common shapes: input.command, params.command, params, input as string)
+      const command = extractCommand(event);
+      if (!command) return;
+
+      if (COMMIT_PATTERNS.some((pattern) => pattern.test(command))) {
+        committedThisTurn = true;
+      }
+    },
+  );
+
+  /**
+   * agent_settled: turn ended. If committed this turn, remind agent to sync tasks.
+   * Debounces multiple commits in one turn into a single reminder.
+   */
+  pi.on("agent_settled", (_event: unknown, ctx: ExtensionContext) => {
+    if (!committedThisTurn) return;
+    committedThisTurn = false;
+
+    // Only in interactive TUI (not headless RPC, like post-edit).
+    if (ctx.mode !== "tui" || !ctx.hasUI) return;
+
+    try {
+      ctx.ui.notify(
+        "⚠️ git commit 检测到 — 请检查 tasks 状态同步（如有完成项，tasks_update done 带 commit SHA）",
+        "warning",
+      );
+    } catch {
+      // Session may have ended; best-effort notification.
+    }
+  });
+
+  /** Reset on session lifecycle. */
+  pi.on("session_start", () => {
+    generation++;
+    committedThisTurn = false;
+  });
+
+  pi.on("session_shutdown", () => {
+    generation++;
+    committedThisTurn = false;
+  });
+}
+
+/**
+ * Extract the bash command string from a tool_result event.
+ * Pi's event shape may vary; try common field names.
+ */
+function extractCommand(event: {
+  input?: unknown;
+  params?: unknown;
+}): string | null {
+  // Try input.command (object with command field)
+  const fromInput =
+    typeof event.input === "object" && event.input !== null
+      ? (event.input as Record<string, unknown>).command
+      : undefined;
+  if (typeof fromInput === "string") return fromInput;
+
+  // Try params.command
+  const fromParams =
+    typeof event.params === "object" && event.params !== null
+      ? (event.params as Record<string, unknown>).command
+      : undefined;
+  if (typeof fromParams === "string") return fromParams;
+
+  // Try input as string directly
+  if (typeof event.input === "string") return event.input;
+
+  // Try params as string directly
+  if (typeof event.params === "string") return event.params;
+
+  return null;
+}

--- a/extensions/commit-task-sync/index.ts
+++ b/extensions/commit-task-sync/index.ts
@@ -6,18 +6,17 @@
  * tasks drift from reality (e.g., T4 blocked→done by owner authorization,
  * but task still shows blocked).
  *
- * **Pattern**: post-edit extension (`pi.on("tool_result")` + `pi.on("agent_settled")`).
- * - `tool_result` handler: hot path, only flips a boolean flag (no await/exec).
- * - `agent_settled`: debounces a turn's commit burst into ONE reminder.
- * - Fire-and-forget: `ctx.ui.notify` is best-effort, never blocks the pipeline.
+ * **Dual-channel reminder** (v2 enhancement):
+ * 1. `pi.on("agent_settled")` → `ctx.ui.notify` (TUI warning, user sees)
+ * 2. `pi.on("context")` → `injectCommitReminder` (context injection, agent sees next turn)
  *
+ * The context injection is the stronger channel: it appends a `<commit-task-sync>`
+ * block to the next turn's messages, so the agent CANNOT miss it (unlike ui.notify
+ * which is advisory/TUI-only). Pattern: `injectTaskProjection` in tasks/index.ts.
+ *
+ * **Pattern**: post-edit extension (`pi.on("tool_result")` flag + `pi.on("agent_settled")` debounce).
  * **Trust surface**: detect `git commit` string in bash command + `!event.isError`.
  * Does NOT execute commands, does NOT auto-modify tasks (agent decides).
- *
- * **Limitation**: `ui.notify` is advisory (agent may miss it). A stronger version
- * would inject a system-prompt or context hint on the next turn, but that requires
- * the context-injection hook (see injectTaskProjection in tasks/index.ts).
- * This first version uses notify — minimal, safe, non-blocking.
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
@@ -27,8 +26,15 @@ const COMMIT_PATTERNS = [
   /\bgit\s+commit\b/,
 ];
 
+/** Reminder text injected into next turn's context (agent-visible). */
+const REMINDER_TEXT = `⚠️ 上轮检测到 git commit 成功。请检查 tasks 状态同步：
+- 如有完成项（commit/reviewer/授权后 done），**立即 tasks_update done** 带 commit SHA + reviewer 结论
+- 如有 blocked→done（业主授权/ADR 落地），同步 status
+- 这是 commit-task-sync hook 自动提醒（防 tasks 残留，不靠 agent 记忆力）
+commit-task-sync 检测到 commit → 注入此提示到下轮上下文。注入后自动清除（仅提醒一次）。`;
+
 export default function commitTaskSync(pi: ExtensionAPI) {
-  let committedThisTurn = false;
+  let commitDetected = false;
   let generation = 0;
 
   /**
@@ -41,26 +47,21 @@ export default function commitTaskSync(pi: ExtensionAPI) {
       if (event.isError) return;
       if (event.toolName !== "bash") return;
 
-      // Extract command string from event (field name varies by pi version;
-      // try common shapes: input.command, params.command, params, input as string)
       const command = extractCommand(event);
       if (!command) return;
 
       if (COMMIT_PATTERNS.some((pattern) => pattern.test(command))) {
-        committedThisTurn = true;
+        commitDetected = true;
       }
     },
   );
 
   /**
-   * agent_settled: turn ended. If committed this turn, remind agent to sync tasks.
-   * Debounces multiple commits in one turn into a single reminder.
+   * Channel 1 — agent_settled: TUI notify (user-visible, advisory).
+   * Does NOT reset commitDetected (context handler owns the reset).
    */
   pi.on("agent_settled", (_event: unknown, ctx: ExtensionContext) => {
-    if (!committedThisTurn) return;
-    committedThisTurn = false;
-
-    // Only in interactive TUI (not headless RPC, like post-edit).
+    if (!commitDetected) return;
     if (ctx.mode !== "tui" || !ctx.hasUI) return;
 
     try {
@@ -73,16 +74,61 @@ export default function commitTaskSync(pi: ExtensionAPI) {
     }
   });
 
+  /**
+   * Channel 2 — context: inject reminder into next turn's messages (agent-visible, mandatory).
+   * This is the STRONGER channel: agent cannot miss it (it's in the conversation context).
+   * Resets commitDetected after injection (remind once per commit).
+   *
+   * Pattern: injectTaskProjection in tasks/index.ts (:483) — return { messages } to replace.
+   */
+  pi.on("context", (event) => {
+    if (!commitDetected) return;
+    commitDetected = false; // Inject once, then reset
+
+    const messages = injectCommitReminder(event.messages);
+    if (messages) {
+      return { messages: messages as typeof event.messages };
+    }
+  });
+
   /** Reset on session lifecycle. */
   pi.on("session_start", () => {
     generation++;
-    committedThisTurn = false;
+    commitDetected = false;
   });
 
   pi.on("session_shutdown", () => {
     generation++;
-    committedThisTurn = false;
+    commitDetected = false;
   });
+}
+
+/**
+ * Inject commit-task-sync reminder into messages (agent-visible next turn).
+ * Pattern: injectTaskProjection in tasks/index.ts — clone, append block to last user message.
+ */
+function injectCommitReminder(messages: unknown[]): unknown[] | undefined {
+  const next = structuredClone(messages) as Array<{
+    role?: string;
+    content?: unknown;
+  }>;
+  for (let index = next.length - 1; index >= 0; index--) {
+    const message = next[index];
+    if (message.role !== "user") continue;
+    const block = {
+      type: "text",
+      text: `\n\n<commit-task-sync>\n${REMINDER_TEXT}\n</commit-task-sync>`,
+    };
+    if (typeof message.content === "string") {
+      message.content = [{ type: "text", text: message.content }, block];
+    } else if (Array.isArray(message.content)) {
+      message.content.push(block);
+    } else {
+      return undefined;
+    }
+    return next;
+  }
+  return undefined;
 }
 
 /**

--- a/extensions/goal/index.ts
+++ b/extensions/goal/index.ts
@@ -481,7 +481,27 @@ export default function sessionGoal(pi: ExtensionAPI) {
     controller.settled(ctx);
     controller.settledWithoutAcknowledgement();
     updateUi(ctx);
+    notifyBlockedGoal(ctx);
   });
+
+  // A blocked goal needs a human in the loop (owner ruling, external wait);
+  // the footer says so but nothing raises an event. Announce it once per
+  // blocked stint, re-armed when the goal leaves the blocked state.
+  let notifiedGoalBlocked = false;
+  const notifyBlockedGoal = (ctx: ExtensionContext) => {
+    if (!ctx.hasUI) return;
+    const goal = controller.snapshot();
+    if (goal?.status === "blocked") {
+      if (notifiedGoalBlocked) return;
+      notifiedGoalBlocked = true;
+      ctx.ui.notify(
+        `Goal blocked: ${goal.objective} — 需要人工介入 (/goal resume)`,
+        "warning",
+      );
+    } else {
+      notifiedGoalBlocked = false;
+    }
+  };
 
   pi.on("session_shutdown", (_event, ctx) => {
     controller.shutdown();

--- a/extensions/multi-signal-sync/index.ts
+++ b/extensions/multi-signal-sync/index.ts
@@ -13,7 +13,7 @@
  * A/B/C are detectable — this extension covers A/B/C.
  *
  * **Dual-channel reminder**:
- * 1. `pi.on("agent_settled")` → `ctx.ui.notify` (TUI warning, user sees)
+ * 1. `pi.on("agent_settled")` → pin onto the Tasks widget (TUI, user sees)
  * 2. `pi.on("context")` → `injectSyncReminder` (context injection, agent sees next turn)
  *
  * **Pattern**: post-edit extension (tool_result flag + agent_settled debounce)
@@ -21,7 +21,11 @@
  * **Trust surface**: regex detection only; no exec, no auto task mutation.
  */
 
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { setTaskWidgetAttachment } from "../shared/task-widget-attachment.ts";
 
 /** A. Bash commands indicating a commit happened. */
 const COMMIT_PATTERNS = [/\bgit\s+commit\b/];
@@ -56,9 +60,9 @@ const SIGNAL_LABEL: Record<SignalKind, string> = {
 };
 
 export default function multiSignalSync(pi: ExtensionAPI) {
-  let signals: SignalKind[] = [];      // context 注入用（下轮消费）
-  let pendingNotify: SignalKind[] = []; // agent_settled footer 驻留用（本轮消费）
-  let statusShown = false;              // footer 驻留状态已显示标记
+  let signals: SignalKind[] = []; // context 注入用（下轮消费）
+  let pendingNotify: SignalKind[] = []; // agent_settled Tasks-widget 驻留用（本轮消费）
+  let statusShown = false; // footer 驻留状态已显示标记
   let generation = 0;
 
   /** Add a signal to both channels (dedupe). */
@@ -73,7 +77,12 @@ export default function multiSignalSync(pi: ExtensionAPI) {
    */
   pi.on(
     "tool_result",
-    (event: { toolName: string; isError?: boolean; input?: unknown; params?: unknown }) => {
+    (event: {
+      toolName: string;
+      isError?: boolean;
+      input?: unknown;
+      params?: unknown;
+    }) => {
       if (event.isError) return;
       if (event.toolName !== "bash") return;
 
@@ -111,9 +120,11 @@ export default function multiSignalSync(pi: ExtensionAPI) {
   });
 
   /**
-   * Channel 1 — agent_settled: footer 驻留状态（Persistent Status Indicator，跨 render 显示）。
-   * 信号轮：setStatus 驻留显示（持续可见，非瞬时 notify）。
-   * 下一轮（无新信号）：清除 footer 状态。
+   * Channel 1 — agent_settled: pin the completion reminder onto the Tasks
+   * widget (Persistent Status Indicator，跨 render 显示). It renders as the
+   * first row under the `◆ Tasks` census header, so the reminder lives where
+   * the list it asks to sync is — not in the footer status bar below the
+   * input. 下一轮（无新信号）：清除该行。
    */
   pi.on("agent_settled", (_event: unknown, ctx: ExtensionContext) => {
     if (ctx.mode !== "tui" || !ctx.hasUI) return;
@@ -121,13 +132,10 @@ export default function multiSignalSync(pi: ExtensionAPI) {
       if (pendingNotify.length > 0) {
         const labels = pendingNotify.map((s) => SIGNAL_LABEL[s]).join(" + ");
         pendingNotify = [];
-        ctx.ui.setStatus(
-          "multi-signal-sync",
-          `⚠️ 完成信号（${labels}）— 请同步 tasks`,
-        );
+        setTaskWidgetAttachment(`⚠️ 完成信号（${labels}）— 请同步 tasks`);
         statusShown = true;
       } else if (statusShown) {
-        ctx.ui.setStatus("multi-signal-sync", undefined);
+        setTaskWidgetAttachment(undefined);
         statusShown = false;
       }
     } catch {
@@ -141,6 +149,7 @@ export default function multiSignalSync(pi: ExtensionAPI) {
     signals = [];
     pendingNotify = [];
     statusShown = false;
+    setTaskWidgetAttachment(undefined);
   });
 
   pi.on("session_shutdown", () => {
@@ -148,6 +157,7 @@ export default function multiSignalSync(pi: ExtensionAPI) {
     signals = [];
     pendingNotify = [];
     statusShown = false;
+    setTaskWidgetAttachment(undefined);
   });
 }
 
@@ -200,7 +210,8 @@ function injectSyncReminder(
  */
 function lastUserMessageHasAuthorization(messages: unknown[]): boolean {
   for (let index = messages.length - 1; index >= 0; index--) {
-    const message = messages[index] as { role?: string; content?: unknown } | undefined;
+    const message = messages[index] as
+      { role?: string; content?: unknown } | undefined;
     if (!message || message.role !== "user") continue;
     const text = messageContentText(message.content);
     if (!text) return false; // last user message has no text → no auth signal

--- a/extensions/multi-signal-sync/index.ts
+++ b/extensions/multi-signal-sync/index.ts
@@ -56,12 +56,14 @@ const SIGNAL_LABEL: Record<SignalKind, string> = {
 };
 
 export default function multiSignalSync(pi: ExtensionAPI) {
-  let signals: SignalKind[] = [];
+  let signals: SignalKind[] = [];      // context 注入用（下轮消费）
+  let pendingNotify: SignalKind[] = []; // agent_settled notify 用（本轮消费）
   let generation = 0;
 
-  /** Add a signal (dedupe). */
+  /** Add a signal to both channels (dedupe). */
   const addSignal = (kind: SignalKind) => {
     if (!signals.includes(kind)) signals.push(kind);
+    if (!pendingNotify.includes(kind)) pendingNotify.push(kind);
   };
 
   /**
@@ -111,11 +113,12 @@ export default function multiSignalSync(pi: ExtensionAPI) {
    * Channel 1 — agent_settled: TUI notify (user-visible, advisory).
    */
   pi.on("agent_settled", (_event: unknown, ctx: ExtensionContext) => {
-    if (signals.length === 0) return;
+    if (pendingNotify.length === 0) return;
     if (ctx.mode !== "tui" || !ctx.hasUI) return;
 
     try {
-      const labels = signals.map((s) => SIGNAL_LABEL[s]).join(" + ");
+      const labels = pendingNotify.map((s) => SIGNAL_LABEL[s]).join(" + ");
+      pendingNotify = [];
       ctx.ui.notify(
         `⚠️ 检测到完成信号（${labels}）— 请检查 tasks 状态同步（如有完成项，tasks_update done 带 commit SHA）`,
         "warning",
@@ -129,11 +132,13 @@ export default function multiSignalSync(pi: ExtensionAPI) {
   pi.on("session_start", () => {
     generation++;
     signals = [];
+    pendingNotify = [];
   });
 
   pi.on("session_shutdown", () => {
     generation++;
     signals = [];
+    pendingNotify = [];
   });
 }
 

--- a/extensions/multi-signal-sync/index.ts
+++ b/extensions/multi-signal-sync/index.ts
@@ -57,7 +57,8 @@ const SIGNAL_LABEL: Record<SignalKind, string> = {
 
 export default function multiSignalSync(pi: ExtensionAPI) {
   let signals: SignalKind[] = [];      // context 注入用（下轮消费）
-  let pendingNotify: SignalKind[] = []; // agent_settled notify 用（本轮消费）
+  let pendingNotify: SignalKind[] = []; // agent_settled footer 驻留用（本轮消费）
+  let statusShown = false;              // footer 驻留状态已显示标记
   let generation = 0;
 
   /** Add a signal to both channels (dedupe). */
@@ -110,21 +111,27 @@ export default function multiSignalSync(pi: ExtensionAPI) {
   });
 
   /**
-   * Channel 1 — agent_settled: TUI notify (user-visible, advisory).
+   * Channel 1 — agent_settled: footer 驻留状态（Persistent Status Indicator，跨 render 显示）。
+   * 信号轮：setStatus 驻留显示（持续可见，非瞬时 notify）。
+   * 下一轮（无新信号）：清除 footer 状态。
    */
   pi.on("agent_settled", (_event: unknown, ctx: ExtensionContext) => {
-    if (pendingNotify.length === 0) return;
     if (ctx.mode !== "tui" || !ctx.hasUI) return;
-
     try {
-      const labels = pendingNotify.map((s) => SIGNAL_LABEL[s]).join(" + ");
-      pendingNotify = [];
-      ctx.ui.notify(
-        `⚠️ 检测到完成信号（${labels}）— 请检查 tasks 状态同步（如有完成项，tasks_update done 带 commit SHA）`,
-        "warning",
-      );
+      if (pendingNotify.length > 0) {
+        const labels = pendingNotify.map((s) => SIGNAL_LABEL[s]).join(" + ");
+        pendingNotify = [];
+        ctx.ui.setStatus(
+          "multi-signal-sync",
+          `⚠️ 完成信号（${labels}）— 请同步 tasks`,
+        );
+        statusShown = true;
+      } else if (statusShown) {
+        ctx.ui.setStatus("multi-signal-sync", undefined);
+        statusShown = false;
+      }
     } catch {
-      // Session may have ended; best-effort notification.
+      // Session may have ended; best-effort status update.
     }
   });
 
@@ -133,12 +140,14 @@ export default function multiSignalSync(pi: ExtensionAPI) {
     generation++;
     signals = [];
     pendingNotify = [];
+    statusShown = false;
   });
 
   pi.on("session_shutdown", () => {
     generation++;
     signals = [];
     pendingNotify = [];
+    statusShown = false;
   });
 }
 

--- a/extensions/multi-signal-sync/index.ts
+++ b/extensions/multi-signal-sync/index.ts
@@ -1,0 +1,237 @@
+/**
+ * multi-signal-sync: MECE task-completion signals → remind agent to sync tasks.
+ *
+ * Upgrades commit-task-sync (single A signal) to full MECE coverage:
+ * - **A. commit**  (git commit exit 0)          — via tool_result
+ * - **B. verify**  (tsc/test/verify PASS exit 0) — via tool_result
+ * - **C. auth**    (owner authorization in user message) — via context
+ *
+ * **First principles**: task status (in_progress/blocked → done) should be
+ * driven by REAL completion signals, not agent memory. MECE decomposition of
+ * completion signals = commit / verify / authorization / no-change (D) /
+ * cancelled (E). D/E have no signal (agent discipline + closeout audit);
+ * A/B/C are detectable — this extension covers A/B/C.
+ *
+ * **Dual-channel reminder**:
+ * 1. `pi.on("agent_settled")` → `ctx.ui.notify` (TUI warning, user sees)
+ * 2. `pi.on("context")` → `injectSyncReminder` (context injection, agent sees next turn)
+ *
+ * **Pattern**: post-edit extension (tool_result flag + agent_settled debounce)
+ * + injectTaskProjection (tasks/index.ts:483 context return { messages }).
+ * **Trust surface**: regex detection only; no exec, no auto task mutation.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+/** A. Bash commands indicating a commit happened. */
+const COMMIT_PATTERNS = [/\bgit\s+commit\b/];
+
+/** B. Bash commands indicating verification passed (tsc/test/verify). */
+const VERIFY_PATTERNS = [
+  /\btsc\b/,
+  /\bnpx\s+tsc\b/,
+  /\bnpm\s+run\s+verify/,
+  /\bnode\s+scripts\/verify/,
+  /--test\b/,
+  /\bverify:/,
+];
+
+/** C. Owner authorization phrases (user message). */
+const AUTHORIZATION_PATTERNS = [
+  /授权/,
+  /同意/,
+  /批准/,
+  /裁定/,
+  /\bapproved\b/i,
+  /\bauthorized\b/i,
+];
+
+type SignalKind = "commit" | "verify" | "authorization";
+
+/** Signal → Chinese label for the reminder. */
+const SIGNAL_LABEL: Record<SignalKind, string> = {
+  commit: "commit",
+  verify: "验证通过",
+  authorization: "业主授权",
+};
+
+export default function multiSignalSync(pi: ExtensionAPI) {
+  let signals: SignalKind[] = [];
+  let generation = 0;
+
+  /** Add a signal (dedupe). */
+  const addSignal = (kind: SignalKind) => {
+    if (!signals.includes(kind)) signals.push(kind);
+  };
+
+  /**
+   * A + B: tool_result — hot path, boolean flag only (no await/exec).
+   * Detects bash tool success with commit/verify commands.
+   */
+  pi.on(
+    "tool_result",
+    (event: { toolName: string; isError?: boolean; input?: unknown; params?: unknown }) => {
+      if (event.isError) return;
+      if (event.toolName !== "bash") return;
+
+      const command = extractCommand(event);
+      if (!command) return;
+
+      if (COMMIT_PATTERNS.some((pattern) => pattern.test(command))) {
+        addSignal("commit");
+      }
+      if (VERIFY_PATTERNS.some((pattern) => pattern.test(command))) {
+        addSignal("verify");
+      }
+    },
+  );
+
+  /**
+   * C + reminder: context — check last user message for authorization phrases,
+   * then inject reminder into next turn's messages if any signal detected.
+   */
+  pi.on("context", (event) => {
+    // C: authorization in last user message
+    if (lastUserMessageHasAuthorization(event.messages)) {
+      addSignal("authorization");
+    }
+
+    // Inject reminder if any signal detected (once, then reset)
+    if (signals.length === 0) return;
+    const detected = signals;
+    signals = [];
+
+    const messages = injectSyncReminder(event.messages, detected);
+    if (messages) {
+      return { messages: messages as typeof event.messages };
+    }
+  });
+
+  /**
+   * Channel 1 — agent_settled: TUI notify (user-visible, advisory).
+   */
+  pi.on("agent_settled", (_event: unknown, ctx: ExtensionContext) => {
+    if (signals.length === 0) return;
+    if (ctx.mode !== "tui" || !ctx.hasUI) return;
+
+    try {
+      const labels = signals.map((s) => SIGNAL_LABEL[s]).join(" + ");
+      ctx.ui.notify(
+        `⚠️ 检测到完成信号（${labels}）— 请检查 tasks 状态同步（如有完成项，tasks_update done 带 commit SHA）`,
+        "warning",
+      );
+    } catch {
+      // Session may have ended; best-effort notification.
+    }
+  });
+
+  /** Reset on session lifecycle. */
+  pi.on("session_start", () => {
+    generation++;
+    signals = [];
+  });
+
+  pi.on("session_shutdown", () => {
+    generation++;
+    signals = [];
+  });
+}
+
+/** Build reminder text for the detected signals. */
+function buildReminderText(signals: SignalKind[]): string {
+  const labels = signals.map((s) => SIGNAL_LABEL[s]).join(" + ");
+  return `⚠️ 上轮检测到完成信号（${labels}）。请检查 tasks 状态同步：
+- commit/验证通过 → 如有完成项，**立即 tasks_update done** 带 commit SHA + reviewer 结论
+- 业主授权 → 如有 blocked task 因授权解除阻塞，同步 status（blocked→done）
+- 无变更完成（分析/设计结论）→ 收口时 tasks_update（此类型无信号，靠收口审计纪律）
+- 这是 multi-signal-sync hook 自动提醒（MECE：commit/验证/授权 三信号，防 tasks 残留）
+注入后自动清除（仅提醒一次/信号）。`;
+}
+
+/**
+ * Inject reminder into messages (agent-visible next turn).
+ * Pattern: injectTaskProjection in tasks/index.ts.
+ */
+function injectSyncReminder(
+  messages: unknown[],
+  signals: SignalKind[],
+): unknown[] | undefined {
+  const next = structuredClone(messages) as Array<{
+    role?: string;
+    content?: unknown;
+  }>;
+  const text = buildReminderText(signals);
+  for (let index = next.length - 1; index >= 0; index--) {
+    const message = next[index];
+    if (message.role !== "user") continue;
+    const block = {
+      type: "text",
+      text: `\n\n<multi-signal-sync>\n${text}\n</multi-signal-sync>`,
+    };
+    if (typeof message.content === "string") {
+      message.content = [{ type: "text", text: message.content }, block];
+    } else if (Array.isArray(message.content)) {
+      message.content.push(block);
+    } else {
+      return undefined;
+    }
+    return next;
+  }
+  return undefined;
+}
+
+/**
+ * Check the last user message for authorization phrases (signal C).
+ * Iterates messages from the end; finds the most recent user message.
+ */
+function lastUserMessageHasAuthorization(messages: unknown[]): boolean {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index] as { role?: string; content?: unknown } | undefined;
+    if (!message || message.role !== "user") continue;
+    const text = messageContentText(message.content);
+    if (!text) return false; // last user message has no text → no auth signal
+    return AUTHORIZATION_PATTERNS.some((pattern) => pattern.test(text));
+  }
+  return false;
+}
+
+/** Flatten message content (string or blocks) to text. */
+function messageContentText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((block) =>
+        typeof block === "object" && block !== null && "text" in block
+          ? String((block as { text: unknown }).text)
+          : "",
+      )
+      .join("\n");
+  }
+  return "";
+}
+
+/**
+ * Extract the bash command string from a tool_result event.
+ * Pi's event shape may vary; try common field names.
+ */
+function extractCommand(event: {
+  input?: unknown;
+  params?: unknown;
+}): string | null {
+  const fromInput =
+    typeof event.input === "object" && event.input !== null
+      ? (event.input as Record<string, unknown>).command
+      : undefined;
+  if (typeof fromInput === "string") return fromInput;
+
+  const fromParams =
+    typeof event.params === "object" && event.params !== null
+      ? (event.params as Record<string, unknown>).command
+      : undefined;
+  if (typeof fromParams === "string") return fromParams;
+
+  if (typeof event.input === "string") return event.input;
+  if (typeof event.params === "string") return event.params;
+
+  return null;
+}

--- a/extensions/shared/task-widget-attachment.ts
+++ b/extensions/shared/task-widget-attachment.ts
@@ -1,0 +1,18 @@
+/**
+ * Cross-extension note row for the Tasks widget.
+ *
+ * A sibling extension (the multi-signal-sync completion reminder) can pin a
+ * one-line notice to the Tasks HUD, so completion-signal reminders surface
+ * exactly where the task list lives instead of competing for the footer
+ * status bar. The value is read synchronously at every widget render, so a
+ * setter call is visible on the next repaint with no extra plumbing.
+ */
+let attachment: string | undefined;
+
+export function setTaskWidgetAttachment(text: string | undefined): void {
+  attachment = text;
+}
+
+export function getTaskWidgetAttachment(): string | undefined {
+  return attachment;
+}

--- a/extensions/subagents/index.ts
+++ b/extensions/subagents/index.ts
@@ -60,11 +60,6 @@ import {
   REASONING_EFFORTS,
   type SubagentSnapshot,
 } from "./src/domain.ts";
-import {
-  formatActivityStatus,
-  hasActivity,
-  unreadActivityCounts,
-} from "../shared/activity-status.ts";
 import { formatContextUtilization } from "./src/format.ts";
 import { SubagentManager, type SubagentManagerShape } from "./src/manager.ts";
 import {
@@ -240,25 +235,25 @@ export default function (pi: ExtensionAPI) {
       widgetKey,
       (tui, theme) => {
         requestWidgetRender = () => tui.requestRender();
-        return new SubagentStripWidget(tui, theme, stripState, stripEntry);
+        return new SubagentStripWidget(
+          tui,
+          theme,
+          stripState,
+          stripEntry,
+          () => navigationManager?.view.list() ?? [],
+        );
       },
-      { placement: "belowEditor" },
+      // Above the editor, like omp's sticky Subagents HUD: one contiguous block
+      // between the transcript and the prompt, never torn apart by tool rows.
+      { placement: "aboveEditor" },
     );
     widgetVisible = true;
   };
 
   const updateStatus = (manager: SubagentManagerShape) => {
-    if (!ui) return;
-    const counts = unreadActivityCounts(
-      manager.view.list(),
-      settledAcknowledgedAt,
-    );
-    ui.setStatus(
-      "subagents",
-      hasActivity(counts)
-        ? formatActivityStatus(ui.theme, "subagents", counts)
-        : undefined,
-    );
+    // Activity is reported by the HUD above the editor (running rows, unread
+    // settled notice, header metrics) — deliberately NOT also pinned to the
+    // footer status bar, so subagent state lives in exactly one place.
     updateSubagentWidget();
   };
 
@@ -438,7 +433,6 @@ export default function (pi: ExtensionAPI) {
     unsubStatus?.();
     unsubStatus = undefined;
     try {
-      ui?.setStatus("subagents", undefined);
       sessionContext?.ui.setWidget(widgetKey, undefined);
     } catch {
       // UI may already be disposed.

--- a/extensions/subagents/navigation.test.ts
+++ b/extensions/subagents/navigation.test.ts
@@ -73,36 +73,124 @@ test("strip selection prefers newest running, then newest unread settled", () =>
   );
 });
 
-test("subagent strip matches Workflow's bounded one-line affordance", () => {
+test("subagent HUD mirrors omp: header plus one row per running subagent", () => {
   const strip = new BelowEditorStripState();
-  const entry = selectSubagentStripEntry(
-    [snapshot("sa-1", "running", Date.now() - 2_000)],
-    0,
-  );
+  const entries = [
+    snapshot("sa-1", "running", Date.now() - 2_000),
+    snapshot("sa-2", "running", Date.now() - 1_000),
+    snapshot("sa-0", "done", 0, 500),
+  ];
+  const entry = selectSubagentStripEntry(entries, 0);
   const widget = new SubagentStripWidget(
     { requestRender() {} } as unknown as TUI,
     theme,
     strip,
     () => entry,
+    () => entries,
   );
   try {
     const idle = widget.render(100);
-    assert.equal(idle.length, 1);
-    assert.match(idle[0]!, /sa-1/);
-    assert.doesNotMatch(idle[0]!, /payload/);
+    // Header + one row per running subagent + unread-settled notice row.
+    assert.equal(idle.length, 4);
+    assert.match(idle[0]!, /Subagents/);
+    assert.match(idle[0]!, /2 running/);
+    assert.match(idle[0]!, /1 done/);
+    assert.doesNotMatch(idle[0]!, /finished/);
     assert.match(idle[0]!, /↓ to manage/);
+    assert.doesNotMatch(idle.join("\n"), /payload/);
+    assert.match(idle[1]!, /sa-1/);
+    assert.match(idle[2]!, /sa-2/);
+    assert.match(idle[3]!, /1 finished — enter to review/);
+    // The settled subagent itself is not a running row.
+    assert.doesNotMatch(idle.join("\n"), /sa-0/);
 
     strip.focused = true;
-    const focused = widget.render(54);
-    assert.equal(focused.length, 1);
-    assert.ok(visibleWidth(focused[0]!) <= 54);
+    const focused = widget.render(100);
+    assert.equal(focused.length, 4);
     assert.match(focused[0]!, /enter open/);
 
-    for (const width of [1, 8, 20]) {
+    for (const width of [1, 8, 20, 54]) {
       const narrow = widget.render(width);
-      assert.equal(narrow.length, 1);
-      assert.ok(visibleWidth(narrow[0]!) <= width);
+      assert.equal(narrow.length, 4);
+      for (const line of narrow) assert.ok(visibleWidth(line) <= width);
     }
+  } finally {
+    widget.dispose();
+  }
+});
+
+test("subagent HUD collapses running rows past its limit", () => {
+  const strip = new BelowEditorStripState();
+  const now = Date.now();
+  const entries = Array.from({ length: 6 }, (_, index) =>
+    snapshot(`sa-${index + 1}`, "running", now - (6 - index)),
+  );
+  const widget = new SubagentStripWidget(
+    { requestRender() {} } as unknown as TUI,
+    theme,
+    strip,
+    () => selectSubagentStripEntry(entries, 0),
+    () => entries,
+  );
+  try {
+    const lines = widget.render(100);
+    // 1 header + 4 rows + 1 hidden-count row (no settled entries).
+    assert.equal(lines.length, 6);
+    assert.match(lines[0]!, /6 running/);
+    assert.match(lines[5]!, /… 2 more running/);
+  } finally {
+    widget.dispose();
+  }
+});
+
+test("subagent HUD shows the newest unfinished tool per running row", () => {
+  const strip = new BelowEditorStripState();
+  const busy = {
+    ...snapshot("sa-1", "running", Date.now() - 2_000),
+    liveTools: [
+      {
+        toolId: "a",
+        name: "read",
+        argsPreview: "src/a.ts",
+        done: true,
+      },
+      {
+        toolId: "b",
+        name: "bash",
+        argsPreview: "npm test",
+      },
+    ],
+  };
+  const widget = new SubagentStripWidget(
+    { requestRender() {} } as unknown as TUI,
+    theme,
+    strip,
+    () => ({ snapshot: busy, counts: { running: 1, done: 0, failed: 0 } }),
+    () => [busy],
+  );
+  try {
+    const lines = widget.render(120);
+    assert.equal(lines.length, 2);
+    // Newest unfinished tool (bash), not the finished read.
+    assert.match(lines[1]!, /⚙ bash/);
+    assert.match(lines[1]!, /npm test/);
+    assert.doesNotMatch(lines[1]!, /read/);
+  } finally {
+    widget.dispose();
+  }
+});
+
+test("subagent HUD hides itself when nothing is running or unread", () => {
+  const strip = new BelowEditorStripState();
+  const widget = new SubagentStripWidget(
+    { requestRender() {} } as unknown as TUI,
+    theme,
+    strip,
+    () => selectSubagentStripEntry([snapshot("old", "done", 1, 5)], 6),
+    () => [snapshot("old", "done", 1, 5)],
+  );
+  try {
+    assert.deepEqual(widget.render(100), []);
   } finally {
     widget.dispose();
   }

--- a/extensions/subagents/navigation.ts
+++ b/extensions/subagents/navigation.ts
@@ -1,5 +1,5 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import type { TUI } from "@earendil-works/pi-tui";
+import { truncateToWidth, type TUI } from "@earendil-works/pi-tui";
 import {
   fitNavigationSides,
   type BelowEditorStripState,
@@ -62,24 +62,40 @@ function statusSquare(snapshot: SubagentSnapshot, theme: Theme) {
   return theme.fg(statusColor(snapshot.status), "■");
 }
 
-/** One-line subagent manager entry with the same affordance as Workflow. */
+/**
+ * Running-subagent rows the HUD can show before collapsing the rest.
+ * Matches the tasks widget's limit so the two blocks above the editor never
+ * crowd the prompt out of view on a short terminal.
+ */
+export const SUBAGENT_HUD_ROWS = 4;
+
+/**
+ * Anchored multi-row subagent HUD above the editor, mirroring omp's sticky
+ * "Subagents" block: one header line with live metrics, then a bounded row per
+ * running subagent, then a single notice row for unread settled results. The
+ * whole block is one contiguous widget, so tool rows in the transcript can
+ * never tear it apart.
+ */
 export class SubagentStripWidget {
   private readonly timer: ReturnType<typeof setInterval>;
   private readonly tui: TUI;
   private readonly theme: Theme;
   private readonly strip: BelowEditorStripState;
   private readonly getEntry: () => SubagentStripEntry | undefined;
+  private readonly getEntries: () => readonly SubagentSnapshot[];
 
   constructor(
     tui: TUI,
     theme: Theme,
     strip: BelowEditorStripState,
     getEntry: () => SubagentStripEntry | undefined,
+    getEntries: () => readonly SubagentSnapshot[],
   ) {
     this.tui = tui;
     this.theme = theme;
     this.strip = strip;
     this.getEntry = getEntry;
+    this.getEntries = getEntries;
     this.timer = setInterval(() => this.tui.requestRender(), 500);
     this.timer.unref?.();
   }
@@ -91,31 +107,86 @@ export class SubagentStripWidget {
   invalidate() {}
 
   render(width: number) {
+    if (width <= 0) return [];
     const entry = this.getEntry();
-    if (!entry || width <= 0) return [];
+    // Nothing running and nothing unread: the HUD has nothing to say and hides
+    // itself entirely instead of parking an empty header above the prompt.
+    if (!entry) return [];
     const { snapshot, counts } = entry;
+    const running = this.getEntries().filter(
+      (item) => item.status === "running",
+    );
+    const lines: string[] = [];
+
     const marker = this.strip.focused
       ? this.theme.fg("accent", "❯")
       : this.theme.fg("dim", "○");
-    const titleText = normalizeSubagentTitle(snapshot.title, snapshot.id);
-    const title = this.strip.focused
-      ? this.theme.bold(this.theme.fg("accent", titleText))
-      : this.theme.fg("text", titleText);
-    const model = snapshot.meta.modelLabel
-      ? cleanLine(snapshot.meta.modelLabel)
-      : undefined;
-    const left = ` ${marker} ${statusSquare(snapshot, this.theme)} ${title}${model ? this.theme.fg("dim", ` · ${model}`) : ""}`;
     const settled = counts.done + counts.failed;
-    const total = counts.running + settled;
     const metrics = [
-      `${settled}/${total} agents`,
+      running.length > 0 ? `${running.length} running` : undefined,
+      counts.done > 0 ? `${counts.done} done` : undefined,
+      counts.failed > 0 ? `${counts.failed} failed` : undefined,
       formatElapsed(snapshot),
       formatContextUtilization(snapshot.usage),
       this.strip.focused ? "enter open · ↑ back" : "↓ to manage",
     ]
       .filter((part): part is string => Boolean(part))
       .join(" · ");
-    const right = this.theme.fg(statusColor(snapshot.status), metrics);
-    return [fitNavigationSides(left, right, width)];
+    const header = fitNavigationSides(
+      ` ${marker} ${this.theme.fg("text", this.theme.bold("Subagents"))}`,
+      this.theme.fg(statusColor(snapshot.status), metrics),
+      width,
+    );
+    lines.push(header);
+
+    // One row per running subagent, same `■ title · model` shape the single
+    // strip used; the selected entry reads at full weight so the manager's
+    // default target is obvious without the row list turning noisy. When the
+    // subagent is mid-tool, its newest unfinished tool shows inline (omp's
+    // `currentTool · args`): the row moves when work moves, so a long-running
+    // child reads as busy instead of frozen.
+    const visible = running.slice(0, SUBAGENT_HUD_ROWS);
+    const hidden = running.length - visible.length;
+    for (const item of visible) {
+      const titleText = normalizeSubagentTitle(item.title, item.id);
+      const title =
+        item.id === snapshot.id
+          ? this.strip.focused
+            ? this.theme.bold(this.theme.fg("accent", titleText))
+            : this.theme.fg("accent", titleText)
+          : this.theme.fg("text", titleText);
+      const model = item.meta.modelLabel
+        ? cleanLine(item.meta.modelLabel)
+        : undefined;
+      const latestTool = [...item.liveTools]
+        .reverse()
+        .find((tool) => tool.done !== true);
+      const action = latestTool
+        ? ` ${this.theme.fg("dim", "⚙")} ${this.theme.fg("muted", `${latestTool.name}${latestTool.argsPreview ? ` ${cleanLine(latestTool.argsPreview)}` : ""}`)}`
+        : "";
+      lines.push(
+        truncateToWidth(
+          `  ${statusSquare(item, this.theme)} ${title}${model ? this.theme.fg("dim", ` · ${model}`) : ""}${action}`,
+          width,
+        ),
+      );
+    }
+    if (hidden > 0) {
+      lines.push(
+        truncateToWidth(
+          this.theme.fg("dim", `  … ${hidden} more running`),
+          width,
+        ),
+      );
+    }
+    if (settled > 0) {
+      lines.push(
+        truncateToWidth(
+          `${this.theme.fg("dim", "  ○")} ${this.theme.fg("dim", `${settled} finished — enter to review`)}`,
+          width,
+        ),
+      );
+    }
+    return lines;
   }
 }

--- a/extensions/tasks/index.ts
+++ b/extensions/tasks/index.ts
@@ -29,6 +29,7 @@ import {
   taskCounts,
   type TaskToolDetails,
 } from "./ui.ts";
+import { getTaskWidgetAttachment } from "../shared/task-widget-attachment.ts";
 
 const TOOL_NAMES = ["tasks_add", "tasks_update", "tasks_list"] as const;
 const TASK_WIDGET_KEY = "session-tasks-panel";
@@ -117,17 +118,38 @@ export default function sessionTasks(pi: ExtensionAPI) {
     }
     if (!ui || uiMode !== "tui") return false;
     const current = snapshot();
+    // The widget also stays up when only a cross-extension reminder is pinned
+    // (e.g. multi-signal-sync's completion notice): the notice is what the
+    // widget is for at that moment, even with zero open tasks.
     const shown =
-      taskWidgetVisible && !problemMessage() && hasActionableTasks();
+      taskWidgetVisible &&
+      !problemMessage() &&
+      (hasActionableTasks() || getTaskWidgetAttachment() !== undefined);
     if (!shown) {
       ui.setWidget(TASK_WIDGET_KEY, undefined);
       return false;
     }
-    ui.setWidget(TASK_WIDGET_KEY, (_tui, theme) => ({
-      render: (width) =>
-        renderTaskWidget(current, theme, width, taskWidgetExpanded),
-      invalidate() {},
-    }));
+    ui.setWidget(TASK_WIDGET_KEY, (tui, theme) => {
+      // Redraw cadence for the in-flight shimmer sweep: ~8 fps keeps the band
+      // advancing about one cell per frame (omp uses 30fps for its loader; the
+      // widget is text-only and 8 fps is plenty to read as flowing).
+      const timer = setInterval(() => tui.requestRender(), 120);
+      timer.unref?.();
+      return {
+        render: (width) =>
+          renderTaskWidget(
+            current,
+            theme,
+            width,
+            taskWidgetExpanded,
+            Date.now(),
+          ),
+        invalidate() {},
+        dispose() {
+          clearInterval(timer);
+        },
+      };
+    });
     return true;
   };
 
@@ -475,10 +497,42 @@ export default function sessionTasks(pi: ExtensionAPI) {
     }
   });
 
-  pi.on("agent_settled", () => {
+  pi.on("agent_settled", (_event, ctx) => {
     activeRun = false;
     frozenProjection = "";
+    notifyBlockedTasks(ctx);
   });
+
+  // Blocked tasks are the one state that needs a human in the loop (owner
+  // ruling, missing credential, external wait). The widget shows them with a
+  // `!` and the /tasks screen explains them, but neither raises an event — a
+  // turn that ends with a blocked task would sit silently until the user
+  // happens to look. Each blocked task is announced once per blocked stint;
+  // clearing the block (or dropping the task) re-arms it.
+  let notifiedBlocked = new Set<number>();
+  const notifyBlockedTasks = (ctx: ExtensionContext) => {
+    if (!ctx.hasUI) return;
+    const current = snapshot().items;
+    const blockedIds = new Set(
+      current
+        .filter((item) => item.status === "blocked")
+        .map((item) => item.id),
+    );
+    for (const item of current) {
+      if (item.status !== "blocked" || notifiedBlocked.has(item.id)) continue;
+      notifiedBlocked.add(item.id);
+      ctx.ui.notify(
+        `T${item.id} blocked: ${item.subject}${item.note ? ` — ${item.note}` : ""} · 需要人工介入`,
+        "warning",
+      );
+    }
+    // Re-arm ids that left the blocked state (or the list) so a later
+    // re-block announces again.
+    for (const id of notifiedBlocked) {
+      if (blockedIds.has(id)) continue;
+      notifiedBlocked.delete(id);
+    }
+  };
 
   pi.on("context", (event) => {
     if (!activeRun || !frozenProjection || problemMessage()) return;

--- a/extensions/tasks/ui.test.ts
+++ b/extensions/tasks/ui.test.ts
@@ -8,8 +8,10 @@ import {
   renderTaskWidget,
   renderToolResult,
   taskCounts,
+  SPINNER_FRAME_MS,
   TASK_WIDGET_LIMIT,
 } from "./ui.ts";
+import { setTaskWidgetAttachment } from "../shared/task-widget-attachment.ts";
 
 // strikethrough is marked rather than dropped, so a test can assert which
 // subjects got struck without matching real ANSI escapes.
@@ -62,7 +64,7 @@ test("persistent task widget matches a compact Claude-style task panel", () => {
     theme,
     100,
   );
-  assert.equal(lines.length, 3);
+  assert.equal(lines.length, 4);
   // Same census as the full list, counted over tracked items only: the widget
   // hides the dropped one, so including it would not add up against the rows.
   assert.match(
@@ -73,7 +75,10 @@ test("persistent task widget matches a compact Claude-style task panel", () => {
   assert.doesNotMatch(lines[0]!, /ctrl\+shift\+t/);
   assert.match(lines[1]!, /T2 Implement task panel/);
   assert.match(lines[2]!, /T3 Verify rendering/);
-  assert.equal(lines.join("\n").includes("Finished setup"), false);
+  // Completed items stay in the widget, struck through like omp's todo HUD:
+  // the glance that finds what is left also sees what is behind. Dropped items
+  // stay hidden — deliberate discard, not history.
+  assert.match(lines[3]!, /T1 <s>Finished setup<\/s>/);
   assert.equal(lines.join("\n").includes("Dropped idea"), false);
   const narrow = renderTaskWidget(
     {
@@ -102,6 +107,76 @@ test("persistent task widget matches a compact Claude-style task panel", () => {
     ),
     [],
   );
+});
+
+test("in-progress row shimmers and spins across time", () => {
+  const snapshot = {
+    version: 1 as const,
+    revision: 1,
+    nextId: 2,
+    items: [{ id: 1, subject: "Busy task", status: "in_progress" as const }],
+  };
+  const marked = {
+    fg: (name: string, text: string) => `<${name}>${text}</${name}>`,
+    bold: (text: string) => `*${text}*`,
+    strikethrough: (text: string) => `<s>${text}</s>`,
+  } as unknown as Theme;
+  const at = (now: number) =>
+    renderTaskWidget(snapshot, marked, 100, false, now).join("\n");
+  // The spinner glyph advances with time…
+  assert.notEqual(at(0), at(SPINNER_FRAME_MS));
+  // …and the shimmer crest sweeps: at t=0 the band sits off the left edge
+  // (no accent run), half a second later it has swept onto the first
+  // character. The assertion targets the task row, not the census header
+  // (which legitimately uses accent for its ◆ mark).
+  const taskRow = (now: number) => at(now).split("\n").at(-1)!;
+  assert.doesNotMatch(taskRow(0), /<accent>/);
+  assert.match(taskRow(500), /\*<accent>B<\/accent>\*/);
+  // Different moments render different color sequences.
+  assert.notEqual(at(0), at(500));
+  // Without an in-progress item nothing shimmers: done rows keep plain text.
+  const doneAt = (now: number) =>
+    renderTaskWidget(
+      {
+        version: 1,
+        revision: 1,
+        nextId: 2,
+        items: [{ id: 1, subject: "Done task", status: "done" as const }],
+      },
+      marked,
+      100,
+      false,
+      now,
+    ).join("\n");
+  assert.equal(doneAt(0), doneAt(SPINNER_FRAME_MS * 10));
+});
+
+test("task widget renders a cross-extension attachment under the census", () => {
+  const widget = () =>
+    renderTaskWidget(
+      {
+        version: 1,
+        revision: 1,
+        nextId: 2,
+        items: [{ id: 1, subject: "Implement panel", status: "in_progress" }],
+      },
+      theme,
+      100,
+    );
+  assert.equal(widget().length, 2);
+  assert.doesNotMatch(widget().join("\n"), /完成信号/);
+
+  setTaskWidgetAttachment("⚠️ 完成信号（commit + 业主授权）— 请同步 tasks");
+  try {
+    const lines = widget();
+    assert.equal(lines.length, 3);
+    // The notice sits directly under the census header, above the task rows.
+    assert.match(lines[1]!, /完成信号/);
+    assert.match(lines[2]!, /T1 Implement panel/);
+  } finally {
+    setTaskWidgetAttachment(undefined);
+  }
+  assert.equal(widget().length, 2);
 });
 
 test("task widget defaults to four items and Ctrl+Shift+T view shows all", () => {

--- a/extensions/tasks/ui.ts
+++ b/extensions/tasks/ui.ts
@@ -12,6 +12,7 @@ import {
   type TUI,
 } from "@earendil-works/pi-tui";
 import type { TaskItem, TaskSnapshot } from "./tasks.ts";
+import { getTaskWidgetAttachment } from "../shared/task-widget-attachment.ts";
 
 const STATUS_ICON: Record<TaskItem["status"], string> = {
   pending: "○",
@@ -20,6 +21,54 @@ const STATUS_ICON: Record<TaskItem["status"], string> = {
   done: "✓",
   dropped: "×",
 };
+
+/**
+ * Time-driven busy glyph for the widget's in-progress row, mirroring omp's
+ * spinner cadence: the row visibly moves while work is in flight, so a long
+ * agent turn cannot read as a frozen task panel. Static views (tool results,
+ * the /tasks screen) keep the plain `●`, because they are settled snapshots.
+ */
+export const SPINNER_FRAMES = ["◐", "◓", "◑", "◒"] as const;
+export const SPINNER_FRAME_MS = 160;
+
+export function spinnerFrame(now: number) {
+  return Math.floor(now / SPINNER_FRAME_MS) % SPINNER_FRAMES.length;
+}
+
+/**
+ * Sweep a brightness band across a text run, omp-style shimmer: every
+ * character outside the band is dim, inside it steps up to muted and then
+ * accent+bold at the crest. The band advances at a fixed cell velocity, so at
+ * the widget's redraw cadence it moves about one cell per frame — the row
+ * visibly *flows* from across the room, unlike a small spinning glyph that
+ * only reads up close.
+ */
+export function shimmerText(
+  text: string,
+  theme: Theme,
+  now: number,
+  options: { speedCellsPerS?: number; bandHalfWidth?: number } = {},
+): string {
+  const speed = options.speedCellsPerS ?? 8;
+  const bandHalf = options.bandHalfWidth ?? 5;
+  const width = [...text].length;
+  if (width === 0) return text;
+  const period = width + bandHalf * 2;
+  const crest = (((now / 1000) * speed) % period) - bandHalf;
+  let out = "";
+  let index = 0;
+  for (const ch of text) {
+    const dist = Math.abs(index - crest);
+    out +=
+      dist <= 1
+        ? theme.bold(theme.fg("accent", ch))
+        : dist <= bandHalf
+          ? theme.fg("muted", ch)
+          : theme.fg("dim", ch);
+    index++;
+  }
+  return out;
+}
 
 const TASK_WIDGET_ORDER: Record<TaskItem["status"], number> = {
   in_progress: 0,
@@ -202,6 +251,7 @@ export function renderTaskWidget(
   theme: Theme,
   width: number,
   expanded = false,
+  now = Date.now(),
 ) {
   const tracked = snapshot.items.filter((item) => item.status !== "dropped");
   const actionable = tracked
@@ -213,7 +263,15 @@ export function renderTaskWidget(
     );
   if (actionable.length === 0) return [];
 
-  const hasOverflow = actionable.length > TASK_WIDGET_LIMIT;
+  // Completed items stay visible, struck through and dimmed, mirroring omp's
+  // todo HUD: the glance that finds what is left also sees what is behind.
+  // Dropped items stay hidden — they are deliberate discard, not history.
+  const done = tracked
+    .filter((item) => item.status === "done")
+    .sort((left, right) => left.id - right.id);
+  const all = [...actionable, ...done];
+
+  const hasOverflow = all.length > TASK_WIDGET_LIMIT;
   const toggleHint = hasOverflow
     ? `  ·  ctrl+shift+t ${expanded ? "collapse" : "show all"}`
     : "";
@@ -226,27 +284,46 @@ export function renderTaskWidget(
     "  " +
     renderTaskSummary(taskCounts(tracked), theme) +
     theme.fg("dim", `  ·  /tasks${toggleHint}`);
-  const visible = expanded
-    ? actionable
-    : actionable.slice(0, TASK_WIDGET_LIMIT);
-  const hidden = actionable.length - visible.length;
+  const visible = expanded ? all : all.slice(0, TASK_WIDGET_LIMIT);
+  const hidden = all.length - visible.length;
   // Right-aligned like the full list, with the same floor: a widget whose ids
   // are ragged next to a list whose ids are not reads as a different control.
   const idWidth = Math.max(...visible.map((i) => `T${i.id}`.length), 3);
   const lines = [truncateToWidth(header, width)];
+  // A sibling extension (multi-signal-sync) can pin a completion-signal
+  // reminder here; it renders as the first row under the census so the notice
+  // reads together with the list it asks the agent to sync.
+  const attachment = getTaskWidgetAttachment();
+  if (attachment) {
+    lines.push(truncateToWidth(theme.fg("warning", `  ${attachment}`), width));
+  }
   for (const [index, item] of visible.entries()) {
     const color =
+      item.status === "done"
+        ? "success"
+        : item.status === "in_progress"
+          ? "warning"
+          : item.status === "blocked"
+            ? "error"
+            : "muted";
+    const icon =
       item.status === "in_progress"
-        ? "warning"
-        : item.status === "blocked"
-          ? "error"
-          : "muted";
+        ? SPINNER_FRAMES[spinnerFrame(now)]
+        : STATUS_ICON[item.status];
+    // The in-flight row's subject carries the shimmer sweep instead of the
+    // static full-weight bold: the whole row flows, so "still running" reads
+    // at a glance from across the room.
+    const subject =
+      item.status === "in_progress"
+        ? shimmerText(item.subject, theme, now)
+        : subjectStyle(item.status, theme)(item.subject);
     const branch = index === visible.length - 1 && hidden === 0 ? "╰─" : "├─";
     lines.push(
       truncateToWidth(
         // Same subject weighting as the full list, so the item in flight reads
-        // the same wherever you happen to be looking.
-        `${theme.fg("dim", branch)} ${theme.fg(color, STATUS_ICON[item.status])} ${theme.fg("dim", `T${item.id}`.padStart(idWidth))} ${subjectStyle(item.status, theme)(item.subject)}`,
+        // the same wherever you happen to be looking; done subjects carry the
+        // same strikethrough as the tool result and the /tasks screen.
+        `${theme.fg("dim", branch)} ${theme.fg(color, icon)} ${theme.fg("dim", `T${item.id}`.padStart(idWidth))} ${subject}`,
         width,
       ),
     );

--- a/extensions/workflows/index.ts
+++ b/extensions/workflows/index.ts
@@ -43,7 +43,6 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
 import { Type, type Static } from "typebox";
-import { formatActivityStatus } from "../shared/activity-status.ts";
 import { waitBounded } from "../shared/child-session.ts";
 import { loadSetupConfig } from "../shared/setup-config.ts";
 import {
@@ -429,8 +428,6 @@ export default function workflows(pi: ExtensionAPI) {
    * next explicit request acknowledges them.
    */
   let lastContext: ExtensionContext | undefined;
-  let completedRuns = 0;
-  let failedRuns = 0;
   let widgetVisible = false;
   let requestWidgetRender: (() => void) | undefined;
   let dashboardOpen = false;
@@ -482,7 +479,9 @@ export default function workflows(pi: ExtensionAPI) {
         requestWidgetRender = () => tui.requestRender();
         return new WorkflowStripWidget(tui, theme, stripState, stripEntry);
       },
-      { placement: "belowEditor" },
+      // Above the editor, like the Subagents HUD: one contiguous block between
+      // the transcript and the prompt, never torn apart by tool rows.
+      { placement: "aboveEditor" },
     );
     widgetVisible = true;
   };
@@ -491,19 +490,9 @@ export default function workflows(pi: ExtensionAPI) {
     const ctx = lastContext;
     if (!ctx) return;
     try {
-      const running = activeRuns.size;
-      if (running === 0 && completedRuns === 0 && failedRuns === 0) {
-        ctx.ui.setStatus("workflows", undefined);
-      } else {
-        ctx.ui.setStatus(
-          "workflows",
-          formatActivityStatus(ctx.ui.theme, "workflows", {
-            running,
-            done: completedRuns,
-            failed: failedRuns,
-          }),
-        );
-      }
+      // Activity is reported by the HUD above the editor (header metrics,
+      // per-agent rows) — deliberately NOT also pinned to the footer status
+      // bar, so workflow state lives in exactly one place.
       updateWorkflowWidget();
     } catch {
       // UI may be unavailable.
@@ -511,15 +500,11 @@ export default function workflows(pi: ExtensionAPI) {
   };
 
   const acknowledgeSettledRuns = () => {
-    completedRuns = 0;
-    failedRuns = 0;
     settledRuns.clear();
   };
 
   const recordSettledRun = (details: WorkflowDetails) => {
     settledRuns.set(details.runId, details);
-    if (details.status === "completed") completedRuns += 1;
-    else failedRuns += 1;
   };
 
   const stopRun = (runId: string) => {
@@ -584,8 +569,6 @@ export default function workflows(pi: ExtensionAPI) {
       projectTrusted: ctx.isProjectTrusted(),
     }).agentTypes;
     turnStartedAt = 0;
-    completedRuns = 0;
-    failedRuns = 0;
     settledRuns.clear();
     installWorkflowNavigation(ctx);
     updateIndicator();

--- a/extensions/workflows/navigation.test.ts
+++ b/extensions/workflows/navigation.test.ts
@@ -179,7 +179,7 @@ test("workflow strip sanitizes restored or legacy metadata defensively", () => {
   }
 });
 
-test("the workflow strip stays one line, bounded, and exposes its navigation hint", () => {
+test("the workflow HUD stays bounded and exposes its navigation hint", () => {
   const strip = new WorkflowStripState();
   const tui = { requestRender() {} } as unknown as TUI;
   const widget = new WorkflowStripWidget(tui, theme, strip, () => ({
@@ -188,14 +188,16 @@ test("the workflow strip stays one line, bounded, and exposes its navigation hin
   }));
   try {
     const idle = widget.render(100);
-    assert.equal(idle.length, 1);
+    // Header + one row per agent (the fixture carries one).
+    assert.equal(idle.length, 2);
     assert.match(idle[0]!, /repair-docs/);
     assert.match(idle[0]!, /↓ to manage/);
+    assert.match(idle[1]!, /chapter-2/);
 
     strip.focused = true;
     const focused = widget.render(56);
-    assert.equal(focused.length, 1);
-    assert.ok(visibleWidth(focused[0]!) <= 56);
+    assert.equal(focused.length, 2);
+    for (const line of focused) assert.ok(visibleWidth(line) <= 56);
     assert.match(focused[0]!, /enter open/);
   } finally {
     widget.dispose();

--- a/extensions/workflows/navigation.ts
+++ b/extensions/workflows/navigation.ts
@@ -1,4 +1,4 @@
-import type { TUI } from "@earendil-works/pi-tui";
+import { truncateToWidth, type TUI } from "@earendil-works/pi-tui";
 import {
   BelowEditorNavigationEditor,
   BelowEditorStripState,
@@ -15,6 +15,7 @@ import {
   statusSquare,
   type Theme,
   type WorkflowDetails,
+  type WorkflowStatus,
 } from "./model.ts";
 
 /** Workflow-named aliases preserve the public seam while sharing interaction. */
@@ -33,7 +34,7 @@ function cleanLine(value: string) {
   return sanitizeTerminalText(value).replace(/\s+/g, " ").trim();
 }
 
-/** Live, one-line Claude-style workflow entry rendered below the editor. */
+/** Live, multi-row workflow HUD above the editor, mirroring the Subagents HUD. */
 export class WorkflowStripWidget {
   private readonly timer: ReturnType<typeof setInterval>;
   private readonly tui: TUI;
@@ -62,13 +63,19 @@ export class WorkflowStripWidget {
   invalidate() {}
 
   render(width: number) {
+    if (width <= 0) return [];
     const entry = this.getEntry();
-    if (!entry || width <= 0) return [];
+    if (!entry) return [];
     const details = entry.details;
-    const { done, failed } = countStates(details);
+    const { done, failed, running } = countStates(details);
     const settled = done + failed;
     const usage = aggregateUsage(details.agents);
     const tokenCount = usage.input + usage.output;
+    const lines: string[] = [];
+
+    // Header, same shape as the Subagents HUD — but its right-side metrics
+    // render in accent rather than warning, so the two stacked panels never
+    // blur into one another at a glance.
     const marker = this.strip.focused
       ? this.theme.fg("accent", "❯")
       : this.theme.fg("dim", "○");
@@ -76,18 +83,64 @@ export class WorkflowStripWidget {
     const name = this.strip.focused
       ? this.theme.bold(this.theme.fg("accent", displayName))
       : this.theme.fg("text", displayName);
-    const rawContext = details.currentPhase ?? details.description;
-    const context = rawContext ? cleanLine(rawContext) : undefined;
-    const left = ` ${marker} ${statusSquare(details.status, this.theme)} ${name}${context ? this.theme.fg("dim", ` · ${context}`) : ""}`;
+    const left = ` ${marker} ${statusSquare(details.status, this.theme)} ${this.theme.fg("text", this.theme.bold("Workflow"))} · ${name}`;
     const metrics = [
-      `${settled}/${details.agents.length} agents`,
+      running > 0 ? `${running} running` : undefined,
+      settled > 0 ? `${settled} done` : undefined,
+      failed > 0 ? `${failed} failed` : undefined,
       formatElapsed(details.startedAt, details.finishedAt),
       tokenCount > 0 ? `${formatTokens(tokenCount)} tokens` : undefined,
       this.strip.focused ? "enter open · ↑ back" : "↓ to manage",
     ]
       .filter((part): part is string => Boolean(part))
       .join(" · ");
-    const right = this.theme.fg(statusColor(details.status), metrics);
-    return [fitNavigationSides(left, right, width)];
+    lines.push(
+      fitNavigationSides(left, this.theme.fg("accent", metrics), width),
+    );
+
+    // One row per agent, same `■ label · phase` shape as the Subagents rows.
+    const visible = details.agents.slice(0, WORKFLOW_HUD_ROWS);
+    const hidden = details.agents.length - visible.length;
+    for (const agent of visible) {
+      const phase = agent.phase ? ` · ${cleanLine(agent.phase)}` : "";
+      const model = agent.model ? ` · ${cleanLine(agent.model)}` : "";
+      // AgentState (running/done/error) maps onto WorkflowStatus (running/
+      // completed/failed/aborted) for the status square.
+      const state: WorkflowStatus =
+        agent.state === "done"
+          ? "completed"
+          : agent.state === "error"
+            ? "failed"
+            : "running";
+      lines.push(
+        truncateToWidth(
+          `  ${statusSquare(state, this.theme)} ${this.theme.fg("text", cleanLine(agent.label))}${phase}${model}`,
+          width,
+        ),
+      );
+    }
+    if (hidden > 0) {
+      lines.push(
+        truncateToWidth(
+          this.theme.fg("dim", `  … ${hidden} more agents`),
+          width,
+        ),
+      );
+    }
+    if (details.status === "failed" || details.status === "aborted") {
+      lines.push(
+        truncateToWidth(
+          this.theme.fg(
+            "error",
+            `  ✗ ${details.status === "failed" ? "failed" : "aborted"} — enter to inspect`,
+          ),
+          width,
+        ),
+      );
+    }
+    return lines;
   }
 }
+
+/** Running-agent rows the workflow HUD shows before collapsing the rest. */
+export const WORKFLOW_HUD_ROWS = 4;

--- a/extensions/working-indicator/frames.test.ts
+++ b/extensions/working-indicator/frames.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildGradientBarFrames, gradientBarFrame } from "./frames.ts";
+
+test("gradient bar frame has one ANSI-colored block per cell", () => {
+  const frame = gradientBarFrame(10, 3);
+  assert.match(frame, /^\x1b\[38;2;\d+;\d+;\d+m█\x1b\[39m/);
+  const blocks = frame.match(/\x1b\[38;2;\d+;\d+;\d+m█\x1b\[39m/g);
+  assert.equal(blocks?.length, 10);
+});
+
+test("crest cell is brightest; cells dim with distance", () => {
+  // Crest at 3: extract the RGB of each cell.
+  const frame = gradientBarFrame(10, 3);
+  const rgbs = [...frame.matchAll(/38;2;(\d+);(\d+);(\d+)m/g)].map((m) =>
+    m.slice(1).map(Number),
+  );
+  assert.equal(rgbs.length, 10);
+  const luminance = rgbs.map(([r, g, b]) => r + g + b);
+  // The crest cell outshines every neighbor…
+  assert.equal(luminance[3], Math.max(...luminance));
+  // …and luminance falls off symmetrically with distance (within bounds).
+  assert.equal(luminance[2], luminance[4]); // dist 1
+  assert.equal(luminance[1], luminance[5]); // dist 2
+  assert.equal(luminance[0], luminance[6]); // dist 3
+  assert.ok(luminance[2] > luminance[1] && luminance[1] > luminance[0]);
+  assert.ok(
+    luminance[4] > luminance[5] &&
+      luminance[5] > luminance[6] &&
+      luminance[6] > luminance[7],
+  );
+});
+
+test("frame sequence moves the crest one cell per frame", () => {
+  const frames = buildGradientBarFrames(10);
+  assert.equal(frames.length, 10);
+  for (let crest = 0; crest < 10; crest++) {
+    const rgbs = [...frames[crest]!.matchAll(/38;2;(\d+);(\d+);(\d+)m/g)].map(
+      (m) => m.slice(1).map(Number),
+    );
+    const lum = rgbs.map(([r, g, b]) => r + g + b);
+    assert.equal(
+      lum.indexOf(Math.max(...lum)),
+      crest,
+      `frame ${crest} peaks at cell ${crest}`,
+    );
+  }
+  // Frames differ from each other (the bar actually flows).
+  assert.notEqual(frames[0], frames[1]);
+});

--- a/extensions/working-indicator/frames.ts
+++ b/extensions/working-indicator/frames.ts
@@ -1,0 +1,56 @@
+/**
+ * Gradient-bar animation frames for the working indicator.
+ *
+ * Replaces pi's built-in braille spinner (⠋⠙⠹…) with a flowing gradient
+ * bar, the same effect omp's shimmer loader has: a bright crest sweeps across
+ * a dim band, so "still running" reads from across the room instead of only
+ * from a few centimeters away.
+ *
+ * Frames are rendered verbatim by pi's Loader (they may carry ANSI colors),
+ * one per `intervalMs` tick, cycling back to the first frame after the last.
+ * The crest therefore advances one cell per frame and wraps around — a
+ * continuous loop, not a start/stop sweep.
+ */
+
+/** RGB of the crest (an accent-ish violet; every other cell is a dimmer mix). */
+const CREST_RGB: readonly [number, number, number] = [224, 176, 255];
+/** Brightness multiplier per cell distance from the crest. */
+const FALL_OFF = [1, 0.62, 0.38, 0.22, 0.13, 0.08] as const;
+
+const FG = "\x1b[38;2;";
+const RESET = "\x1b[39m";
+
+export function gradientBarFrame(
+  width: number,
+  crest: number,
+  color: readonly [number, number, number] = CREST_RGB,
+  fallOff: readonly number[] = FALL_OFF,
+): string {
+  let frame = "";
+  for (let index = 0; index < width; index++) {
+    const dist = Math.abs(index - crest);
+    const t = fallOff[Math.min(dist, fallOff.length - 1)];
+    const r = Math.round(color[0] * t);
+    const g = Math.round(color[1] * t);
+    const b = Math.round(color[2] * t);
+    frame += `${FG}${r};${g};${b}m█${RESET}`;
+  }
+  return frame;
+}
+
+/**
+ * One frame per crest position: `width` frames, each with the bright crest on
+ * a different cell, so the bar visibly flows cell by cell. At pi's 80 ms
+ * tick the loop takes `width * 80 ms`, smooth to the eye and readable across
+ * a room.
+ */
+export function buildGradientBarFrames(
+  width = 10,
+  color?: readonly [number, number, number],
+): string[] {
+  const frames: string[] = [];
+  for (let crest = 0; crest < width; crest++) {
+    frames.push(gradientBarFrame(width, crest, color));
+  }
+  return frames;
+}

--- a/extensions/working-indicator/index.ts
+++ b/extensions/working-indicator/index.ts
@@ -1,0 +1,26 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { buildGradientBarFrames } from "./frames.ts";
+
+/**
+ * working-indicator: swap pi's built-in braille spinner for a flowing
+ * gradient bar on the "Working..." status line (the turn-running indicator
+ * above the editor). The bar's bright crest sweeps cell by cell, so activity
+ * reads at a glance from across the room — the same effect omp's shimmer
+ * loader has, instead of a tiny spinning glyph you must lean in to see.
+ *
+ * pi's Loader renders the frames verbatim and repaints on every tick, so the
+ * frames themselves carry the ANSI gradient; no timer is needed here.
+ */
+export default function workingIndicator(pi: ExtensionAPI) {
+  pi.on("session_start", (_event, ctx) => {
+    if (ctx.mode !== "tui" || !ctx.hasUI) return;
+    try {
+      ctx.ui.setWorkingIndicator({
+        frames: buildGradientBarFrames(10),
+        intervalMs: 80,
+      });
+    } catch {
+      // UI may already be disposed; best-effort override.
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Display overhaul of the openpi extension HUDs, modeled on omp's (oh-my-pi) sticky anchored blocks:

**tasks** — completed items stay visible in the widget, struck through (SGR 9) like omp's todo HUD; the in-progress subject carries a time-driven shimmer sweep (8 cells/s crest, 120ms redraw); a cross-extension attachment row renders under the census header so completion-signal reminders (multi-signal-sync) live in the task panel instead of the footer status bar.

**subagents** — the strip moves from `belowEditor` to `aboveEditor` as a multi-row HUD: one row per running subagent with its newest unfinished tool inline (`⚙ bash npm test`), unread-settled notice row, header metrics (running/done/failed). Footer `setStatus` removed — the HUD is the single source of truth.

**workflows** — same treatment: multi-row HUD above the editor, per-agent rows, metrics in accent so the two stacked panels (subagents warning-yellow vs workflows accent) stay distinguishable at a glance. Footer `setStatus` removed.

**working-indicator** — new extension replacing pi's braille spinner with a flowing truecolor gradient bar (10 frames, 80ms tick) on the `Working...` status line: activity reads from across the room, not only up close.

**notifications** — blocked tasks and blocked goals now announce on `agent_settled` (once per blocked stint, re-armed on state change), fixing the silent-wait-for-human-intervention gap.

## Tests
100/100 passing across tasks/subagents/workflows/goal/working-indicator suites; tsc --noEmit clean; prettier clean.