### PR TITLE
fix(workflows): bound structured result artifacts

### DIFF
--- a/extensions/workflows/artifacts.test.ts
+++ b/extensions/workflows/artifacts.test.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import {
   boundedArtifactTranscript,
   createWorkflowPersistence,
+  persistWorkflowAgentResult,
   persistWorkflowJson,
 } from "./artifacts.ts";
 import {
@@ -112,6 +113,38 @@ test("live artifact persistence includes current agents and transcripts", () => 
         finishedAt: 25,
         durationMs: 15,
       },
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("agent result artifacts are complete or fail without leaving a file", () => {
+  const directory = mkdtempSync(join(tmpdir(), "pi-workflow-agent-result-"));
+  try {
+    const artifact = persistWorkflowAgentResult(directory, 1, {
+      output: "complete",
+      structured: { verdict: "accepted", emoji: "你好🙂" },
+    });
+    assert.deepEqual(
+      JSON.parse(readFileSync(join(directory, artifact), "utf8")),
+      {
+        output: "complete",
+        structured: { verdict: "accepted", emoji: "你好🙂" },
+      },
+    );
+
+    assert.throws(
+      () =>
+        persistWorkflowAgentResult(directory, 2, {
+          output: "too large",
+          structured: "x".repeat(3 * 1024 * 1024),
+        }),
+      /agent result artifact exceeded the .* budget/i,
+    );
+    assert.throws(
+      () => readFileSync(join(directory, "agent-results/agent-0002.json")),
+      /ENOENT/,
     );
   } finally {
     rmSync(directory, { recursive: true, force: true });

--- a/extensions/workflows/artifacts.test.ts
+++ b/extensions/workflows/artifacts.test.ts
@@ -1,14 +1,16 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import {
   boundedArtifactTranscript,
   createWorkflowPersistence,
+  loadJournal,
   persistWorkflowAgentResult,
   persistWorkflowJson,
 } from "./artifacts.ts";
+import { JOURNAL_MAX_BYTES } from "./journal.ts";
 import {
   emptyUsage,
   type TranscriptEntry,
@@ -146,6 +148,20 @@ test("agent result artifacts are complete or fail without leaving a file", () =>
       () => readFileSync(join(directory, "agent-results/agent-0002.json")),
       /ENOENT/,
     );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("oversized replay journals fail closed before parsing", () => {
+  const directory = mkdtempSync(join(tmpdir(), "pi-workflow-journal-read-"));
+  try {
+    writeFileSync(
+      join(directory, "journal.json"),
+      Buffer.alloc(JOURNAL_MAX_BYTES + 1, 0x20),
+    );
+
+    assert.equal(loadJournal(directory), undefined);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/extensions/workflows/artifacts.ts
+++ b/extensions/workflows/artifacts.ts
@@ -1,22 +1,23 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  boundedJournal,
+  JOURNAL_MAX_BYTES,
+  type JournalEntry,
+  parseJournal,
+  type WorkflowJournal,
+} from "./journal.ts";
 import {
   refreshWorkflowGraph,
   type TranscriptEntry,
   type WorkflowDetails,
 } from "./model.ts";
 import {
-  boundedJournal,
-  parseJournal,
-  type JournalEntry,
-  type WorkflowJournal,
-} from "./journal.ts";
-import {
   encodeCompleteJson,
   safeStringify,
   truncateUtf8,
   writeFileAtomic,
 } from "./serialization.ts";
-import * as fs from "node:fs";
-import * as path from "node:path";
 
 export const JOURNAL_FILE = "journal.json";
 
@@ -256,10 +257,42 @@ export function createWorkflowPersistence(
  * turn into a new way for a run to fail.
  */
 export function loadJournal(runDir: string): WorkflowJournal | undefined {
+  let descriptor: number | undefined;
   try {
-    const raw = fs.readFileSync(path.join(runDir, JOURNAL_FILE), "utf8");
+    descriptor = fs.openSync(path.join(runDir, JOURNAL_FILE), "r");
+    const initialSize = fs.fstatSync(descriptor).size;
+    if (initialSize > JOURNAL_MAX_BYTES) return undefined;
+
+    // Read at most one byte beyond the cap. The descriptor pins the inspected
+    // file, while the extra byte catches growth after fstat without ever
+    // allocating or parsing an unbounded journal.
+    const bytes = Buffer.allocUnsafe(initialSize + 1);
+    let length = 0;
+    while (length < bytes.length) {
+      const read = fs.readSync(
+        descriptor,
+        bytes,
+        length,
+        bytes.length - length,
+        null,
+      );
+      if (read === 0) break;
+      length += read;
+    }
+    // Filling the extra byte means the file changed after inspection. Reject
+    // that race even when the new size would still fit the ordinary cap.
+    if (length === bytes.length) return undefined;
+    const raw = bytes.toString("utf8", 0, length);
     return parseJournal(JSON.parse(raw));
   } catch {
     return undefined;
+  } finally {
+    if (descriptor !== undefined) {
+      try {
+        fs.closeSync(descriptor);
+      } catch {
+        // Loading a replay cache is optional and always fails open to a miss.
+      }
+    }
   }
 }

--- a/extensions/workflows/artifacts.ts
+++ b/extensions/workflows/artifacts.ts
@@ -10,8 +10,8 @@ import {
   type WorkflowJournal,
 } from "./journal.ts";
 import {
+  encodeCompleteJson,
   safeStringify,
-  toSerializable,
   truncateUtf8,
   writeFileAtomic,
 } from "./serialization.ts";
@@ -22,6 +22,7 @@ export const JOURNAL_FILE = "journal.json";
 
 const ARTIFACT_TRANSCRIPT_MAX_BYTES = 32 * 1024;
 const ARTIFACT_TRANSCRIPT_ENTRY_MAX_BYTES = 8 * 1024;
+const AGENT_RESULT_ARTIFACT_MAX_BYTES = 2 * 1024 * 1024;
 export const WORKFLOW_CHECKPOINT_INTERVAL_MS = 500;
 const ENTRY_TRUNCATION_MARKER = "\n[entry truncated]";
 const TRANSCRIPT_TRUNCATION_MARKER =
@@ -111,27 +112,26 @@ export function persistWorkflowAgentResult(
     "agent-results",
     `agent-${String(index).padStart(4, "0")}.json`,
   );
-  writeRunFile(
-    runDir,
-    artifact,
-    JSON.stringify(
-      toSerializable(
-        {
-          output: result.output,
-          ...(result.structured !== undefined
-            ? { structured: result.structured }
-            : {}),
-        },
-        {
-          maxDepth: 32,
-          maxNodes: 100_000,
-          maxStringBytes: 2 * 1024 * 1024,
-        },
-      ),
-      null,
-      2,
-    ),
+  const encoded = encodeCompleteJson(
+    {
+      output: result.output,
+      ...(result.structured !== undefined
+        ? { structured: result.structured }
+        : {}),
+    },
+    {
+      maxBytes: AGENT_RESULT_ARTIFACT_MAX_BYTES,
+      maxDepth: 32,
+      maxNodes: 100_000,
+      maxStringBytes: AGENT_RESULT_ARTIFACT_MAX_BYTES,
+    },
   );
+  if (!encoded.ok) {
+    throw new Error(
+      `Agent result artifact exceeded the ${AGENT_RESULT_ARTIFACT_MAX_BYTES}-byte budget (${encoded.limit} limit at ${encoded.path})`,
+    );
+  }
+  writeRunFile(runDir, artifact, encoded.json);
   return artifact;
 }
 

--- a/extensions/workflows/execute.e2e.test.ts
+++ b/extensions/workflows/execute.e2e.test.ts
@@ -725,6 +725,73 @@ test("oversized authoritative agent results fail without a success record", asyn
   }
 });
 
+test("an oversized legacy replay is rejected without a success record", async () => {
+  let sessionCreations = 0;
+  const factory: WorkflowAgentSessionFactory = async () => {
+    sessionCreations++;
+    return { session: fakeAgentSession("legacy replay source") };
+  };
+  __setWorkflowTestAgentSessionFactory(factory);
+  const script =
+    'export const meta = { name: "oversized-replay" };\n' +
+    'const r = await agent("replay fixture", { agent_type: "reviewer" });\n' +
+    "return { ok: r.ok, error: r.error };";
+
+  try {
+    const first = (await workflow.execute(
+      "e2e-oversized-replay-source",
+      { script, wait: true },
+      undefined,
+      undefined,
+      ctx,
+    )) as { details: { runId?: unknown } };
+    const sourceDir = runDirFor(first.details.runId);
+    const journalPath = join(sourceDir, "journal.json");
+    const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
+      entries: Array<Record<string, unknown>>;
+    };
+    let tooDeep: Record<string, unknown> = { leaf: true };
+    for (let depth = 0; depth < 40; depth++) tooDeep = { next: tooDeep };
+    journal.entries[0]!.structured = tooDeep;
+    writeFileSync(journalPath, JSON.stringify(journal));
+
+    const resumed = (await workflow.execute(
+      "e2e-oversized-replay-resume",
+      {
+        script,
+        resume_from_run_id: String(first.details.runId),
+        wait: true,
+      },
+      undefined,
+      undefined,
+      ctx,
+    )) as { details: { runId?: unknown } };
+
+    assert.equal(sessionCreations, 1);
+    const resumedDir = runDirFor(resumed.details.runId);
+    const persisted = readWorkflowJson(resumed.details.runId);
+    const agents = persisted.agents as Array<{
+      state: unknown;
+      replayed?: unknown;
+      error?: unknown;
+      resultArtifact?: unknown;
+      resultRef?: unknown;
+    }>;
+    assert.equal(agents[0]?.state, "error");
+    assert.equal(agents[0]?.replayed, undefined);
+    assert.match(String(agents[0]?.error), /agent result artifact exceeded/i);
+    assert.equal(agents[0]?.resultArtifact, undefined);
+    assert.equal(agents[0]?.resultRef, undefined);
+    assert.equal(
+      existsSync(join(resumedDir, "agent-results/agent-0001.json")),
+      false,
+    );
+    assert.equal(existsSync(join(resumedDir, "journal.json")), false);
+  } finally {
+    __setWorkflowTestAgentSessionFactory(undefined);
+  }
+});
+
 test.after(() => {
   for (const handler of handlers.get("session_shutdown") ?? []) {
     void handler({}, ctx);

--- a/extensions/workflows/execute.e2e.test.ts
+++ b/extensions/workflows/execute.e2e.test.ts
@@ -641,6 +641,90 @@ test("agent calls run through the injected session factory and resume replays th
   }
 });
 
+test("oversized authoritative agent results fail without a success record", async () => {
+  const factory: WorkflowAgentSessionFactory = async (options) => {
+    const structuredTool = options?.customTools?.find(
+      (tool) => tool.name === "structured_output",
+    );
+    assert.ok(structuredTool);
+    const session = fakeAgentSession("");
+    const existingTools = session.getAllTools();
+    session.getAllTools = () => [
+      ...existingTools,
+      {
+        name: structuredTool.name,
+        description: structuredTool.description,
+        parameters: structuredTool.parameters,
+        promptGuidelines: structuredTool.promptGuidelines,
+        sourceInfo: {
+          path: "<custom:structured_output>",
+          source: "custom",
+          scope: "temporary",
+          origin: "top-level",
+        },
+      },
+    ];
+    session.getActiveToolNames = () => [
+      ...existingTools.map((tool) => tool.name),
+      structuredTool.name,
+    ];
+    session.getToolDefinition = (name) =>
+      name === structuredTool.name ? structuredTool : undefined;
+    session.prompt = async () => {
+      await structuredTool.execute(
+        "oversized-structured-output",
+        { blob: "x".repeat(3 * 1024 * 1024) },
+        new AbortController().signal,
+        () => {},
+        ctx,
+      );
+    };
+    return { session };
+  };
+  __setWorkflowTestAgentSessionFactory(factory);
+
+  try {
+    const result = (await workflow.execute(
+      "e2e-agent-result-budget",
+      {
+        script:
+          'export const meta = { name: "oversized-agent-result" };\n' +
+          'const r = await agent("return a large fixture", { agent_type: "reviewer", schema: { type: "object", properties: { blob: { type: "string" } }, required: ["blob"] } });\n' +
+          "return { ok: r.ok, error: r.error };",
+        wait: true,
+      },
+      undefined,
+      undefined,
+      ctx,
+    )) as { details: { runId?: unknown } };
+
+    const persisted = readWorkflowJson(result.details.runId);
+    const agents = persisted.agents as Array<{
+      state: unknown;
+      error?: unknown;
+      resultArtifact?: unknown;
+      resultRef?: unknown;
+    }>;
+    assert.equal(agents.length, 1);
+    assert.equal(agents[0]?.state, "error");
+    assert.match(String(agents[0]?.error), /agent result artifact exceeded/i);
+    assert.equal(agents[0]?.resultArtifact, undefined);
+    assert.equal(agents[0]?.resultRef, undefined);
+    assert.equal(
+      existsSync(
+        join(runDirFor(result.details.runId), "agent-results/agent-0001.json"),
+      ),
+      false,
+    );
+    assert.equal(
+      existsSync(join(runDirFor(result.details.runId), "journal.json")),
+      false,
+    );
+  } finally {
+    __setWorkflowTestAgentSessionFactory(undefined);
+  }
+});
+
 test.after(() => {
   for (const handler of handlers.get("session_shutdown") ?? []) {
     void handler({}, ctx);

--- a/extensions/workflows/index.ts
+++ b/extensions/workflows/index.ts
@@ -1874,7 +1874,24 @@ export default function workflows(pi: ExtensionAPI) {
               });
               const acceptance = judged.ledger;
               if (acceptance) record.acceptance = acceptance;
-              const outcomeOk = judged.ok;
+              let artifactError: string | undefined;
+              if (judged.ok) {
+                try {
+                  record.resultArtifact = persistWorkflowAgentResult(
+                    runDir,
+                    index,
+                    {
+                      output: outcome.output,
+                      ...(outcome.structured !== undefined
+                        ? { structured: outcome.structured }
+                        : {}),
+                    },
+                  );
+                } catch (error) {
+                  artifactError = errorText(error);
+                }
+              }
+              const outcomeOk = judged.ok && artifactError === undefined;
               record.invocation = transitionInvocation(record.invocation!, {
                 status: "settled",
                 outcome: outcomeOk ? "success" : "error",
@@ -1882,21 +1899,11 @@ export default function workflows(pi: ExtensionAPI) {
               });
               record.state = outcomeOk ? "done" : "error";
               if (outcomeOk) delete record.error;
-              else
-                record.error = judged.error
-                  ? sanitizeWorkflowDisplayLine(judged.error)
+              else {
+                const failureError = artifactError ?? judged.error;
+                record.error = failureError
+                  ? sanitizeWorkflowDisplayLine(failureError)
                   : undefined;
-              if (outcomeOk) {
-                record.resultArtifact = persistWorkflowAgentResult(
-                  runDir,
-                  index,
-                  {
-                    output: outcome.output,
-                    ...(outcome.structured !== undefined
-                      ? { structured: outcome.structured }
-                      : {}),
-                  },
-                );
               }
               const ref = handoffs.register({
                 callId,

--- a/extensions/workflows/index.ts
+++ b/extensions/workflows/index.ts
@@ -1651,18 +1651,25 @@ export default function workflows(pi: ExtensionAPI) {
           });
         const callKey = replayIdentity ? replayKey(replayIdentity) : undefined;
         let replayBoundaryViolated = false;
+        const persistAgentResult = (result: {
+          output: string;
+          structured?: unknown;
+        }) => {
+          try {
+            return {
+              ok: true as const,
+              artifact: persistWorkflowAgentResult(runDir, index, result),
+            };
+          } catch (error) {
+            return { ok: false as const, error: errorText(error) };
+          }
+        };
         // Checked before controller.schedule on purpose: schedule() charges the
         // run's agent-call budget on entry, and a replayed call runs no agent.
         const cached =
           callKey && replayLease.canReplay ? replay?.take(callKey) : undefined;
         if (cached) {
           const finishedAt = Date.now();
-          record.invocation = transitionInvocation(record.invocation!, {
-            status: "replayed",
-            at: finishedAt,
-          });
-          record.state = "done";
-          record.replayed = true;
           record.finishedAt = finishedAt;
           record.preview = sanitizeWorkflowDisplayText(
             cached.output,
@@ -1674,12 +1681,38 @@ export default function workflows(pi: ExtensionAPI) {
               cached.structured,
             );
           }
-          record.resultArtifact = persistWorkflowAgentResult(runDir, index, {
+          const persisted = persistAgentResult({
             output: cached.output,
             ...(cached.structured !== undefined
               ? { structured: cached.structured }
               : {}),
           });
+          if (!persisted.ok) {
+            record.invocation = transitionInvocation(record.invocation!, {
+              status: "rejected",
+              at: finishedAt,
+            });
+            record.state = "error";
+            record.error = sanitizeWorkflowDisplayLine(persisted.error);
+            emit();
+            replayLease.end();
+            return {
+              ok: false,
+              output: cached.output,
+              ...(cached.structured !== undefined
+                ? { structured: cached.structured }
+                : {}),
+              ...(record.acceptance ? { acceptance: record.acceptance } : {}),
+              error: persisted.error,
+            };
+          }
+          record.invocation = transitionInvocation(record.invocation!, {
+            status: "replayed",
+            at: finishedAt,
+          });
+          record.state = "done";
+          record.replayed = true;
+          record.resultArtifact = persisted.artifact;
           const ref = handoffs.register({
             callId,
             settled: true,
@@ -1876,20 +1909,14 @@ export default function workflows(pi: ExtensionAPI) {
               if (acceptance) record.acceptance = acceptance;
               let artifactError: string | undefined;
               if (judged.ok) {
-                try {
-                  record.resultArtifact = persistWorkflowAgentResult(
-                    runDir,
-                    index,
-                    {
-                      output: outcome.output,
-                      ...(outcome.structured !== undefined
-                        ? { structured: outcome.structured }
-                        : {}),
-                    },
-                  );
-                } catch (error) {
-                  artifactError = errorText(error);
-                }
+                const persisted = persistAgentResult({
+                  output: outcome.output,
+                  ...(outcome.structured !== undefined
+                    ? { structured: outcome.structured }
+                    : {}),
+                });
+                if (persisted.ok) record.resultArtifact = persisted.artifact;
+                else artifactError = persisted.error;
               }
               const outcomeOk = judged.ok && artifactError === undefined;
               record.invocation = transitionInvocation(record.invocation!, {

--- a/extensions/workflows/serialization.test.ts
+++ b/extensions/workflows/serialization.test.ts
@@ -132,6 +132,73 @@ test("complete JSON encoding contains object enumeration failures", () => {
   assert.doesNotThrow(() => JSON.parse(encoded.json));
 });
 
+test("complete JSON encoding charges sparse array slots to the node budget", () => {
+  let lengthReads = 0;
+  let hasChecks = 0;
+  const values = new Proxy(new Array(10_000), {
+    get(target, property, receiver) {
+      if (property === "length") lengthReads++;
+      return Reflect.get(target, property, receiver);
+    },
+    has(target, property) {
+      hasChecks++;
+      return Reflect.has(target, property);
+    },
+  });
+
+  const encoded = encodeCompleteJson(values, {
+    maxBytes: 1024 * 1024,
+    maxDepth: 8,
+    maxNodes: 5,
+    maxStringBytes: 128,
+  });
+
+  assert.equal(encoded.ok, false);
+  assert.equal(encoded.ok ? undefined : encoded.limit, "nodes");
+  assert.equal(lengthReads, 1);
+  assert.ok(hasChecks <= 4, `checked ${hasChecks} slots after the node budget`);
+});
+
+test("complete JSON encoding rejects non-finite budget configuration", () => {
+  for (const invalid of [Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.throws(
+      () =>
+        encodeCompleteJson("value", {
+          maxBytes: invalid,
+          maxDepth: 8,
+          maxNodes: 10,
+          maxStringBytes: 128,
+        }),
+      /maxBytes must be a finite integer/i,
+    );
+  }
+});
+
+test("oversized object keys fail before their values are read", () => {
+  let valueRead = false;
+  const key = "k".repeat(1024 * 1024);
+  const value = Object.defineProperty({}, key, {
+    enumerable: true,
+    get() {
+      valueRead = true;
+      return "unreachable";
+    },
+  });
+
+  const encoded = encodeCompleteJson(value, {
+    maxBytes: 2 * 1024 * 1024,
+    maxDepth: 8,
+    maxNodes: 10,
+    maxStringBytes: 128,
+  });
+
+  assert.equal(encoded.ok, false);
+  if (encoded.ok) return;
+  assert.equal(encoded.limit, "string");
+  assert.equal(valueRead, false);
+  assert.ok(Buffer.byteLength(encoded.path, "utf8") <= 256);
+});
+
 test("safeStringify handles cycles, bigint, depth, and size", () => {
   const value: Record<string, unknown> = {
     bigint: 42n,

--- a/extensions/workflows/serialization.test.ts
+++ b/extensions/workflows/serialization.test.ts
@@ -3,7 +3,134 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
-import { safeStringify, writeFileAtomic } from "./serialization.ts";
+import {
+  encodeCompleteJson,
+  safeStringify,
+  writeFileAtomic,
+} from "./serialization.ts";
+
+test("complete JSON encoding stops reading arrays at the first hard limit", () => {
+  let reads = 0;
+  const values = new Proxy(new Array(1_000_000).fill("value"), {
+    get(target, property, receiver) {
+      if (typeof property === "string" && /^\d+$/.test(property)) reads++;
+      return Reflect.get(target, property, receiver);
+    },
+  });
+
+  const encoded = encodeCompleteJson(values, {
+    maxBytes: 1_024,
+    maxDepth: 8,
+    maxNodes: 5,
+    maxStringBytes: 128,
+  });
+
+  assert.deepEqual(encoded.ok ? undefined : encoded.limit, "nodes");
+  assert.ok(reads <= 4, `read ${reads} array elements after the node budget`);
+});
+
+test("complete JSON encoding charges escaped UTF-8 bytes before reading values", () => {
+  let lateValueRead = false;
+  const value = Object.defineProperties(
+    {},
+    {
+      ['"\n'.repeat(40)]: {
+        enumerable: true,
+        get: () => "first",
+      },
+      late: {
+        enumerable: true,
+        get: () => {
+          lateValueRead = true;
+          throw new Error("late value must not be read");
+        },
+      },
+    },
+  );
+
+  const encoded = encodeCompleteJson(value, {
+    maxBytes: 96,
+    maxDepth: 8,
+    maxNodes: 20,
+    maxStringBytes: 1_024,
+  });
+
+  assert.equal(encoded.ok, false);
+  assert.equal(encoded.ok ? undefined : encoded.limit, "bytes");
+  assert.equal(lateValueRead, false);
+});
+
+test("complete JSON encoding preserves supported values within its exact cap", () => {
+  const value: Record<string, unknown> = {
+    emoji: "你好🙂",
+    quote: '"\\\n',
+    bigint: 42n,
+    number: Number.NaN,
+  };
+  value.self = value;
+
+  const encoded = encodeCompleteJson(value, {
+    maxBytes: 512,
+    maxDepth: 8,
+    maxNodes: 20,
+    maxStringBytes: 128,
+  });
+
+  assert.equal(encoded.ok, true);
+  if (!encoded.ok) return;
+  assert.equal(encoded.bytes, Buffer.byteLength(encoded.json, "utf8"));
+  assert.ok(encoded.bytes <= 512);
+  const parsed = JSON.parse(encoded.json) as Record<string, unknown>;
+  assert.equal(parsed.emoji, "你好🙂");
+  assert.equal(parsed.quote, '"\\\n');
+  assert.equal(parsed.bigint, "42n");
+  assert.equal(parsed.number, "[number: NaN]");
+  assert.equal(parsed.self, "[circular: $root]");
+});
+
+test("lossy serialization also stops collection reads at the node limit", () => {
+  let reads = 0;
+  const values = new Proxy(new Array(1_000_000).fill("value"), {
+    get(target, property, receiver) {
+      if (typeof property === "string" && /^\d+$/.test(property)) reads++;
+      return Reflect.get(target, property, receiver);
+    },
+  });
+
+  const text = safeStringify(values, {
+    maxBytes: 1_024,
+    maxDepth: 8,
+    maxNodes: 5,
+    maxStringBytes: 128,
+  });
+
+  assert.doesNotThrow(() => JSON.parse(text));
+  assert.match(text, /truncated/);
+  assert.ok(reads <= 4, `read ${reads} array elements after the node budget`);
+});
+
+test("complete JSON encoding contains object enumeration failures", () => {
+  const value = new Proxy(
+    {},
+    {
+      ownKeys() {
+        throw new Error("fixture ownKeys failure");
+      },
+    },
+  );
+
+  const encoded = encodeCompleteJson(value, {
+    maxBytes: 512,
+    maxDepth: 8,
+    maxNodes: 20,
+    maxStringBytes: 128,
+  });
+
+  assert.equal(encoded.ok, true);
+  if (!encoded.ok) return;
+  assert.match(encoded.json, /unreadable object.*fixture ownKeys failure/);
+  assert.doesNotThrow(() => JSON.parse(encoded.json));
+});
 
 test("safeStringify handles cycles, bigint, depth, and size", () => {
   const value: Record<string, unknown> = {

--- a/extensions/workflows/serialization.ts
+++ b/extensions/workflows/serialization.ts
@@ -8,6 +8,24 @@ export interface SerializationOptions {
   maxStringBytes?: number;
 }
 
+export type CompleteJsonLimit = "bytes" | "depth" | "nodes" | "string";
+
+export type CompleteJsonEncoding =
+  | {
+      readonly ok: true;
+      readonly json: string;
+      readonly bytes: number;
+      readonly nodes: number;
+    }
+  | {
+      readonly ok: false;
+      readonly limit: CompleteJsonLimit;
+      readonly path: string;
+      readonly maximum: number;
+      readonly observedAtLeast: number;
+      readonly nodes: number;
+    };
+
 const DEFAULT_MAX_BYTES = 1024 * 1024;
 const DEFAULT_MAX_DEPTH = 16;
 const DEFAULT_MAX_NODES = 20_000;
@@ -15,6 +33,236 @@ const DEFAULT_MAX_STRING_BYTES = 64 * 1024;
 
 function byteLength(value: string) {
   return Buffer.byteLength(value, "utf8");
+}
+
+function boundedPath(parent: string, child: string) {
+  const path = `${parent}.${child}`;
+  return byteLength(path) <= 256
+    ? path
+    : `${truncateUtf8(path, 240)}...[path truncated]`;
+}
+
+/**
+ * Encode a complete inert JSON value while bounding work and output during
+ * traversal. Unlike `safeStringify`, this interface never returns a truncated
+ * value: callers that persist authoritative data can fail closed instead.
+ */
+export function encodeCompleteJson(
+  value: unknown,
+  options: Required<SerializationOptions>,
+): CompleteJsonEncoding {
+  const maxBytes = Math.max(1, Math.floor(options.maxBytes));
+  const maxDepth = Math.max(0, Math.floor(options.maxDepth));
+  const maxNodes = Math.max(1, Math.floor(options.maxNodes));
+  const maxStringBytes = Math.max(0, Math.floor(options.maxStringBytes));
+  const chunks: string[] = [];
+  const seen = new WeakMap<object, string>();
+  let bytes = 0;
+  let nodes = 0;
+  let failure: Exclude<CompleteJsonEncoding, { ok: true }> | undefined;
+
+  const stop = (
+    limit: CompleteJsonLimit,
+    path: string,
+    maximum: number,
+    observedAtLeast: number,
+  ) => {
+    failure ??= {
+      ok: false,
+      limit,
+      path: truncateUtf8(path, 256),
+      maximum,
+      observedAtLeast,
+      nodes,
+    };
+    return false;
+  };
+
+  const append = (text: string, path: string) => {
+    const addition = byteLength(text);
+    if (bytes + addition > maxBytes) {
+      return stop("bytes", path, maxBytes, bytes + addition);
+    }
+    chunks.push(text);
+    bytes += addition;
+    return true;
+  };
+
+  const encodedString = (text: string, path: string) => {
+    const sourceBytes = byteLength(text);
+    if (sourceBytes > maxStringBytes) {
+      stop("string", path, maxStringBytes, sourceBytes);
+      return undefined;
+    }
+    return JSON.stringify(text);
+  };
+
+  const safeErrorText = (error: unknown) => {
+    try {
+      return error instanceof Error ? error.message : String(error);
+    } catch {
+      return "unknown error";
+    }
+  };
+
+  const visit = (current: unknown, depth: number, path: string): boolean => {
+    if (failure) return false;
+    if (nodes >= maxNodes) {
+      return stop("nodes", path, maxNodes, nodes + 1);
+    }
+    nodes++;
+    if (depth > maxDepth) {
+      return stop("depth", path, maxDepth, depth);
+    }
+
+    if (current === null) return append("null", path);
+    if (typeof current === "boolean")
+      return append(current ? "true" : "false", path);
+    if (typeof current === "string") {
+      const encoded = encodedString(current, path);
+      return encoded === undefined ? false : append(encoded, path);
+    }
+    if (typeof current === "number") {
+      return append(
+        Number.isFinite(current)
+          ? JSON.stringify(current)
+          : JSON.stringify(`[number: ${String(current)}]`),
+        path,
+      );
+    }
+    if (typeof current === "bigint")
+      return append(JSON.stringify(`${current.toString()}n`), path);
+    if (typeof current === "undefined")
+      return append(JSON.stringify("[undefined]"), path);
+    if (typeof current === "symbol")
+      return append(
+        JSON.stringify(`[symbol: ${current.description ?? ""}]`),
+        path,
+      );
+    if (typeof current === "function")
+      return append(
+        JSON.stringify(`[function: ${current.name || "anonymous"}]`),
+        path,
+      );
+    if (typeof current !== "object")
+      return append(JSON.stringify(String(current)), path);
+
+    const prior = seen.get(current);
+    if (prior) return append(JSON.stringify(`[circular: ${prior}]`), path);
+    seen.set(current, path);
+
+    if (current instanceof Date) {
+      try {
+        return append(
+          JSON.stringify(
+            Number.isNaN(current.getTime())
+              ? "[date: invalid]"
+              : current.toISOString(),
+          ),
+          path,
+        );
+      } catch (error) {
+        return append(
+          JSON.stringify(`[unreadable date: ${safeErrorText(error)}]`),
+          path,
+        );
+      }
+    }
+
+    if (current instanceof Error) {
+      let name = "Error";
+      let message = "";
+      let stack: string | undefined;
+      try {
+        name = current.name;
+      } catch {}
+      try {
+        message = current.message;
+      } catch {}
+      try {
+        stack = current.stack;
+      } catch {}
+      return visit(
+        {
+          name,
+          message,
+          ...(stack ? { stack: truncateUtf8(stack, 16 * 1024) } : {}),
+        },
+        depth,
+        path,
+      );
+    }
+
+    if (Array.isArray(current)) {
+      if (!append("[", path)) return false;
+      for (let index = 0; index < current.length; index++) {
+        if (nodes >= maxNodes) {
+          return stop(
+            "nodes",
+            boundedPath(path, String(index)),
+            maxNodes,
+            nodes + 1,
+          );
+        }
+        if (index > 0 && !append(",", path)) return false;
+        if (!(index in current)) {
+          if (!append("null", boundedPath(path, String(index)))) return false;
+          continue;
+        }
+        let item: unknown;
+        try {
+          item = current[index];
+        } catch (error) {
+          item = `[unreadable property: ${safeErrorText(error)}]`;
+        }
+        if (!visit(item, depth + 1, boundedPath(path, String(index)))) {
+          return false;
+        }
+      }
+      return append("]", path);
+    }
+
+    const objectChunkStart = chunks.length;
+    const objectByteStart = bytes;
+    if (!append("{", path)) return false;
+    let count = 0;
+    try {
+      for (const key in current) {
+        if (!Object.prototype.hasOwnProperty.call(current, key)) continue;
+        if (nodes >= maxNodes) {
+          return stop("nodes", boundedPath(path, key), maxNodes, nodes + 1);
+        }
+        const childPath = boundedPath(path, key);
+        const keyJson = encodedString(key, childPath);
+        if (keyJson === undefined) return false;
+        if (count > 0 && !append(",", path)) return false;
+        if (!append(keyJson, childPath) || !append(":", childPath)) {
+          return false;
+        }
+        let child: unknown;
+        try {
+          child = (current as Record<string, unknown>)[key];
+        } catch (error) {
+          child = `[unreadable property: ${safeErrorText(error)}]`;
+        }
+        if (!visit(child, depth + 1, childPath)) return false;
+        count++;
+      }
+    } catch (error) {
+      chunks.length = objectChunkStart;
+      bytes = objectByteStart;
+      return visit(
+        `[unreadable object: ${safeErrorText(error)}]`,
+        depth + 1,
+        path,
+      );
+    }
+    return append("}", path);
+  };
+
+  visit(value, 0, "$root");
+  if (failure) return failure;
+  return { ok: true, json: chunks.join(""), bytes, nodes };
 }
 
 export function truncateUtf8(value: string, maxBytes: number) {
@@ -72,9 +320,27 @@ export function toSerializable(
     seen.set(current, location);
 
     if (Array.isArray(current)) {
-      return current.map((item, index) =>
-        visit(item, depth + 1, `${location}[${index}]`),
-      );
+      const result: unknown[] = [];
+      for (let index = 0; index < current.length; index++) {
+        if (nodes >= maxNodes) {
+          result.push("[truncated: node limit]");
+          break;
+        }
+        if (!(index in current)) {
+          result.length++;
+          continue;
+        }
+        try {
+          result.push(
+            visit(current[index], depth + 1, `${location}[${index}]`),
+          );
+        } catch (error) {
+          result.push(
+            `[unreadable property: ${error instanceof Error ? error.message : String(error)}]`,
+          );
+        }
+      }
+      return result;
     }
 
     if (current instanceof Date) {
@@ -93,23 +359,30 @@ export function toSerializable(
     }
 
     const result: Record<string, unknown> = Object.create(null);
-    let keys: string[];
     try {
-      keys = Object.keys(current);
+      for (const key in current) {
+        if (!Object.prototype.hasOwnProperty.call(current, key)) continue;
+        if (nodes >= maxNodes) {
+          let marker = "[truncated: node limit]";
+          while (Object.prototype.hasOwnProperty.call(result, marker)) {
+            marker += ".";
+          }
+          result[marker] = true;
+          break;
+        }
+        try {
+          result[key] = visit(
+            (current as Record<string, unknown>)[key],
+            depth + 1,
+            `${location}.${key}`,
+          );
+        } catch (error) {
+          result[key] =
+            `[unreadable property: ${error instanceof Error ? error.message : String(error)}]`;
+        }
+      }
     } catch (error) {
       return `[unreadable object: ${error instanceof Error ? error.message : String(error)}]`;
-    }
-    for (const key of keys) {
-      try {
-        result[key] = visit(
-          (current as Record<string, unknown>)[key],
-          depth + 1,
-          `${location}.${key}`,
-        );
-      } catch (error) {
-        result[key] =
-          `[unreadable property: ${error instanceof Error ? error.message : String(error)}]`;
-      }
     }
     return result;
   };

--- a/extensions/workflows/serialization.ts
+++ b/extensions/workflows/serialization.ts
@@ -36,10 +36,22 @@ function byteLength(value: string) {
 }
 
 function boundedPath(parent: string, child: string) {
-  const path = `${parent}.${child}`;
+  const childPreview =
+    child.length <= 128 ? child : `${child.slice(0, 128)}...[key truncated]`;
+  const path = `${parent}.${childPreview}`;
   return byteLength(path) <= 256
     ? path
     : `${truncateUtf8(path, 240)}...[path truncated]`;
+}
+
+function configuredBudget(name: string, value: number, minimum: number) {
+  if (!Number.isSafeInteger(value) || !Number.isFinite(value)) {
+    throw new RangeError(`${name} must be a finite integer`);
+  }
+  if (value < minimum) {
+    throw new RangeError(`${name} must be at least ${minimum}`);
+  }
+  return value;
 }
 
 /**
@@ -51,10 +63,14 @@ export function encodeCompleteJson(
   value: unknown,
   options: Required<SerializationOptions>,
 ): CompleteJsonEncoding {
-  const maxBytes = Math.max(1, Math.floor(options.maxBytes));
-  const maxDepth = Math.max(0, Math.floor(options.maxDepth));
-  const maxNodes = Math.max(1, Math.floor(options.maxNodes));
-  const maxStringBytes = Math.max(0, Math.floor(options.maxStringBytes));
+  const maxBytes = configuredBudget("maxBytes", options.maxBytes, 1);
+  const maxDepth = configuredBudget("maxDepth", options.maxDepth, 0);
+  const maxNodes = configuredBudget("maxNodes", options.maxNodes, 1);
+  const maxStringBytes = configuredBudget(
+    "maxStringBytes",
+    options.maxStringBytes,
+    0,
+  );
   const chunks: string[] = [];
   const seen = new WeakMap<object, string>();
   let bytes = 0;
@@ -194,8 +210,18 @@ export function encodeCompleteJson(
     }
 
     if (Array.isArray(current)) {
+      let length: number;
+      try {
+        length = current.length;
+      } catch (error) {
+        return visit(
+          `[unreadable array: ${safeErrorText(error)}]`,
+          depth + 1,
+          path,
+        );
+      }
       if (!append("[", path)) return false;
-      for (let index = 0; index < current.length; index++) {
+      for (let index = 0; index < length; index++) {
         if (nodes >= maxNodes) {
           return stop(
             "nodes",
@@ -206,6 +232,7 @@ export function encodeCompleteJson(
         }
         if (index > 0 && !append(",", path)) return false;
         if (!(index in current)) {
+          nodes++;
           if (!append("null", boundedPath(path, String(index)))) return false;
           continue;
         }
@@ -227,14 +254,20 @@ export function encodeCompleteJson(
     if (!append("{", path)) return false;
     let count = 0;
     try {
+      // JavaScript has no interruptible own-key iterator: a Proxy's ownKeys
+      // trap may allocate before iteration begins. Once keys are available,
+      // the budgets below stop before reading any further property values.
       for (const key in current) {
         if (!Object.prototype.hasOwnProperty.call(current, key)) continue;
         if (nodes >= maxNodes) {
           return stop("nodes", boundedPath(path, key), maxNodes, nodes + 1);
         }
+        const keyBytes = byteLength(key);
         const childPath = boundedPath(path, key);
-        const keyJson = encodedString(key, childPath);
-        if (keyJson === undefined) return false;
+        if (keyBytes > maxStringBytes) {
+          return stop("string", childPath, maxStringBytes, keyBytes);
+        }
+        const keyJson = JSON.stringify(key);
         if (count > 0 && !append(",", path)) return false;
         if (!append(keyJson, childPath) || !append(":", childPath)) {
           return false;
@@ -321,12 +354,14 @@ export function toSerializable(
 
     if (Array.isArray(current)) {
       const result: unknown[] = [];
-      for (let index = 0; index < current.length; index++) {
+      const length = current.length;
+      for (let index = 0; index < length; index++) {
         if (nodes >= maxNodes) {
           result.push("[truncated: node limit]");
           break;
         }
         if (!(index in current)) {
+          nodes++;
           result.length++;
           continue;
         }


### PR DESCRIPTION
## Summary

- add an exact, fail-closed JSON encoder that enforces byte, node, depth, string, and finite-configuration limits during traversal
- stop exact and lossy serialization from reading collection values after the node budget is exhausted, including sparse array slots
- bound diagnostic paths for oversized object keys before any property value is read
- persist live and replayed agent results only when the complete authoritative artifact fits the fixed 2 MiB budget
- record artifact-budget failures as agent errors, with no result artifact, handoff reference, replay marker, or new journal entry
- bound replay journal reads before parsing and reject oversized or concurrently growing files as cache misses
- cover early-stop behavior, escaped UTF-8 accounting, cycles/special values, enumeration failures, sparse arrays, invalid budgets, oversized keys, bounded journal reads, atomic artifact absence, and live/replay state consistency

`safeStringify` remains the lossy projection interface. The exact encoder is reserved for authoritative persistence, so truncated data is never presented as a successful canonical result.

## Validation

- `bun run check`
- `bun run test`: 912 Node tests and 30 Vitest tests passed
- `git diff --check`

Closes #111
