### PR TITLE
fix(workflow): fall back on malformed render details

### DIFF
--- a/extensions/workflows/index.ts
+++ b/extensions/workflows/index.ts
@@ -594,6 +594,25 @@ function errorText(error: unknown): string {
   );
 }
 
+function isWorkflowRenderDetails(value: unknown): value is WorkflowDetails {
+  if (!value || typeof value !== "object") return false;
+  const details = value as Partial<WorkflowDetails>;
+  return (
+    typeof details.runId === "string" &&
+    details.runId.length > 0 &&
+    typeof details.background === "boolean" &&
+    (details.status === "running" ||
+      details.status === "completed" ||
+      details.status === "failed" ||
+      details.status === "aborted" ||
+      details.status === "uncertain") &&
+    typeof details.startedAt === "number" &&
+    Number.isFinite(details.startedAt) &&
+    Array.isArray(details.phases) &&
+    Array.isArray(details.agents)
+  );
+}
+
 function summaryLine(details: WorkflowDetails): string {
   const { done, failed, uncertain } = countStates(details);
   const settled = done + failed;
@@ -2149,8 +2168,8 @@ export default function workflows(pi: ExtensionAPI) {
     },
 
     renderResult(result, { expanded, isPartial }, theme, context) {
-      const details = result.details as WorkflowDetails | undefined;
-      if (!details) {
+      const details = result.details;
+      if (!isWorkflowRenderDetails(details)) {
         const first = result.content[0];
         return new Text(
           first?.type === "text" ? first.text : "(no output)",

--- a/extensions/workflows/rendering.test.ts
+++ b/extensions/workflows/rendering.test.ts
@@ -61,6 +61,46 @@ function captureRenderers() {
   return { workflow, message };
 }
 
+test("workflow tool errors with malformed details fall back to plain text", (t) => {
+  t.mock.timers.enable({ apis: ["setInterval", "Date"], now: 0 });
+  const { workflow } = captureRenderers();
+  const renderResult = workflow.renderResult!;
+  const errorText = "Workflow script failed to parse: Unexpected token (1:7)";
+  let invalidations = 0;
+  const context = {
+    args: {},
+    toolCallId: "call-parse-error",
+    invalidate: () => {
+      invalidations += 1;
+    },
+    lastComponent: undefined,
+    state: {},
+    cwd: process.cwd(),
+    executionStarted: true,
+    argsComplete: true,
+    isPartial: false,
+    expanded: false,
+    showImages: false,
+    isError: true,
+  } as Parameters<typeof renderResult>[3];
+
+  for (const details of [{}, { runId: "wf_incomplete", agents: [] }]) {
+    const component = renderResult(
+      {
+        content: [{ type: "text", text: errorText }],
+        details,
+      } as unknown as AgentToolResult<WorkflowDetails>,
+      { expanded: false, isPartial: false },
+      theme,
+      context,
+    );
+
+    assert.equal(component.render(100).join("\n").trimEnd(), errorText);
+  }
+  t.mock.timers.tick(SPINNER_INTERVAL_MS);
+  assert.equal(invalidations, 0);
+});
+
 test("running workflow cards request and render each shared spinner frame", (t) => {
   t.mock.timers.enable({ apis: ["setInterval", "Date"], now: 0 });
   const { workflow } = captureRenderers();


### PR DESCRIPTION
## Summary

- validate `workflow` tool-result details before entering the custom card renderer
- fall back to Pi's plain text rendering for empty or structurally incomplete error details
- keep malformed results out of the Workflow spinner lifecycle
- add regression coverage for the exact parse-error crash path

## Why

Pi represents some extension-tool execution failures with `isError: true` and `details: {}`. The Workflow renderer previously treated every truthy `details` value as `WorkflowDetails`, then called `aggregateUsage(details.agents)`. A Workflow parse error therefore became an uncaught `TypeError: agents is not iterable` and terminated the TUI.

The fix checks the mandatory top-level Workflow render contract (`runId`, `background`, terminal/running status, finite `startedAt`, `phases`, and `agents`) before using the custom renderer. Invalid shapes preserve the original error text and do not start a spinner. Valid Workflow cards are unchanged.

## Test plan

- `node --test --experimental-strip-types extensions/workflows/rendering.test.ts`
- `bun run check`
- `bun run test` — 868 Node tests and 30 Vitest tests passed
- `git diff --check`

Closes #101
