### PR TITLE
fix(capabilities): 兼容 Kimi 的严格工具 Schema 校验

### DIFF
--- a/extensions/capabilities/index.test.ts
+++ b/extensions/capabilities/index.test.ts
@@ -148,6 +148,15 @@ test("the gateway does not add an ineffective resident adoption guideline", () =
   assert.equal(h.tool().promptGuidelines, undefined);
 });
 
+test("the gateway exposes a provider-portable string enum for capability groups", () => {
+  const parameters = JSON.parse(JSON.stringify(harness().tool().parameters));
+
+  assert.deepEqual(parameters.properties.groups.items, {
+    type: "string",
+    enum: ["search", "delegate", "workflow", "background", "session"],
+  });
+});
+
 test("the gateway stays within its compact provider-surface budget", () => {
   const tool = harness().tool();
   const serialized = JSON.stringify({

--- a/extensions/capabilities/index.ts
+++ b/extensions/capabilities/index.ts
@@ -17,7 +17,10 @@ import {
   resetOpenPiToolSurface,
 } from "../shared/tool-surface.ts";
 
-const CapabilitySchema = Type.Enum(OPENPI_CAPABILITY_NAMES);
+const CapabilitySchema = Type.Unsafe<OpenPiCapability>({
+  type: "string",
+  enum: OPENPI_CAPABILITY_NAMES,
+});
 
 const OpenPiLoadToolsParameters = Type.Object({
   groups: Type.Optional(


### PR DESCRIPTION
Closes #49

## 问题

`openpi_load_tools.groups.items` 由 `Type.Enum` 生成，仅包含 `enum`，没有显式的 `type`。Kimi/Moonshot 在模型推理前校验全部活动工具，因此当 capability gateway 可见时直接返回：

```text
properties.groups.items: type is not defined
```

Pi 内置工具正常；只加载 OpenPI capabilities extension 即可复现。`--no-tools` 会绕过 Schema，不能作为兼容性通过证据。

## 修复

- 将 capability group 元素改为紧凑的 `type: "string" + enum` Schema。
- 保留 `OpenPiCapability` 静态类型、原有 enum 值、运行逻辑和工具表面预算。
- 不使用冗长的 `anyOf + const`，避免无意义增加常驻输入。
- 增加 Provider-facing 回归测试，直接检查 Pi Extension API 注册出的真实参数 Schema。

仓库扫描确认：这是产品源码中唯一一处 `Type.Enum`；另一处手写 enum 已明确包含 `type: "string"`。

## 验证

- 红灯：旧实现下新增测试精确缺少 `type: "string"`。
- 专项：capabilities **13/13**。
- `bun run check`：通过（仅有既存 Effect warnings）。
- `bun run test`：**746 Node + 29 Vitest** 全绿。
- `git diff --check`：通过。
- 真实 K3 smoke：Pi `0.84.2`，`kimi-code/k3:low`，`--no-extensions` 排除 npm 包，显式加载本分支 capabilities extension，保留正常工具模式并触发 `openpi_load_tools` 进入请求；K3 成功返回 `schema-ok`，不再出现 HTTP 400。

## 性能

仅增加一个 `"type":"string"` 字段；不增加模型调用、工具调用或运行时分支，provider surface 仍通过既有 500 字符预算测试。
