### PR TITLE
fix(workflows): reject missing assistant responses

### DIFF
--- a/extensions/workflows/execute.e2e.test.ts
+++ b/extensions/workflows/execute.e2e.test.ts
@@ -19,9 +19,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import type {
-  AgentToolResult,
   AgentSession,
   AgentSessionEventListener,
+  AgentToolResult,
   ExtensionAPI,
   ExtensionContext,
   ToolDefinition,
@@ -239,6 +239,7 @@ function fakeAgentSession(output: string, promptGate?: Promise<void>) {
     {
       role: "assistant",
       content: [{ type: "text", text: output }],
+      api: "openai-responses",
       provider: "fixture",
       model: "fixture",
       usage: {
@@ -246,6 +247,7 @@ function fakeAgentSession(output: string, promptGate?: Promise<void>) {
         output: 5,
         cacheRead: 0,
         cacheWrite: 0,
+        totalTokens: 8,
         cost: {
           input: 0,
           output: 0,
@@ -257,7 +259,7 @@ function fakeAgentSession(output: string, promptGate?: Promise<void>) {
       stopReason: "stop",
       timestamp: 2,
     },
-  ];
+  ] satisfies AgentSession["messages"];
   return {
     messages,
     model: undefined,
@@ -269,6 +271,13 @@ function fakeAgentSession(output: string, promptGate?: Promise<void>) {
     },
     async prompt() {
       await promptGate;
+      const assistant = messages.find(
+        (message) => message.role === "assistant",
+      );
+      assert.ok(assistant);
+      for (const listener of listeners) {
+        listener({ type: "message_end", message: assistant });
+      }
     },
     async abort() {},
     dispose() {},

--- a/extensions/workflows/runner.test.ts
+++ b/extensions/workflows/runner.test.ts
@@ -4,12 +4,12 @@ import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { test } from "node:test";
 import {
-  DefaultResourceLoader,
-  SessionManager,
-  SettingsManager,
   type AgentSession,
   type AgentSessionEvent,
   type AgentSessionEventListener,
+  DefaultResourceLoader,
+  SessionManager,
+  SettingsManager,
   type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
@@ -20,10 +20,10 @@ import {
   observeAssistantSettlement,
   recordToolExecutionTiming,
   runAgent,
-  transcriptFromMessages,
-  workflowChildTools,
   type ToolExecutionTiming,
+  transcriptFromMessages,
   type WorkflowAgentSessionFactory,
+  workflowChildTools,
 } from "./runner.ts";
 
 async function withTempDir(run: (directory: string) => Promise<void>) {
@@ -121,6 +121,19 @@ const zeroUsage = {
     total: 0,
   },
 };
+
+function assistantTextMessage(text: string) {
+  return {
+    role: "assistant",
+    content: [{ type: "text" as const, text }],
+    api: "openai-responses",
+    provider: "fixture",
+    model: "fixture",
+    usage: zeroUsage,
+    stopReason: "stop" as const,
+    timestamp: 1_000,
+  } satisfies AgentSession["messages"][number];
+}
 
 function parallelToolMessages(): AgentSession["messages"] {
   return [
@@ -347,6 +360,37 @@ test("assistant settlement survives failed compaction and clears after recovery"
     "prompt rejected",
     "a thrown prompt error must remain independent from assistant recovery",
   );
+});
+
+test("schema-less agents fail when prompt resolves without an assistant response", async () => {
+  const harness = runnerHarness({});
+
+  const outcome = await runHarnessAgent(harness);
+
+  assert.equal(outcome.ok, false);
+  assert.equal(outcome.aborted, false);
+  assert.equal(outcome.output, "");
+  assert.equal(outcome.error, "Agent finished without an assistant response.");
+  assert.equal(harness.aborts(), 0);
+  assert.equal(harness.disposals(), 1);
+});
+
+test("schema-less agents accept an empty assistant message_end", async () => {
+  let respond = () => {};
+  const harness = runnerHarness({ prompt: async () => respond() });
+  respond = () => {
+    const message = assistantTextMessage("");
+    harness.messages.push(message);
+    harness.emit({ type: "message_end", message });
+  };
+
+  const outcome = await runHarnessAgent(harness);
+
+  assert.equal(outcome.ok, true);
+  assert.equal(outcome.aborted, false);
+  assert.equal(outcome.output, "");
+  assert.equal(outcome.error, undefined);
+  assert.equal(harness.disposals(), 1);
 });
 
 test("cancel during prompt owns the session and returns after bounded disposal", async () => {

--- a/extensions/workflows/runner.ts
+++ b/extensions/workflows/runner.ts
@@ -11,19 +11,20 @@
  */
 
 import {
-  createAgentSession,
-  DefaultResourceLoader,
-  defineTool,
-  SessionManager,
-  SettingsManager,
   type AgentSession,
   type AgentSessionEvent,
   type AgentSessionEventListener,
+  createAgentSession,
+  DefaultResourceLoader,
+  defineTool,
   type ExtensionAPI,
   type ExtensionContext,
+  SessionManager,
+  SettingsManager,
   type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
-import { Type, type TSchema } from "typebox";
+import { type TSchema, Type } from "typebox";
+import { AgentToolRenderLedger } from "../shared/agent-tool-renderer.ts";
 import {
   bindChildSessionExtensions,
   childToolPolicy,
@@ -31,18 +32,17 @@ import {
   shutdownAndDisposeChildSession,
 } from "../shared/child-session.ts";
 import { createToolCallTimeoutGuard } from "../shared/tool-call-timeout.ts";
-import { emptyUsage, type AgentUsage, type TranscriptEntry } from "./model.ts";
-import {
-  createReplayFilesystemBoundary,
-  type ReplayFilesystemBoundaryOptions,
-} from "./replay-safety.ts";
+import { type AgentUsage, emptyUsage, type TranscriptEntry } from "./model.ts";
 import {
   buildWorkflowAgentPrompt,
   STRUCTURED_OUTPUT_SYSTEM_INSTRUCTION,
   STRUCTURED_OUTPUT_TOOL_DESCRIPTION,
 } from "./prompt.ts";
+import {
+  createReplayFilesystemBoundary,
+  type ReplayFilesystemBoundaryOptions,
+} from "./replay-safety.ts";
 import { safeStringify, truncateUtf8 } from "./serialization.ts";
-import { AgentToolRenderLedger } from "../shared/agent-tool-renderer.ts";
 import { bindWorkflowToolRenderer } from "./tool-renderer.ts";
 
 const AGENT_OUTPUT_MAX_BYTES = 64 * 1024;
@@ -831,6 +831,20 @@ export async function runAgent(
       output,
       error:
         "Agent finished without calling structured_output; no structured result matching the schema was produced.",
+      aborted: false,
+      usage,
+      model: modelId,
+      contextWindow,
+      transcript,
+    };
+  }
+
+  if (options.schema === undefined && assistantSettlement === undefined) {
+    return {
+      ok: false,
+      output,
+      structured,
+      error: "Agent finished without an assistant response.",
       aborted: false,
       usage,
       model: modelId,


### PR DESCRIPTION
## Summary

- require a schema-less Workflow child to produce an assistant `message_end` settlement before reporting success
- preserve empty assistant responses as successful when the settlement exists
- keep schema-backed child behavior unchanged and align the Workflow e2e session fixture with Pi lifecycle events

## Tests

- `bun run check`
- `bun run test` (Node 918/918, Vitest 30/30)

Fixes #115