### PR TITLE
chore(release): 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tt-a1i/openpi",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "OpenPI — a Pi-native multi-agent workbench with background execution, isolated subagents, replay-safe workflows, goals, tasks, and observable TUI",
   "license": "MIT",
   "author": "tt-a1i",


### PR DESCRIPTION
## 发布

将 `@tt-a1i/openpi` 从 `0.3.0` 升级到 `0.3.1`。

本补丁版本包含：

- #48：父 Agent busy 期间完成的子代理结果会在 idle 边界自动回传并唤醒；
- #50：`openpi_load_tools` 输出明确的 string enum，兼容 Kimi/Moonshot 严格工具 Schema 校验。

## 验证

- `bun run check`：通过（仅既存 Effect warnings）；
- `bun run test`：746 Node + 29 Vitest 全绿；
- `npm pack --dry-run`：131 files，421.2 kB，版本 `0.3.1`；
- Kimi K3 正常工具模式 smoke 已在 #50 通过。

合并后从精确 merge commit 创建 `v0.3.1`，发布 npm，并创建 GitHub Release。
