### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tt-a1i/openpi",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "OpenPI — a Pi-native multi-agent workbench with background execution, isolated subagents, replay-safe workflows, goals, tasks, and observable TUI",
   "license": "MIT",
   "author": "tt-a1i",


### PR DESCRIPTION
## Summary

- bump `@tt-a1i/openpi` from 0.3.1 to 0.4.0
- release Workflow V2 and the current `main` feature set
- include the Workflow sandbox `usage().limits` projection fix merged in #94

## Validation

- `bun run check`
- `bun run test` (860 Node + 30 Vitest)
- `npm publish --dry-run --access public`
- package: 145 files, 457.3 kB compressed, 1.5 MB unpacked

Issue #93 is not part of this release.
