### PR TITLE
fix(workflows): expose call capacity in sandbox usage

### DIFF
--- a/extensions/workflows/narrator.test.ts
+++ b/extensions/workflows/narrator.test.ts
@@ -203,6 +203,38 @@ test("usage() advances as agents settle, so a post-await read sees them", async 
   assert.deepEqual(readings, { before: 0, afterOne: 1000, afterTwo: 2000 });
 });
 
+test("usage() exposes the host's resolved call capacity", async () => {
+  const result = await runSandbox(
+    `
+      const capacity = usage().limits;
+      try { capacity.callsRemaining = 999; } catch { /* frozen */ }
+      return {
+        concurrency: capacity.concurrency,
+        maxAgentCalls: capacity.maxAgentCalls,
+        callsUsed: capacity.callsUsed,
+        callsRemaining: capacity.callsRemaining,
+      };
+    `,
+    {
+      usageSnapshot: () => ({
+        total: 1_000,
+        limits: {
+          concurrency: 8,
+          maxAgentCalls: 128,
+          callsUsed: 1,
+          callsRemaining: 127,
+        },
+      }),
+    },
+  );
+  assert.deepEqual(result, {
+    concurrency: 8,
+    maxAgentCalls: 128,
+    callsUsed: 1,
+    callsRemaining: 127,
+  });
+});
+
 test("usage() degrades to a zero reading rather than failing the run", async () => {
   const result = await runSandbox(`return usage().total;`, {
     usageSnapshot: () => {

--- a/extensions/workflows/sandbox-child.cjs
+++ b/extensions/workflows/sandbox-child.cjs
@@ -207,6 +207,11 @@ const BOOTSTRAP = String.raw`
       const value = raw && typeof raw === "object" ? raw[key] : undefined;
       return typeof value === "number" && Number.isFinite(value) ? value : 0;
     };
+    const readLimit = (key) => {
+      const limits = raw && typeof raw === "object" ? raw.limits : undefined;
+      const value = limits && typeof limits === "object" ? limits[key] : undefined;
+      return typeof value === "number" && Number.isFinite(value) ? value : 0;
+    };
     // Every field is coerced, so a missing or malformed snapshot reads as zero
     // rather than undefined: a script doing arithmetic on it gets 0, not NaN.
     return deepFreeze({
@@ -217,6 +222,12 @@ const BOOTSTRAP = String.raw`
       total: read("total"),
       cost: read("cost"),
       agents: read("agents"),
+      limits: {
+        concurrency: readLimit("concurrency"),
+        maxAgentCalls: readLimit("maxAgentCalls"),
+        callsUsed: readLimit("callsUsed"),
+        callsRemaining: readLimit("callsRemaining"),
+      },
     });
   }
 


### PR DESCRIPTION
## 问题

Workflow V2 的 host 已经把 `controller.capacity()` 放进 `usageSnapshot().limits`，Skill 和模型提示也要求脚本使用 `usage().limits.callsRemaining` 做动态 fan-out；但 sandbox child 在重建 `usage()` 返回值时只复制了 token/cost/agents 字段，静默丢弃了 `limits`。

真实 run `wf_815de99b4a45` 因此在 Discovery 完成后失败：

```text
TypeError: Cannot read properties of undefined (reading 'callsRemaining')
```

## 修复

- 在 sandbox 边界显式投影并数值校验 `limits` 四个 Runtime facts；
- 将嵌套对象纳入既有 `deepFreeze`，模型脚本不能篡改容量；
- 增加真实脚本形状的回归测试，修复前稳定失败、修复后通过。

## 验证

- `bun run check` ✅
- Node 860/860 ✅
- Vitest 30/30 ✅
- `git diff --check` ✅

这是 `0.4.0` 发布阻塞修复；不包含 Issue #93 的 child transcript UI 改动。
