### PR TITLE
feat(ui): launch marker for the subagent spawn card

### DIFF
--- a/extensions/subagents/index.ts
+++ b/extensions/subagents/index.ts
@@ -810,10 +810,10 @@ export default function (pi: ExtensionAPI) {
       const meta = [details.harness, details.model]
         .filter(Boolean)
         .join(" \u00b7 ");
-      // A spawn launches an agent into the pool: a quiet launch marker, then
-      // the strip's spinner carries the running state from here on.
+      // A spawn launches an agent out of the parent: a quiet outbound arrow,
+      // then the strip's spinner carries the running state from here on.
       return new Text(
-        `${theme.fg("dim", "▸")} ${theme.bold(details.title ?? details.id)} ${theme.fg("dim", meta)}`,
+        `${theme.fg("dim", "↗")} ${theme.bold(details.title ?? details.id)} ${theme.fg("dim", meta)}`,
         0,
         0,
       );

--- a/extensions/subagents/index.ts
+++ b/extensions/subagents/index.ts
@@ -810,10 +810,10 @@ export default function (pi: ExtensionAPI) {
       const meta = [details.harness, details.model]
         .filter(Boolean)
         .join(" \u00b7 ");
-      // A spawn adds an agent to the pool: a quiet plus, then the strip's
-      // spinner carries the running state from here on.
+      // A spawn launches an agent into the pool: a quiet launch marker, then
+      // the strip's spinner carries the running state from here on.
       return new Text(
-        `${theme.fg("dim", "+")} ${theme.bold(details.title ?? details.id)} ${theme.fg("dim", meta)}`,
+        `${theme.fg("dim", "▸")} ${theme.bold(details.title ?? details.id)} ${theme.fg("dim", meta)}`,
         0,
         0,
       );

--- a/extensions/subagents/index.ts
+++ b/extensions/subagents/index.ts
@@ -810,10 +810,11 @@ export default function (pi: ExtensionAPI) {
       const meta = [details.harness, details.model]
         .filter(Boolean)
         .join(" \u00b7 ");
-      // A spawn launches an agent out of the parent: a quiet outbound arrow,
-      // then the strip's spinner carries the running state from here on.
+      // A spawn is an event, not a state, so it speaks in the activity rows'
+      // verb language ("Wrote" / "Ran" / "Spawned") rather than a glyph; the
+      // strip's spinner carries the running state from here on.
       return new Text(
-        `${theme.fg("dim", "↗")} ${theme.bold(details.title ?? details.id)} ${theme.fg("dim", meta)}`,
+        `${theme.fg("toolTitle", "Spawned")}  ${theme.bold(details.title ?? details.id)} ${theme.fg("dim", meta)}`,
         0,
         0,
       );


### PR DESCRIPTION
spawn 卡片的暗色 `+` 换成 `▸`——加号读起来像列表计数，小三角表达"启动了一个代理"，依然安静不抢戏。

- `bun run check` ✅
- `bun run test` ✅ 801 + 30

真实 TUI smoke：未验证，`/reload` 后 spawn 任意子代理可见。