### PR TITLE
fix(ui): mute completed tool activity

### DIFF
--- a/extensions/file-mutation-display/render.test.ts
+++ b/extensions/file-mutation-display/render.test.ts
@@ -162,6 +162,7 @@ function renderCollapsed(
   result?: AgentToolResult<any>,
   isError = false,
   width = 120,
+  renderTheme = theme,
 ) {
   const state = {};
   const context = {
@@ -178,14 +179,14 @@ function renderCollapsed(
     showImages: false,
     isError,
   };
-  const call = definition.renderCall?.(args, theme, context);
+  const call = definition.renderCall?.(args, renderTheme, context);
   assert.ok(call);
   let resultComponent: Component | undefined;
   if (result) {
     resultComponent = definition.renderResult?.(
       result,
       { expanded: false, isPartial: false },
-      theme,
+      renderTheme,
       { ...context, isPartial: false, isError },
     );
   }
@@ -193,6 +194,21 @@ function renderCollapsed(
     ...call.render(width),
     ...(resultComponent?.render(width) ?? []),
   ].filter((line) => line.trim().length > 0);
+}
+
+function recordingTheme(calls: Array<[string, string]>) {
+  return new Proxy(
+    {},
+    {
+      get: (_target, property) =>
+        property === "fg" || property === "bg"
+          ? (color: string, text: string) => {
+              calls.push([color, text]);
+              return text;
+            }
+          : (text: string) => text,
+    },
+  ) as Theme;
 }
 
 test("all activity tools render one semantic success row", () => {
@@ -204,6 +220,58 @@ test("all activity tools render one semantic success row", () => {
     assert.ok(lines[0]?.startsWith("  "), fixture.name);
     assert.ok(lines[0]?.endsWith("  "), fixture.name);
     assert.match(lines[0] ?? "", fixture.success, fixture.name);
+  }
+});
+
+test("completed targets are muted without weakening pending or failed targets", () => {
+  const definition = withActivityRenderer(createBashToolDefinition(cwd));
+  const args = { command: "bun run check" };
+
+  const successColors: Array<[string, string]> = [];
+  renderCollapsed(
+    definition,
+    args,
+    { content: [{ type: "text", text: "ok" }], details: undefined },
+    false,
+    120,
+    recordingTheme(successColors),
+  );
+  assert.ok(
+    successColors.some(
+      ([color, text]) => color === "muted" && text === args.command,
+    ),
+  );
+
+  const cases: Array<{
+    label: string;
+    result?: AgentToolResult<any>;
+    isError: boolean;
+  }> = [
+    { label: "pending", isError: false },
+    {
+      label: "failed",
+      result: {
+        content: [{ type: "text", text: "failed" }],
+        details: undefined,
+      },
+      isError: true,
+    },
+  ];
+  for (const { label, result, isError } of cases) {
+    const calls: Array<[string, string]> = [];
+    renderCollapsed(
+      definition,
+      args,
+      result,
+      isError,
+      120,
+      recordingTheme(calls),
+    );
+    assert.equal(
+      calls.some(([color, text]) => color === "muted" && text === args.command),
+      false,
+      label,
+    );
   }
 });
 

--- a/extensions/file-mutation-display/render.ts
+++ b/extensions/file-mutation-display/render.ts
@@ -248,7 +248,11 @@ function activityText(
         : row.verb
   ).padEnd(8);
   const verb = theme.fg(
-    state.status === "error" ? "error" : "toolTitle",
+    state.status === "error"
+      ? "error"
+      : state.status === "success"
+        ? "muted"
+        : "toolTitle",
     verbText,
   );
   if (state.status === "pending") {
@@ -274,7 +278,7 @@ function activityText(
   }
   if (elapsed) parts.push(theme.fg("dim", elapsed));
   const detail = parts.join(theme.fg("dim", " · "));
-  return `${theme.fg("dim", activityIcon(name))} ${verb} ${row.target}${detail ? `  ${detail}` : ""}`;
+  return `${theme.fg("dim", activityIcon(name))} ${verb} ${theme.fg("muted", row.target)}${detail ? `  ${detail}` : ""}`;
 }
 
 function activityComponent(


### PR DESCRIPTION
Closes #87

## Summary

- render completed compact activity verbs and targets with the theme `muted` token
- keep pending activity at normal prominence and failures in the error state
- preserve Edit `+N / -N` accents and Pi-native `Ctrl+O` expanded rendering
- add a semantic color regression test so later refactors cannot mute active or failed commands accidentally

## Validation

- focused renderer tests: 6/6
- `bun run check`
- full suite: 823 Node tests + 30 Vitest tests, 0 failures
- real Pi TUI smoke from the single local checkout: compact `Ran pwd` rendered with both verb and target using the configured muted color

## Scope

Existing already-open TUI sessions may retain historical component display state. This PR intentionally does not add a historical UI migration; new sessions and newly rendered activity are the supported boundary.
