### PR TITLE
ci: deduplicate pull request runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- run branch CI through `pull_request` only
- keep `push` CI for `main`
- cancel superseded runs for the same PR or ref

This removes the duplicate push + pull-request matrix seen on PR #77 while preserving Node 22/24 coverage and post-merge validation.

## Validation
- `bun run check`
- `bun run test` (801 Node tests + 30 Vitest tests)