### PR TITLE
feat(ui): color edit stats and spin the pending activity row

### DIFF
--- a/extensions/file-mutation-display/render.test.ts
+++ b/extensions/file-mutation-display/render.test.ts
@@ -114,7 +114,7 @@ const fixtures: Array<{
         patch: "@@ -1 +1,2 @@\n-old\n+new\n+second",
       },
     },
-    success: /Edited\s+README\.md\s+\+2\s+−1/,
+    success: /Edited\s+README\.md\s+\+2 -1/,
   },
   {
     name: "grep",
@@ -236,7 +236,11 @@ test("all activity tools render pending and failure as one explicit row", () => 
     const definition = withActivityRenderer(fixture.definition);
     const pending = renderCollapsed(definition, fixture.args);
     assert.equal(pending.length, 1, `${fixture.name} pending`);
-    assert.match(pending[0] ?? "", /^ {2}◌ /, `${fixture.name} pending`);
+    assert.match(
+      pending[0] ?? "",
+      /^ {2}[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏] /,
+      `${fixture.name} pending`,
+    );
     assert.ok(pending[0]?.endsWith("  "), `${fixture.name} pending`);
 
     const failed = renderCollapsed(
@@ -274,7 +278,7 @@ test("long activity rows stay one line and fit narrow terminals", () => {
   );
   assert.equal(lines.length, 1);
   assert.ok(visibleWidth(lines[0]!) <= 24);
-  assert.match(lines[0] ?? "", /^ {2}◌ Running\s+bun/);
+  assert.match(lines[0] ?? "", /^ {2}[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏] Running\s+bun/);
   assert.ok(lines[0]?.endsWith("  "));
 });
 

--- a/extensions/file-mutation-display/render.ts
+++ b/extensions/file-mutation-display/render.ts
@@ -7,6 +7,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, type Component } from "@earendil-works/pi-tui";
 import type { TSchema } from "typebox";
+import { spinnerFrame } from "../shared/spinner.ts";
 
 type ActivityStatus = "pending" | "success" | "error";
 
@@ -91,13 +92,14 @@ function plural(count: number, singular: string) {
 
 function editStats(details: unknown) {
   const diff = string(record(details).diff);
+  if (!diff) return undefined;
   let additions = 0;
   let removals = 0;
   for (const line of diff.split(/\r?\n/)) {
     if (line.startsWith("+") && !line.startsWith("+++")) additions += 1;
     if (line.startsWith("-") && !line.startsWith("---")) removals += 1;
   }
-  return `+${additions} −${removals}`;
+  return { additions, removals };
 }
 
 function range(args: Record<string, unknown>) {
@@ -140,11 +142,7 @@ function activityRow(
       return { verb: "Wrote", target: path, detail: plural(lines, "line") };
     }
     case "edit":
-      return {
-        verb: "Edited",
-        target: path,
-        detail: editStats(result?.details),
-      };
+      return { verb: "Edited", target: path };
     case "grep":
       return {
         verb: "Searched",
@@ -242,17 +240,41 @@ function activityText(
 ) {
   const row = activityRow(name, args, state.result, cwd);
   const elapsed = duration(state);
+  const verbText = (
+    state.status === "pending"
+      ? pendingVerb(name)
+      : state.status === "error"
+        ? "Failed"
+        : row.verb
+  ).padEnd(8);
+  const verb = theme.fg(
+    state.status === "error" ? "error" : "toolTitle",
+    verbText,
+  );
   if (state.status === "pending") {
     const detail = elapsed ? ` · ${elapsed}` : "";
-    return `${theme.fg("warning", "◌")} ${theme.fg("toolTitle", pendingVerb(name))}  ${row.target}${theme.fg("dim", detail)}`;
+    return `${theme.fg("warning", spinnerFrame(Date.now()))} ${verb} ${row.target}${theme.fg("dim", detail)}`;
   }
   if (state.status === "error") {
     const summary = errorSummary(state.result);
     const detail = [elapsed, summary].filter(Boolean).join(" · ");
-    return `${theme.fg("error", "✕")} ${theme.fg("error", "Failed")}   ${row.target}${detail ? theme.fg("dim", ` · ${detail}`) : ""}`;
+    return `${theme.fg("error", "✕")} ${verb} ${row.target}${detail ? theme.fg("dim", ` · ${detail}`) : ""}`;
   }
-  const detail = [row.detail, elapsed].filter(Boolean).join(" · ");
-  return `${theme.fg("dim", activityIcon(name))} ${theme.fg("toolTitle", row.verb.padEnd(8))} ${row.target}${detail ? theme.fg("dim", `  ${detail}`) : ""}`;
+  const parts: string[] = [];
+  if (name === "edit") {
+    // Kimi-style diff stats: additions green, removals red.
+    const stats = editStats(state.result?.details);
+    if (stats) {
+      parts.push(
+        `${theme.fg("success", `+${stats.additions}`)} ${theme.fg("error", `-${stats.removals}`)}`,
+      );
+    }
+  } else if (row.detail) {
+    parts.push(theme.fg("dim", row.detail));
+  }
+  if (elapsed) parts.push(theme.fg("dim", elapsed));
+  const detail = parts.join(theme.fg("dim", " · "));
+  return `${theme.fg("dim", activityIcon(name))} ${verb} ${row.target}${detail ? `  ${detail}` : ""}`;
 }
 
 function activityComponent(


### PR DESCRIPTION
## 改动

工具活动行（read/bash/write/edit/grep/find/ls 的折叠态单行）三处打磨：

- **edit 统计红绿着色**:`+14 -15` 按 Kimi 风格 additions 绿色、removals 红色；没有 diff 的行不再显示 `+0 −0` 噪声（同时把 Unicode 减号 − 统一为 ASCII -);
- **pending  glyph 换 spinner**：静态 `◌` 换成包内共享的 braille spinner,bash 行每秒刷新所以会真实转动，和 subagent/workflow 视图同一语言；
- **动词列对齐**:pending/success/error 三态共用 8 字符动词栏，target 列纵向对齐。

## 验证

- `bun run check` ✅(270 files)
- `bun run test` ✅ 801 node:test + 30 vitest
- 本地预览脚本渲染六态行确认效果（脚本已删）
- 真实 TUI smoke：未验证 —— `/reload` 后任意编辑操作即可看到

效果：

```
  Wrote    scripts/mirror.sh  56 lines
  Edited   scripts/mirror.sh  +14 -15     ← 绿/红
  ⠧ Running  ./scripts/mirror.sh · 24s    ← spinner
  ✕ Failed   gh repo list … · command exited with code 1
```