### PR TITLE
fix(ui): use Pi-native child tool renderers

### DIFF
--- a/extensions/shared/agent-tool-renderer.ts
+++ b/extensions/shared/agent-tool-renderer.ts
@@ -1,0 +1,208 @@
+/** Ephemeral bridge from child tool events to Pi's canonical tool renderer. */
+
+import {
+  ToolExecutionComponent,
+  type ToolDefinition,
+} from "@earendil-works/pi-coding-agent";
+import type { TUI } from "@earendil-works/pi-tui";
+
+export interface AgentToolRenderRequest {
+  readonly toolId: string;
+  readonly name: string;
+  readonly cwd?: string;
+}
+
+/** Operator-only projection. It is deliberately absent from persisted state. */
+export interface AgentToolRenderer {
+  renderTool(
+    request: AgentToolRenderRequest,
+    width: number,
+  ): string[] | undefined;
+  invalidate?(): void;
+}
+
+type ToolResult = Parameters<ToolExecutionComponent["updateResult"]>[0];
+
+interface ToolExecutionRecord {
+  name: string;
+  args: unknown;
+  definition?: ToolDefinition;
+  executionStarted: boolean;
+  argsComplete: boolean;
+  result?: ToolResult;
+  resultSource?: unknown;
+  isPartial: boolean;
+  component?: ToolExecutionComponent;
+  componentCwd?: string;
+}
+
+const inertTui = {
+  requestRender() {},
+} as TUI;
+
+function resultContent(value: unknown): ToolResult["content"] {
+  if (typeof value === "string") return [{ type: "text", text: value }];
+  if (!value || typeof value !== "object") return [];
+  const content = (value as { content?: unknown }).content;
+  if (!Array.isArray(content)) return [];
+  return content.flatMap((part) => {
+    if (!part || typeof part !== "object") return [];
+    const candidate = part as {
+      type?: unknown;
+      text?: unknown;
+      data?: unknown;
+      mimeType?: unknown;
+    };
+    if (typeof candidate.type !== "string") return [];
+    return [
+      {
+        type: candidate.type,
+        ...(typeof candidate.text === "string" ? { text: candidate.text } : {}),
+        ...(typeof candidate.data === "string" ? { data: candidate.data } : {}),
+        ...(typeof candidate.mimeType === "string"
+          ? { mimeType: candidate.mimeType }
+          : {}),
+      },
+    ];
+  });
+}
+
+function normalizeResult(value: unknown, isError: boolean): ToolResult {
+  const details =
+    value && typeof value === "object"
+      ? (value as { details?: unknown }).details
+      : undefined;
+  return {
+    content: resultContent(value),
+    ...(details === undefined ? {} : { details }),
+    isError,
+  };
+}
+
+/**
+ * Retains the real definition and event payloads only for the lifetime of the
+ * child session/run. The model transcript and persisted artifacts remain the
+ * compact, serializable source of execution facts.
+ */
+export class AgentToolRenderLedger implements AgentToolRenderer {
+  private executions = new Map<string, ToolExecutionRecord>();
+
+  start(
+    toolId: string,
+    name: string,
+    args: unknown,
+    definition?: ToolDefinition,
+  ) {
+    const current = this.executions.get(toolId);
+    if (current) {
+      if (definition && definition !== current.definition) {
+        current.definition = definition;
+        current.component = undefined;
+        current.componentCwd = undefined;
+      }
+      current.name = name;
+      if (current.args !== args) {
+        current.args = args;
+        current.component?.updateArgs(args);
+      }
+      const wasStarted = current.executionStarted;
+      const wereArgsComplete = current.argsComplete;
+      current.executionStarted = true;
+      current.argsComplete = true;
+      if (!wasStarted) current.component?.markExecutionStarted();
+      if (!wereArgsComplete) current.component?.setArgsComplete();
+      return;
+    }
+    this.executions.set(toolId, {
+      name,
+      args,
+      ...(definition ? { definition } : {}),
+      executionStarted: true,
+      argsComplete: true,
+      isPartial: true,
+    });
+  }
+
+  update(toolId: string, name: string, args: unknown, result: unknown) {
+    const current = this.executions.get(toolId);
+    if (!current) {
+      this.executions.set(toolId, {
+        name,
+        args,
+        executionStarted: true,
+        argsComplete: true,
+        result: normalizeResult(result, false),
+        resultSource: result,
+        isPartial: true,
+      });
+      return;
+    }
+    if (current.args !== args) {
+      current.args = args;
+      current.component?.updateArgs(args);
+    }
+    if (current.resultSource === result && current.isPartial) return;
+    current.result = normalizeResult(result, false);
+    current.resultSource = result;
+    current.isPartial = true;
+    current.component?.updateResult(current.result, true);
+  }
+
+  end(toolId: string, name: string, result: unknown, isError: boolean) {
+    const current = this.executions.get(toolId);
+    if (!current) {
+      this.executions.set(toolId, {
+        name,
+        args: {},
+        executionStarted: true,
+        argsComplete: true,
+        result: normalizeResult(result, isError),
+        resultSource: result,
+        isPartial: false,
+      });
+      return;
+    }
+    if (
+      current.resultSource === result &&
+      !current.isPartial &&
+      current.result?.isError === isError
+    ) {
+      return;
+    }
+    current.result = normalizeResult(result, isError);
+    current.resultSource = result;
+    current.isPartial = false;
+    current.component?.updateResult(current.result, false);
+  }
+
+  renderTool(request: AgentToolRenderRequest, width: number) {
+    const execution = this.executions.get(request.toolId);
+    if (!execution || execution.name !== request.name) return undefined;
+    const cwd = request.cwd ?? process.cwd();
+    if (!execution.component || execution.componentCwd !== cwd) {
+      execution.component = new ToolExecutionComponent(
+        execution.name,
+        request.toolId,
+        execution.args,
+        { showImages: false },
+        execution.definition,
+        inertTui,
+        cwd,
+      );
+      execution.componentCwd = cwd;
+      if (execution.executionStarted)
+        execution.component.markExecutionStarted();
+      if (execution.argsComplete) execution.component.setArgsComplete();
+      if (execution.result) {
+        execution.component.updateResult(execution.result, execution.isPartial);
+      }
+    }
+    return execution.component.render(width);
+  }
+
+  invalidate() {
+    for (const execution of this.executions.values()) {
+      execution.component?.invalidate();
+    }
+  }
+}

--- a/extensions/shared/agent-transcript.ts
+++ b/extensions/shared/agent-transcript.ts
@@ -8,6 +8,7 @@ import {
   type Theme,
 } from "@earendil-works/pi-coding-agent";
 import { TruncatedText } from "@earendil-works/pi-tui";
+import type { AgentToolRenderer } from "./agent-tool-renderer.ts";
 import { sanitizeTerminalText } from "./terminal-text.ts";
 import {
   parseToolArgsPreview,
@@ -46,6 +47,8 @@ export type AgentTranscriptItem =
 export interface AgentTranscriptDocument {
   readonly items: ReadonlyArray<AgentTranscriptItem>;
   readonly cwd?: string;
+  /** Ephemeral native renderer for the live child; never persisted. */
+  readonly toolRenderer?: AgentToolRenderer;
   readonly liveAssistant?: { readonly text: string; readonly thinking: string };
   readonly liveTools?: ReadonlyArray<{
     readonly toolId: string;
@@ -148,30 +151,37 @@ function activityStatus(phase: ToolPhase): ToolActivityStatus {
   return "pending";
 }
 
-function renderToolLine(
+function renderToolBlock(
   theme: Theme,
   phase: ToolPhase,
+  toolId: string,
   name: string,
   argsPreview: string | undefined,
   outputPreview: string | undefined,
   width: number,
   now: number,
   cwd?: string,
+  toolRenderer?: AgentToolRenderer,
 ) {
+  const native = toolRenderer?.renderTool({ toolId, name, cwd }, width);
+  if (native) return native;
   const { args, fallback } = parseToolArgsPreview(argsPreview);
-  return renderPaddedToolActivityLine(
-    {
-      name,
-      args,
-      argsFallback: fallback,
-      output: outputPreview,
-      status: activityStatus(phase),
-      cwd,
-    },
-    theme,
-    width,
-    now,
-  );
+  return [
+    "",
+    renderPaddedToolActivityLine(
+      {
+        name,
+        args,
+        argsFallback: fallback,
+        output: outputPreview,
+        status: activityStatus(phase),
+        cwd,
+      },
+      theme,
+      width,
+      now,
+    ),
+  ];
 }
 
 function renderAssistantItem(
@@ -181,6 +191,7 @@ function renderAssistantItem(
   tools: ReadonlyMap<string, ToolRenderState>,
   now: number,
   cwd?: string,
+  toolRenderer?: AgentToolRenderer,
 ) {
   const out = renderAssistantParts(item.parts, width);
   for (const part of item.parts) {
@@ -190,17 +201,18 @@ function renderAssistantItem(
       // the streaming output; rendering the call here too would show the same
       // command twice and make the block reflow when the tool settles.
       if (state.phase === "live") continue;
-      out.push("");
       out.push(
-        renderToolLine(
+        ...renderToolBlock(
           theme,
           state.phase,
+          part.toolId,
           part.name,
           part.argsPreview,
           state.result?.outputPreview,
           width,
           now,
           cwd,
+          toolRenderer,
         ),
       );
     }
@@ -215,21 +227,21 @@ function renderToolResultItem(
   paired: boolean,
   now: number,
   cwd?: string,
+  toolRenderer?: AgentToolRenderer,
 ) {
   if (paired) return [];
-  return [
-    "",
-    renderToolLine(
-      theme,
-      item.isError ? "error" : "ok",
-      item.name,
-      undefined,
-      item.outputPreview,
-      width,
-      now,
-      cwd,
-    ),
-  ];
+  return renderToolBlock(
+    theme,
+    item.isError ? "error" : "ok",
+    item.toolId,
+    item.name,
+    undefined,
+    item.outputPreview,
+    width,
+    now,
+    cwd,
+    toolRenderer,
+  );
 }
 
 function hasEarlierToolCall(
@@ -258,12 +270,37 @@ function renderTranscriptItem(
   context: ItemContext,
   now: number,
   cwd?: string,
+  toolRenderer?: AgentToolRenderer,
 ) {
   if (item.kind === "user") return renderUserText(item.text, width);
   if (item.kind === "assistant") {
-    return renderAssistantItem(theme, item, width, context.tools, now, cwd);
+    return renderAssistantItem(
+      theme,
+      item,
+      width,
+      context.tools,
+      now,
+      cwd,
+      toolRenderer,
+    );
   }
-  return renderToolResultItem(theme, item, width, context.paired, now, cwd);
+  return renderToolResultItem(
+    theme,
+    item,
+    width,
+    context.paired,
+    now,
+    cwd,
+    toolRenderer,
+  );
+}
+
+function itemHasTool(item: AgentTranscriptItem) {
+  return (
+    item.kind === "toolResult" ||
+    (item.kind === "assistant" &&
+      item.parts.some((part) => part.type === "toolCall"))
+  );
 }
 
 interface ItemContext {
@@ -340,6 +377,7 @@ function findResult(
  */
 export class AgentTranscriptRenderer {
   private itemCache = new WeakMap<AgentTranscriptItem, Map<string, string[]>>();
+  private toolRenderers = new Set<AgentToolRenderer>();
 
   render(
     document: AgentTranscriptDocument,
@@ -350,17 +388,27 @@ export class AgentTranscriptRenderer {
     const out: string[] = [];
     const now = options?.now ?? Date.now();
     const liveTools = document.liveTools ?? [];
+    if (document.toolRenderer) this.toolRenderers.add(document.toolRenderer);
     const liveIds = new Set(liveTools.map((tool) => tool.toolId));
 
     for (let index = 0; index < document.items.length; index++) {
       const item = document.items[index];
       const context = itemContext(document.items, index, liveIds);
       const key = `${width}|${context.token}`;
-      const cached = this.itemCache.get(item)?.get(key);
+      const cacheable = !document.toolRenderer || !itemHasTool(item);
+      const cached = cacheable ? this.itemCache.get(item)?.get(key) : undefined;
       const lines =
         cached ??
-        renderTranscriptItem(theme, item, width, context, now, document.cwd);
-      if (!cached) {
+        renderTranscriptItem(
+          theme,
+          item,
+          width,
+          context,
+          now,
+          document.cwd,
+          document.toolRenderer,
+        );
+      if (!cached && cacheable) {
         const widths = this.itemCache.get(item) ?? new Map<string, string[]>();
         if (widths.size >= MAX_CACHED_WIDTHS_PER_ITEM) {
           const oldestWidth = widths.keys().next().value;
@@ -388,22 +436,23 @@ export class AgentTranscriptRenderer {
     // lands, and the transcript's call line then takes over with the settled
     // glyph in the same column, so the block never reflows.
     for (const tool of liveTools) {
-      out.push("");
       const phase: ToolPhase = tool.done
         ? tool.isError
           ? "error"
           : "ok"
         : "live";
       out.push(
-        renderToolLine(
+        ...renderToolBlock(
           theme,
           phase,
+          tool.toolId,
           tool.name,
           tool.argsPreview,
           tool.outputPreview,
           width,
           now,
           document.cwd,
+          document.toolRenderer,
         ),
       );
     }
@@ -427,5 +476,7 @@ export class AgentTranscriptRenderer {
 
   invalidate() {
     this.itemCache = new WeakMap();
+    for (const renderer of this.toolRenderers) renderer.invalidate?.();
+    this.toolRenderers.clear();
   }
 }

--- a/extensions/subagents/src/backend.ts
+++ b/extensions/subagents/src/backend.ts
@@ -10,6 +10,7 @@
 
 import type { Effect, Scope, Stream } from "effect";
 import { Context } from "effect";
+import type { AgentToolRenderer } from "../../shared/agent-tool-renderer.ts";
 import type {
   BackendName,
   SendError,
@@ -42,6 +43,8 @@ export interface SubagentSession {
    * this with a timeout and fall back to closing the session scope.
    */
   readonly interrupt: Effect.Effect<void>;
+  /** Ephemeral Pi-native tool projection for the operator-facing child page. */
+  readonly toolRenderer?: AgentToolRenderer;
 }
 
 export interface SubagentBackend {

--- a/extensions/subagents/src/backends/pi.ts
+++ b/extensions/subagents/src/backends/pi.ts
@@ -41,6 +41,7 @@ import {
   shutdownAndDisposeChildSession,
 } from "../../../shared/child-session.ts";
 import { reclaimWorktree } from "../../../shared/worktree.ts";
+import { AgentToolRenderLedger } from "../../../shared/agent-tool-renderer.ts";
 
 const DIRECT_WORKTREE_CLEANUP_TIMEOUT_MS = 4_000;
 
@@ -231,6 +232,7 @@ const makePiSession = (
 
     const toolTimeout = createToolCallTimeoutGuard();
     toolTimeout.apply(session);
+    const toolRenderer = new AgentToolRenderLedger();
 
     const activeModel = (): Model<any> | undefined => {
       const sessionModel = session.model;
@@ -346,6 +348,12 @@ const makePiSession = (
           break;
         }
         case "tool_execution_start":
+          toolRenderer.start(
+            event.toolCallId,
+            event.toolName,
+            event.args,
+            session.getToolDefinition(event.toolName),
+          );
           emit({
             _tag: "ToolStart",
             toolId: event.toolCallId,
@@ -354,6 +362,12 @@ const makePiSession = (
           });
           break;
         case "tool_execution_update":
+          toolRenderer.update(
+            event.toolCallId,
+            event.toolName,
+            event.args,
+            event.partialResult,
+          );
           emit({
             _tag: "ToolUpdate",
             toolId: event.toolCallId,
@@ -361,6 +375,12 @@ const makePiSession = (
           });
           break;
         case "tool_execution_end":
+          toolRenderer.end(
+            event.toolCallId,
+            event.toolName,
+            event.result,
+            event.isError,
+          );
           emit({
             _tag: "ToolEnd",
             toolId: event.toolCallId,
@@ -444,6 +464,7 @@ const makePiSession = (
     startRun(task.prompt);
 
     return {
+      toolRenderer,
       meta: Effect.sync(currentMeta),
       events: Stream.fromQueue(events),
       send: (text) =>

--- a/extensions/subagents/src/manager.ts
+++ b/extensions/subagents/src/manager.ts
@@ -27,6 +27,7 @@ import {
   Stream,
 } from "effect";
 import type { SubagentBackend, SubagentSession } from "./backend.ts";
+import type { AgentToolRenderer } from "../../shared/agent-tool-renderer.ts";
 import { BackendRegistry } from "./backend.ts";
 import type {
   BackendName,
@@ -137,6 +138,8 @@ interface Entry {
 export interface SubagentReadModel {
   list(): ReadonlyArray<SubagentSnapshot>;
   get(id: string): SubagentSnapshot | undefined;
+  /** Native tool projection retained by the live child session, when present. */
+  getToolRenderer?(id: string): AgentToolRenderer | undefined;
   size(): number;
   /** Any-change notification (footer status, dashboard). */
   subscribe(listener: () => void): () => void;
@@ -792,6 +795,7 @@ const makeManager = (config: SubagentManagerConfig = {}) =>
     const view: SubagentReadModel = {
       list: () => [...entries.values()].map((entry) => entry.snapshot),
       get: (id) => entries.get(id)?.snapshot,
+      getToolRenderer: (id) => entries.get(id)?.session.toolRenderer,
       size: () => entries.size,
       subscribe: (listener) => {
         listeners.add(listener);

--- a/extensions/subagents/src/ui/takeover.ts
+++ b/extensions/subagents/src/ui/takeover.ts
@@ -418,7 +418,10 @@ export class TakeoverView implements Component, Focusable {
           id: snap.id,
           title: snap.title,
           status: snap.status,
-          document: subagentTranscriptDocument(snap),
+          document: subagentTranscriptDocument(
+            snap,
+            view.getToolRenderer?.(id),
+          ),
           metadata: [
             options?.badge,
             snap.meta.modelLabel,

--- a/extensions/subagents/src/ui/transcript.ts
+++ b/extensions/subagents/src/ui/transcript.ts
@@ -1,4 +1,5 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { AgentToolRenderer } from "../../../shared/agent-tool-renderer.ts";
 import {
   AgentTranscriptRenderer,
   type AgentTranscriptDocument,
@@ -17,10 +18,12 @@ export type { ToolPhase } from "../../../shared/agent-transcript.ts";
 /** Thin projection from Direct Subagent state to the shared UI document. */
 export function subagentTranscriptDocument(
   snap: SubagentSnapshot,
+  toolRenderer?: AgentToolRenderer,
 ): AgentTranscriptDocument {
   return {
     items: snap.transcript,
     cwd: snap.cwd,
+    ...(toolRenderer ? { toolRenderer } : {}),
     ...(snap.liveAssistant ? { liveAssistant: snap.liveAssistant } : {}),
     ...(snap.liveTools.length > 0 ? { liveTools: snap.liveTools } : {}),
     ...(snap.queued.length > 0 ? { queued: snap.queued } : {}),
@@ -36,9 +39,10 @@ export class TranscriptRenderer {
     width: number,
     theme: Theme,
     options?: { readonly now?: number },
+    toolRenderer?: AgentToolRenderer,
   ) {
     return this.renderer.render(
-      subagentTranscriptDocument(snap),
+      subagentTranscriptDocument(snap, toolRenderer),
       width,
       theme,
       options,
@@ -56,11 +60,13 @@ export function buildTranscriptLines(
   theme: Theme,
   renderer?: TranscriptRenderer,
   options?: { readonly now?: number },
+  toolRenderer?: AgentToolRenderer,
 ) {
   return (renderer ?? new TranscriptRenderer()).render(
     snap,
     width,
     theme,
     options,
+    toolRenderer,
   );
 }

--- a/extensions/subagents/transcript.test.ts
+++ b/extensions/subagents/transcript.test.ts
@@ -1,8 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { initTheme, type Theme } from "@earendil-works/pi-coding-agent";
+import {
+  defineTool,
+  initTheme,
+  type Theme,
+} from "@earendil-works/pi-coding-agent";
 import { stripVTControlCharacters } from "node:util";
-import { visibleWidth } from "@earendil-works/pi-tui";
+import { Text, visibleWidth } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+import { AgentToolRenderLedger } from "../shared/agent-tool-renderer.ts";
 import type { SubagentSnapshot } from "./src/domain.ts";
 import {
   SPINNER_INTERVAL_MS,
@@ -51,6 +57,76 @@ test("transcript sanitization strips terminal control sequences before rendering
     sanitizeText("\u001b]52;c;Y2xpcGJvYXJk\u0007**safe**\u001b[31m"),
     "**safe**",
   );
+});
+
+test("extension tool calls use their Pi-native renderer instead of raw JSON", () => {
+  const definition = defineTool({
+    name: "git_log",
+    label: "Git Log",
+    description: "test renderer",
+    parameters: Type.Object({
+      revision: Type.String(),
+      limit: Type.Number(),
+      oneline: Type.Boolean(),
+    }),
+    execute: async () => ({
+      content: [{ type: "text", text: "unused" }],
+      details: undefined,
+    }),
+    renderCall: (args, nativeTheme) =>
+      new Text(
+        nativeTheme.fg(
+          "toolTitle",
+          `git log ${args.revision} ${args.oneline ? "--oneline " : ""}-n ${args.limit}`,
+        ),
+        0,
+        0,
+      ),
+  });
+  const toolRenderer = new AgentToolRenderLedger();
+  const args = { revision: "main", limit: 3, oneline: true };
+  toolRenderer.start("git-log-1", "git_log", args, definition);
+  toolRenderer.end(
+    "git-log-1",
+    "git_log",
+    { content: [{ type: "text", text: "abc first\ndef second\nghi third" }] },
+    false,
+  );
+  const rendered = plain(
+    buildTranscriptLines(
+      snapshot({
+        status: "done",
+        transcript: [
+          {
+            kind: "assistant",
+            parts: [
+              {
+                type: "toolCall",
+                toolId: "git-log-1",
+                name: "git_log",
+                argsPreview: '{"revision":"main","limit":3,"oneline":true}',
+              },
+            ],
+          },
+          {
+            kind: "toolResult",
+            toolId: "git-log-1",
+            name: "git_log",
+            isError: false,
+            outputPreview: "abc first\ndef second\nghi third",
+          },
+        ],
+      }),
+      80,
+      theme,
+      undefined,
+      { now: 0 },
+      toolRenderer,
+    ),
+  );
+
+  assert.match(rendered, /git log main --oneline -n 3/);
+  assert.doesNotMatch(rendered, /\{"revision":"main"/);
 });
 
 test("takeover transcript renders finalized and live assistant Markdown within its width", () => {

--- a/extensions/workflows/index.ts
+++ b/extensions/workflows/index.ts
@@ -765,6 +765,9 @@ export default function workflows(pi: ExtensionAPI) {
       [...activeRuns].map(([runId, run]) => [runId, run.details] as const),
     );
   const settledRuns = new Map<string, WorkflowDetails>();
+  /** Keep current-session settled records live for their ephemeral UI renderer. */
+  const dashboardDetails = () =>
+    new Map<string, WorkflowDetails>([...settledRuns, ...activeDetails()]);
   const registerStableToolFamily = () =>
     patchOwnedTools(pi, "workflows", {
       enable: OPENPI_TOOL_SURFACE.workflows.entry,
@@ -935,7 +938,7 @@ export default function workflows(pi: ExtensionAPI) {
     try {
       await showWorkflowDashboard(
         ctx,
-        activeDetails,
+        dashboardDetails,
         initialRunId,
         startedSince,
         stopRun,

--- a/extensions/workflows/runner.ts
+++ b/extensions/workflows/runner.ts
@@ -42,6 +42,8 @@ import {
   STRUCTURED_OUTPUT_TOOL_DESCRIPTION,
 } from "./prompt.ts";
 import { safeStringify, truncateUtf8 } from "./serialization.ts";
+import { AgentToolRenderLedger } from "../shared/agent-tool-renderer.ts";
+import { bindWorkflowToolRenderer } from "./tool-renderer.ts";
 
 const AGENT_OUTPUT_MAX_BYTES = 64 * 1024;
 export const FIRST_RESPONSE_TIMEOUT_MS = 45_000;
@@ -571,6 +573,7 @@ export async function runAgent(
   }
 
   const childSession = session;
+  const toolRenderer = new AgentToolRenderLedger();
   let usage = emptyUsage();
   let modelId = childSession.model?.id ?? options.model?.id;
   let contextWindow = childSession.model?.contextWindow;
@@ -578,7 +581,33 @@ export async function runAgent(
   let promptErrorMessage: string | undefined;
   const toolTimings = new Map<string, ToolExecutionTiming>();
 
+  const captureToolRenderData = () => {
+    for (const message of childSession.messages) {
+      if (message.role === "assistant") {
+        for (const part of message.content) {
+          if (part.type !== "toolCall") continue;
+          toolRenderer.start(
+            part.id,
+            part.name,
+            part.arguments,
+            childSession.getToolDefinition(part.name),
+          );
+        }
+      } else if (message.role === "toolResult") {
+        toolRenderer.end(
+          message.toolCallId,
+          message.toolName,
+          message,
+          message.isError,
+        );
+      }
+    }
+  };
+
   const sync = () => {
+    // Operator reuse can restore earlier messages before this activation's
+    // event subscription starts. Rehydrate their native UI projection here.
+    captureToolRenderData();
     const messages = childSession.messages;
     usage = computeUsage(messages);
 
@@ -627,6 +656,28 @@ export async function runAgent(
   let cancelFirstResponseWatchdog = () => {};
   const unsubscribe = childSession.subscribe((event) => {
     if (settled) return;
+    if (event.type === "tool_execution_start") {
+      toolRenderer.start(
+        event.toolCallId,
+        event.toolName,
+        event.args,
+        childSession.getToolDefinition(event.toolName),
+      );
+    } else if (event.type === "tool_execution_update") {
+      toolRenderer.update(
+        event.toolCallId,
+        event.toolName,
+        event.args,
+        event.partialResult,
+      );
+    } else if (event.type === "tool_execution_end") {
+      toolRenderer.end(
+        event.toolCallId,
+        event.toolName,
+        event.result,
+        event.isError,
+      );
+    }
     if (isAssistantResponseEvent(event)) markFirstResponse();
     if (event.type === "message_end") {
       assistantSettlement = observeAssistantSettlement(
@@ -646,12 +697,16 @@ export async function runAgent(
       return;
     }
     sync();
+    const progressTranscript = bindWorkflowToolRenderer(
+      transcriptFromMessages(childSession.messages, toolTimings),
+      toolRenderer,
+    );
     options.onProgress?.({
       preview: finalOutput(childSession.messages),
       usage,
       model: modelId,
       contextWindow,
-      transcript: transcriptFromMessages(childSession.messages, toolTimings),
+      transcript: progressTranscript,
     });
   });
 
@@ -720,7 +775,10 @@ export async function runAgent(
       finalOutput(childSession.messages),
       AGENT_OUTPUT_MAX_BYTES,
     );
-    transcript = transcriptFromMessages(childSession.messages, toolTimings);
+    transcript = bindWorkflowToolRenderer(
+      transcriptFromMessages(childSession.messages, toolTimings),
+      toolRenderer,
+    );
     const cleanup = await shutdownAndDisposeChildSession(childSession, {
       abort: aborted || promptErrorMessage !== undefined,
       abortOperation,

--- a/extensions/workflows/tool-renderer.ts
+++ b/extensions/workflows/tool-renderer.ts
@@ -1,0 +1,22 @@
+/** In-memory association between a workflow transcript projection and its child renderer. */
+
+import type { AgentToolRenderer } from "../shared/agent-tool-renderer.ts";
+import type { TranscriptEntry } from "./model.ts";
+
+const renderers = new WeakMap<
+  ReadonlyArray<TranscriptEntry>,
+  AgentToolRenderer
+>();
+
+export function bindWorkflowToolRenderer<
+  T extends ReadonlyArray<TranscriptEntry>,
+>(transcript: T, renderer: AgentToolRenderer): T {
+  renderers.set(transcript, renderer);
+  return transcript;
+}
+
+export function workflowToolRenderer(
+  transcript: ReadonlyArray<TranscriptEntry>,
+) {
+  return renderers.get(transcript);
+}

--- a/extensions/workflows/transcript.test.ts
+++ b/extensions/workflows/transcript.test.ts
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { initTheme, type Theme } from "@earendil-works/pi-coding-agent";
+import {
+  defineTool,
+  initTheme,
+  type Theme,
+} from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+import { AgentToolRenderLedger } from "../shared/agent-tool-renderer.ts";
 import type { SubagentSnapshot } from "../subagents/src/domain.ts";
 import {
   buildTranscriptLines,
@@ -11,6 +18,7 @@ import {
   WorkflowTranscriptRenderer,
   workflowTranscriptDocument,
 } from "./transcript.ts";
+import { bindWorkflowToolRenderer } from "./tool-renderer.ts";
 
 initTheme("dark", false);
 
@@ -97,6 +105,88 @@ test("Direct and Workflow adapters render one equivalent conversation body", () 
       now: 0,
     }),
   );
+});
+
+test("Workflow children use the same native renderer as Direct children", () => {
+  const definition = defineTool({
+    name: "future_tool",
+    label: "Future Tool",
+    description: "synthetic future extension tool",
+    parameters: Type.Object({ value: Type.String() }),
+    execute: async () => ({
+      content: [{ type: "text", text: "unused" }],
+      details: undefined,
+    }),
+    renderCall: (args) => new Text(`native future ${args.value}`, 0, 0),
+    renderResult: () => new Text("native result", 0, 0),
+  });
+  const renderer = new AgentToolRenderLedger();
+  renderer.start("future-1", "future_tool", { value: "works" }, definition);
+  renderer.end(
+    "future-1",
+    "future_tool",
+    { content: [{ type: "text", text: "done" }] },
+    false,
+  );
+  const workflow = bindWorkflowToolRenderer(
+    [
+      {
+        role: "tool" as const,
+        name: "future_tool",
+        toolCallId: "future-1",
+        text: '{"value":"works"}',
+      },
+      {
+        role: "toolResult" as const,
+        name: "future_tool",
+        toolCallId: "future-1",
+        text: "done",
+      },
+    ],
+    renderer,
+  );
+  const direct: SubagentSnapshot = {
+    ...directSnapshot(),
+    transcript: [
+      {
+        kind: "assistant",
+        parts: [
+          {
+            type: "toolCall",
+            toolId: "future-1",
+            name: "future_tool",
+            argsPreview: '{"value":"works"}',
+          },
+        ],
+      },
+      {
+        kind: "toolResult",
+        toolId: "future-1",
+        name: "future_tool",
+        isError: false,
+        outputPreview: "done",
+      },
+    ],
+  };
+
+  const directLines = buildTranscriptLines(
+    direct,
+    80,
+    theme,
+    undefined,
+    { now: 0 },
+    renderer,
+  );
+  const workflowLines = new WorkflowTranscriptRenderer().render(
+    workflow,
+    direct.cwd,
+    80,
+    theme,
+    { now: 0 },
+  );
+  assert.deepEqual(workflowLines, directLines);
+  assert.match(workflowLines.join("\n"), /native future works/);
+  assert.match(workflowLines.join("\n"), /native result/);
 });
 
 test("old Workflow transcript entries without call ids remain renderable", () => {

--- a/extensions/workflows/transcript.ts
+++ b/extensions/workflows/transcript.ts
@@ -6,6 +6,7 @@ import {
   type AgentTranscriptPart,
 } from "../shared/agent-transcript.ts";
 import type { TranscriptEntry } from "./model.ts";
+import { workflowToolRenderer } from "./tool-renderer.ts";
 
 /** Project the bounded Workflow artifact into the shared operator document. */
 function buildWorkflowTranscriptDocument(
@@ -75,22 +76,30 @@ function buildWorkflowTranscriptDocument(
     });
   }
 
-  return { items, cwd };
+  const toolRenderer = workflowToolRenderer(transcript);
+  return {
+    items,
+    cwd,
+    ...(toolRenderer ? { toolRenderer } : {}),
+  };
 }
 
 /** Preserve the shared renderer's identity cache between Workflow repaint ticks. */
 export class WorkflowTranscriptAdapter {
   private previousEntries?: ReadonlyArray<TranscriptEntry>;
   private previousCwd?: string;
+  private previousToolRenderer?: AgentTranscriptDocument["toolRenderer"];
   private previousDocument?: AgentTranscriptDocument;
 
   document(
     transcript: ReadonlyArray<TranscriptEntry>,
     cwd?: string,
   ): AgentTranscriptDocument {
+    const toolRenderer = workflowToolRenderer(transcript);
     if (
       this.previousDocument &&
       this.previousCwd === cwd &&
+      this.previousToolRenderer === toolRenderer &&
       this.previousEntries?.length === transcript.length &&
       this.previousEntries.every((entry, index) => entry === transcript[index])
     ) {
@@ -100,6 +109,7 @@ export class WorkflowTranscriptAdapter {
     const document = buildWorkflowTranscriptDocument(transcript, cwd);
     this.previousEntries = [...transcript];
     this.previousCwd = cwd;
+    this.previousToolRenderer = toolRenderer;
     this.previousDocument = document;
     return document;
   }


### PR DESCRIPTION
## Summary

- render Direct Subagent and Workflow child tool activity through Pi native `ToolExecutionComponent`
- retain real tool definitions and raw event payloads only in an ephemeral operator-side ledger
- keep persisted transcripts unchanged and preserve the compatibility renderer for historical artifacts
- retain current-session Workflow renderers after settlement so opening a completed child does not regress to JSON fallback

## Root cause

The child transcript projection discarded the child session actual `ToolDefinition` and raw call/result payloads. Its closed handwritten formatter therefore rendered extension tools such as `git_log` as raw JSON even though the main Pi session used the tool native renderer.

## Validation

- regression test first reproduced `git_log` rendering as raw JSON
- focused Direct/Workflow transcript tests: 23 passed, 0 failed
- `bun run check`
- `bun run test` (Node 889 passed; Vitest 30 passed)
- `git diff --check`

Isolated partial `pi -e` smoke attempts were not counted as acceptance because they did not reconstruct the canonical OpenPI tool surface. The installed stable runtime was left untouched.

Closes #105