### PR TITLE
fix(background-terminals): harden output and process lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,10 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Test Windows process lifecycle
-        run: node --test --experimental-strip-types extensions/background-terminals/manager.test.ts
+        run: |
+          $testPath = if (Test-Path "tests/extensions/background-terminals/manager.test.ts") {
+            "tests/extensions/background-terminals/manager.test.ts"
+          } else {
+            "extensions/background-terminals/manager.test.ts"
+          }
+          node --test --experimental-strip-types $testPath

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,20 @@ jobs:
             --extension "$package/extensions/file-search/index.ts" \
             --extension "$package/extensions/git-info/index.ts" \
             </dev/null
+
+  windows-background-terminals:
+    name: Background terminals (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.19.0
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Test Windows process lifecycle
+        run: node --test --experimental-strip-types extensions/background-terminals/manager.test.ts

--- a/extensions/background-terminals/docs/implementation-guide.md
+++ b/extensions/background-terminals/docs/implementation-guide.md
@@ -736,6 +736,8 @@ export interface TerminalReadModel {
   subscribe(listener: () => void): () => void;
   subscribeTo(id: string, listener: () => void): () => void;
   requestKill(id: string): void;   // fire-and-forget via the scoped FiberSet runtime
+  retainResult(id: string): void;  // keep spill evidence for a pending completion
+  releaseResult(id: string): void; // release evidence after delivery/consumption
   setOnSettled(hook?: (snap: TerminalSnapshot, consumed: boolean) => void): void;
 }
 ```

--- a/extensions/background-terminals/docs/implementation-guide.md
+++ b/extensions/background-terminals/docs/implementation-guide.md
@@ -25,8 +25,8 @@ they run, check on them, and stop them. It can **never** write to a running proc
 processes are launched with `stdin: "ignore"`; there is no send/steer surface at all (this is
 the key simplification vs. subagents' `send()`).
 
-- Full stdout and stderr are captured **separately and completely** in private spill files;
-  bounded in-memory tails keep `/ps` responsive (§7.4).
+- Stdout and stderr are captured separately in bounded private spill files while the session
+  budget remains available; bounded in-memory tails keep `/ps` responsive (§7.4).
 - Tool responses to the model are **always truncated** with the pi truncation utilities.
 - When processes exit, every settlement reaches the model **exactly once** — no polling —
   using the same deferred-delivery/consumed dance as subagents (§9). Idle settlements share
@@ -402,17 +402,21 @@ reason). Resolution:
 
 - **In-memory retained cap: 2 MiB per stream per process** (so ≤ 8 procs × 2 streams × 2 MiB =
   32 MiB worst case). The newest output is always retained; the head is dropped.
-- **Spill-to-disk for the full capture** (this is what makes "full stdout/stderr" true even
-  past the cap): create the shared/session directories with owner-only `0700` permissions,
+- **Spill-to-disk for a budgeted full capture:** create the shared/session directories with
+  owner-only `0700` permissions,
   then open two `0600` append-mode `WriteStream`s under
   ``path.join(os.tmpdir(), "pi-background-terminals", sessionId, `${id}.stdout.log`)`` (and
   `.stderr.log`). A `WriteStream` serializes writes per stream; settlement ends and awaits
-  both streams behind a bounded flush barrier before publishing the result. A stream error or
-  flush timeout clears the affected full-log pointer and surfaces a bounded `errorText` note.
+  both streams behind a bounded flush barrier before publishing the result. Each stream may
+  reserve at most 256 MiB and the session may reserve at most 512 MiB across all terminals.
+  Crossing either limit fails closed: the affected full-log pointer is cleared and a bounded
+  `errorText` says that complete evidence is unavailable. A stream error or flush timeout does
+  the same. Pruning a settled entry removes its spill files and releases their reservations.
   The `/ps` detail view shows the in-memory tail and, when `truncatedBytes > 0`, a header line
   "first N KiB dropped from view — full log: <spillPath>"; model-facing results reference the
-  same path. `disposeAll` removes the private session spill directory after all entry scopes
-  and spill flushes complete, so secret-bearing logs do not outlive the owning pi session.
+  same path when a complete spill remains available. `disposeAll` removes the private session
+  spill directory after all entry scopes and spill flushes complete, so secret-bearing logs do
+  not outlive the owning pi session.
 - Precedent for "truncate + point at the full file": docs/extensions.md "Output Truncation"
   section recommends exactly this shape for tool results.
 
@@ -776,6 +780,8 @@ const STATUS_STDERR_MAX = 8 * 1024;    // bg_status stderr tail
 const RESULT_STDOUT_MAX = 16 * 1024;   // completion follow-up stdout tail
 const RESULT_STDERR_MAX = 8 * 1024;
 const RETAINED_PER_STREAM = 2 * 1024 * 1024;  // in-memory cap per stream (spill keeps the rest)
+const MAX_SPILL_BYTES_PER_STREAM = 256 * 1024 * 1024;
+const MAX_SPILL_BYTES_PER_SESSION = 512 * 1024 * 1024;
 ```
 
 All clamped by `Math.min(..., DEFAULT_MAX_BYTES)` and `DEFAULT_MAX_LINES` (imports from
@@ -881,10 +887,11 @@ tricks; they exist on any machine running pi)
 - [ ] Manager, output, result-delivery, and ps-selection tests pass through the root suite.
 - [ ] Tools registered: `bg_start`, `bg_status`, `bg_list`, `bg_kill`; descriptions document
       no-stdin, session-scoped lifetime, and truncation limits; no stdin/steer surface exists.
-- [ ] stdout and stderr captured separately and completely (in-memory tail + spill file);
-      `/ps` detail can inspect both, read-only, scrollable, ANSI-sanitized, live-tailing.
-- [ ] Every model-visible output path truncated (`truncateTail` + clamps) with pointers to the
-      full log.
+- [ ] stdout and stderr captured separately (in-memory tail + budgeted spill file); `/ps`
+      detail can inspect both, read-only, scrollable, ANSI-sanitized, live-tailing. Spill-limit
+      failures are explicit, and prune/dispose remove files owned by the session.
+- [ ] Every model-visible output path is sanitized before tail truncation (`truncateTail` +
+      clamps), with pointers to the full log only when complete evidence remains available.
 - [ ] Exactly-once async completion notification via `sendMessage followUp + triggerTurn`,
       deferred-delivery map, consumed-set for kill, `agent_settled` flush, `isIdle()` fast
       path, `disposed` guard. No polling anywhere.

--- a/extensions/background-terminals/docs/implementation-guide.md
+++ b/extensions/background-terminals/docs/implementation-guide.md
@@ -110,6 +110,7 @@ export interface TerminalSnapshot {
 
 export interface OutputView {
   readonly text: string;               // decoded, possibly head-trimmed text (bounded)
+  readonly modelSafeText: string;      // stateful bounded projection for model-facing output
   readonly totalBytes: number;         // true total bytes ever received
   readonly truncatedBytes: number;     // bytes dropped from the head (0 = complete)
   readonly spillPath?: string;         // on-disk full capture, when spilling engaged (§7.6)
@@ -388,7 +389,7 @@ export class OutputBuffer {
        older whole chunks until retained bytes fit. Every discarded byte
        increments truncatedBytes; totalBytes counts the original input. */
   }
-  view(): OutputView { /* { text: this.chunks.join(""), totalBytes, truncatedBytes, spillPath } */ }
+  view(): OutputView { /* { text, modelSafeText, totalBytes, truncatedBytes, spillPath } */ }
 }
 ```
 

--- a/extensions/background-terminals/docs/implementation-guide.md
+++ b/extensions/background-terminals/docs/implementation-guide.md
@@ -531,10 +531,12 @@ Unknown id → throw with the known-ids list (copy the exact error style from `s
 stdout and stderr sections:
 
 ```ts
-const stdout = truncateTail(snap.stdout.text, { maxBytes: 16 * 1024, maxLines: 400 });
-const stderr = truncateTail(snap.stderr.text, { maxBytes: 8 * 1024, maxLines: 200 });
+const stdout = truncateTail(snap.stdout.modelSafeText, { maxBytes: 16 * 1024, maxLines: 400 });
+const stderr = truncateTail(snap.stderr.modelSafeText, { maxBytes: 8 * 1024, maxLines: 200 });
 ```
 
+The stateful `modelSafeText` projection is built before the retained head can
+move, so a control string cannot become visible when its opener is evicted.
 `truncateTail` (not head) because for process logs the end matters — this is the documented
 guidance in docs/extensions.md Output Truncation. When truncated, append
 `[stdout truncated: showing last X of Y. Full log: <spillPath or "in /ps viewer">]` using

--- a/extensions/background-terminals/index.ts
+++ b/extensions/background-terminals/index.ts
@@ -95,6 +95,7 @@ interface WatchToolDetails {
 export default function (pi: ExtensionAPI) {
   let runtime: TerminalRuntime | undefined;
   let managerPromise: Promise<TerminalManagerShape> | undefined;
+  let managerForHooks: TerminalManagerShape | undefined;
   let sessionContext: ExtensionContext | undefined;
   let ui: ExtensionUIContext | undefined;
   let unsubStatus: (() => void) | undefined;
@@ -118,6 +119,7 @@ export default function (pi: ExtensionAPI) {
     managerPromise ??= getRuntime()
       .runPromise(TerminalManager)
       .then((manager) => {
+        managerForHooks = manager;
         manager.view.setOnSettled(onSettled);
         unsubStatus?.();
         unsubStatus = manager.view.subscribe(() => updateWidget(manager));
@@ -214,6 +216,7 @@ export default function (pi: ExtensionAPI) {
         // costing a turn.
         resultDeliveryOptions(wake),
       );
+      for (const snap of snaps) managerForHooks?.view.releaseResult(snap.id);
       return true;
     } catch (error) {
       // Session may be shutting down, but retain the snapshot so any later
@@ -253,6 +256,7 @@ export default function (pi: ExtensionAPI) {
       stdout: { ...snap.stdout },
       stderr: { ...snap.stderr },
     });
+    managerForHooks?.view.retainResult(snap.id);
     // Pending settlements remain retractable while busy, so bg_status/bg_kill
     // can consume them before they are committed to context. bg_start applies
     // backpressure across running + pending + reserved work, keeping this map
@@ -311,6 +315,7 @@ export default function (pi: ExtensionAPI) {
     const closing = runtime;
     runtime = undefined;
     managerPromise = undefined;
+    managerForHooks = undefined;
     await closing?.dispose();
   });
 
@@ -423,12 +428,16 @@ export default function (pi: ExtensionAPI) {
         );
       }
 
+      const text = buildStatusResult(snap);
       // This status is returning the settlement itself; a pending automatic
       // follow-up for the same settle would be a duplicate.
-      if (snap.status !== "running") resultDelivery.consume([snap.id]);
+      if (snap.status !== "running") {
+        resultDelivery.consume([snap.id]);
+        manager.view.releaseResult(snap.id);
+      }
 
       return {
-        content: [{ type: "text", text: buildStatusResult(snap) }],
+        content: [{ type: "text", text }],
         details: {
           id: snap.id,
           status: snap.status,
@@ -510,6 +519,7 @@ export default function (pi: ExtensionAPI) {
       // via the killInterest consumed flag). Remove any deferred automatic
       // delivery now that this tool returns the final state itself.
       resultDelivery.consume(ids);
+      for (const id of ids) manager.view.releaseResult(id);
 
       return {
         content: [{ type: "text", text: buildKillReport(report) }],

--- a/extensions/background-terminals/src/domain.ts
+++ b/extensions/background-terminals/src/domain.ts
@@ -23,6 +23,8 @@ export type TerminalStatus =
 export interface OutputView {
   /** Decoded, possibly head-trimmed text (bounded by the in-memory cap). */
   readonly text: string;
+  /** Stateful, bounded projection safe for model-facing output. */
+  readonly modelSafeText: string;
   /** True total bytes ever received on this stream. */
   readonly totalBytes: number;
   /** Bytes dropped from the head of the in-memory view (0 = complete). */

--- a/extensions/background-terminals/src/manager.ts
+++ b/extensions/background-terminals/src/manager.ts
@@ -42,9 +42,12 @@ const MAX_SETTLED_HISTORY = MAX_TRACKED * 4;
 export const RETAINED_PER_STREAM = 2 * 1024 * 1024;
 /** Private full-log spills are bounded so a firehose cannot fill the temp disk. */
 export const MAX_SPILL_BYTES_PER_STREAM = 256 * 1024 * 1024;
+/** Aggregate private full-log budget across every terminal in one session. */
+export const MAX_SPILL_BYTES_PER_SESSION = 512 * 1024 * 1024;
 const STOP_TIMEOUT_MS = 5_000;
 /** SIGTERM is normally enough; the second deadline covers a wedged process. */
 const FORCE_KILL_AFTER_MS = 2_000;
+const FORCE_CLOSE_WAIT_MS = 500;
 /** After termination, how long to wait for the natural close→flush→settle
  * path before force-settling (a grandchild can hold the stdio pipes open). */
 const SETTLE_GRACE_MS = 1_000;
@@ -76,16 +79,19 @@ interface MutableSnapshot extends TerminalSnapshot {
   errorText?: string;
 }
 
+function appendSnapshotError(snapshot: MutableSnapshot, message: string) {
+  snapshot.errorText = bounded(
+    snapshot.errorText ? `${snapshot.errorText}; ${message}` : message,
+  );
+}
+
 interface Entry {
   snapshot: MutableSnapshot;
   child: ChildProcess;
   scope: Scope.Closeable;
   stdoutBuf: OutputBuffer;
   stderrBuf: OutputBuffer;
-  spillStreams: fs.WriteStream[];
-  /** Set in the same synchronous effect that sends SIGTERM so a natural exit
-   * before signaling keeps its truthful status. */
-  killSignaled: boolean;
+  spillFiles: SpillFile[];
   /** Deadline won the race and initiated termination. */
   timedOut: boolean;
   timeoutTimer?: ReturnType<typeof setTimeout>;
@@ -99,12 +105,29 @@ interface Entry {
   stdioClosed: boolean;
   /** A settle-after-spill-flush is in flight; don't start a second one. */
   settling: boolean;
+  /** Scope termination is deciding whether a process-tree boundary was
+   * actually reached. A concurrent close event must wait for that evidence. */
+  terminationInFlight: boolean;
+  /** At least one termination signal was sent to the child or its tree. */
+  killSignaled: boolean;
+  /** False when only a direct-child fallback was available or signaling
+   * failed, so user-visible output must not claim a process-tree kill. */
+  terminationConfirmed: boolean;
+  /** A live target could not be terminated at the promised process-tree
+   * boundary. This also covers the case where every signal attempt failed. */
+  terminationFailed: boolean;
   /** The shell exited without stdio closing; a bounded scope close is queued
    * to reap descendants that still hold the inherited pipes open. */
   exitCleanupStarted: boolean;
   /** Completed exactly once when the entry settles. Kill callers and the scope
    * finalizer can all await the same result without missing a notification. */
   settled: Deferred.Deferred<void>;
+}
+
+interface SpillFile {
+  readonly path: string;
+  readonly file: fs.WriteStream;
+  reservedBytes: number;
 }
 
 export interface StartOptions {
@@ -124,6 +147,10 @@ export interface KillResult {
   /** True when this call initiated the termination AND the entry settled as
    * killed (a natural exit that won the race reports killed: false). */
   readonly killed: boolean;
+  /** A kill was attempted, but the promised process-tree boundary could not
+   * be confirmed. */
+  readonly terminationFailed?: boolean;
+  readonly errorText?: string;
   /** Final exit rendering ("exit 0", "SIGTERM", ...) captured at settle time,
    * so reports stay accurate even if the entry is pruned afterwards. */
   readonly exit: string;
@@ -190,55 +217,170 @@ function shellInvocation(command: string) {
   return { shell: "/bin/sh", args: ["-c", command] };
 }
 
-/** Signal the whole process group on POSIX so descendants (servers a shell
- * command spawned) die with it; a wedged child must not orphan its tree. */
-function killTree(child: ChildProcess, signal: NodeJS.Signals) {
-  if (process.platform === "win32" && child.pid) {
-    try {
-      const killer = spawn(
-        "taskkill",
-        [
-          "/pid",
-          String(child.pid),
-          "/T",
-          ...(signal === "SIGKILL" ? ["/F"] : []),
-        ],
-        { stdio: "ignore", windowsHide: true },
-      );
-      killer.once("error", () => {
-        try {
-          child.kill(signal);
-        } catch {
-          // Process may already be gone.
-        }
-      });
-      killer.once("exit", (code) => {
-        if (code === 0) return;
-        try {
-          child.kill(signal);
-        } catch {
-          // Process may already be gone.
-        }
-      });
-      killer.unref();
-      return;
-    } catch {
-      // Fall through to the direct signal when taskkill cannot be launched.
+type ProcessSignalTarget = Pick<ChildProcess, "pid" | "kill">;
+type TaskkillSpawner = (pid: number, force: boolean) => ChildProcess;
+
+export type ProcessTreeSignalResult =
+  | { readonly outcome: "sent" }
+  | { readonly outcome: "already_exited"; readonly detail: string }
+  | { readonly outcome: "fallback_sent"; readonly detail: string }
+  | { readonly outcome: "failed"; readonly detail: string };
+
+export type WindowsTaskkillResult =
+  | {
+      readonly outcome: "completed";
+      readonly exitCode: number | null;
+      readonly signal: NodeJS.Signals | null;
     }
-  }
-  if (process.platform !== "win32" && child.pid) {
+  | { readonly outcome: "launch_failed"; readonly error: string }
+  | { readonly outcome: "timed_out"; readonly timeoutMs: number };
+
+function spawnTaskkill(pid: number, force: boolean) {
+  return spawn(
+    "taskkill",
+    ["/pid", String(pid), "/T", ...(force ? ["/F"] : [])],
+    { stdio: "ignore", windowsHide: true },
+  );
+}
+
+/** Resolve only after taskkill has either failed to launch or closed. */
+export function waitForWindowsTaskkill(
+  pid: number,
+  force: boolean,
+  launch: TaskkillSpawner = spawnTaskkill,
+  timeoutMs = force ? FORCE_CLOSE_WAIT_MS : FORCE_KILL_AFTER_MS,
+) {
+  return new Promise<WindowsTaskkillResult>((resolve) => {
+    let killer: ChildProcess;
     try {
-      process.kill(-child.pid, signal);
+      killer = launch(pid, force);
+    } catch (error) {
+      resolve({ outcome: "launch_failed", error: boundedError(error) });
       return;
-    } catch {
-      // Group may already be gone; fall through to the direct signal.
     }
-  }
+
+    let finished = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const finish = (result: WindowsTaskkillResult) => {
+      if (finished) return;
+      finished = true;
+      if (timer) clearTimeout(timer);
+      killer.off("error", onError);
+      killer.off("close", onClose);
+      resolve(result);
+    };
+    const onError = (error: Error) =>
+      finish({ outcome: "launch_failed", error: boundedError(error) });
+    const onClose = (exitCode: number | null, signal: NodeJS.Signals | null) =>
+      finish({ outcome: "completed", exitCode, signal });
+    killer.once("error", onError);
+    killer.once("close", onClose);
+    timer = setTimeout(() => {
+      try {
+        killer.kill("SIGKILL");
+      } catch {
+        // The helper may already be gone; the bounded result stays the same.
+      }
+      finish({ outcome: "timed_out", timeoutMs });
+    }, timeoutMs);
+  });
+}
+
+function directSignal(
+  child: ProcessSignalTarget,
+  signal: NodeJS.Signals,
+  targetExited: () => boolean,
+  detail: string,
+): ProcessTreeSignalResult {
+  if (targetExited()) return { outcome: "already_exited", detail };
   try {
-    child.kill(signal);
-  } catch {
-    // Process may already be gone.
+    if (child.kill(signal)) return { outcome: "fallback_sent", detail };
+    if (targetExited()) return { outcome: "already_exited", detail };
+    return {
+      outcome: "failed",
+      detail: `${detail}; direct child signal returned false`,
+    };
+  } catch (error) {
+    if (targetExited()) return { outcome: "already_exited", detail };
+    return {
+      outcome: "failed",
+      detail: `${detail}; direct child signal failed: ${boundedError(error)}`,
+    };
   }
+}
+
+/** Windows process-tree signaling with explicit taskkill and fallback evidence. */
+export async function signalWindowsProcessTree(
+  child: ProcessSignalTarget,
+  signal: NodeJS.Signals,
+  targetExited: () => boolean,
+  launch: TaskkillSpawner = spawnTaskkill,
+): Promise<ProcessTreeSignalResult> {
+  if (targetExited()) {
+    return {
+      outcome: "already_exited",
+      detail: "target exited before taskkill started",
+    };
+  }
+  if (!child.pid) {
+    return directSignal(
+      child,
+      signal,
+      targetExited,
+      "taskkill unavailable because the child has no pid",
+    );
+  }
+
+  const attempt = await waitForWindowsTaskkill(
+    child.pid,
+    signal === "SIGKILL",
+    launch,
+  );
+  if (attempt.outcome === "completed" && attempt.exitCode === 0) {
+    return { outcome: "sent" };
+  }
+  const detail =
+    attempt.outcome === "launch_failed"
+      ? `taskkill failed to launch: ${attempt.error}`
+      : attempt.outcome === "timed_out"
+        ? `taskkill timed out after ${attempt.timeoutMs}ms`
+        : `taskkill exited ${attempt.exitCode ?? "without a code"}${attempt.signal ? ` (${attempt.signal})` : ""}`;
+  return directSignal(child, signal, targetExited, detail);
+}
+
+/** Signal the whole process group on POSIX so descendants (servers a shell
+ * command spawned) die with it; return exact evidence for every fallback. */
+function signalProcessTree(
+  child: ChildProcess,
+  signal: NodeJS.Signals,
+  targetExited: () => boolean,
+) {
+  if (process.platform === "win32") {
+    return Effect.promise(() =>
+      signalWindowsProcessTree(child, signal, targetExited),
+    );
+  }
+  return Effect.sync((): ProcessTreeSignalResult => {
+    if (child.pid) {
+      try {
+        process.kill(-child.pid, signal);
+        return { outcome: "sent" };
+      } catch (error) {
+        return directSignal(
+          child,
+          signal,
+          targetExited,
+          `process-group ${signal} failed: ${boundedError(error)}`,
+        );
+      }
+    }
+    return directSignal(
+      child,
+      signal,
+      targetExited,
+      "process-group signal unavailable because the child has no pid",
+    );
+  });
 }
 
 /** Await stdio closure without retaining a listener after interruption. */
@@ -260,32 +402,58 @@ function awaitChildClose(child: ChildProcess, closed: () => boolean) {
 function terminateChild(
   child: ChildProcess,
   closed: () => boolean,
-  onSignal: () => void,
+  targetExited: () => boolean,
 ) {
   return Effect.suspend(() => {
-    if (closed()) return Effect.void;
-    return Effect.gen(function* () {
-      yield* Effect.sync(() => {
-        onSignal();
-        killTree(child, "SIGTERM");
+    if (closed()) {
+      return Effect.succeed({
+        signalSent: false,
+        treeConfirmed: true,
+        terminationFailed: false,
+        detail: undefined as string | undefined,
       });
+    }
+    const liveAtStart = !targetExited();
+    return Effect.gen(function* () {
+      const attempts: ProcessTreeSignalResult[] = [];
+      const gracefulDeadline = Date.now() + FORCE_KILL_AFTER_MS;
+      attempts.push(yield* signalProcessTree(child, "SIGTERM", targetExited));
       yield* awaitChildClose(child, closed).pipe(
-        Effect.timeout(FORCE_KILL_AFTER_MS),
+        Effect.timeout(Math.max(0, gracefulDeadline - Date.now())),
         Effect.ignore,
       );
-      if (closed()) return;
-      yield* Effect.sync(() => killTree(child, "SIGKILL"));
-      yield* awaitChildClose(child, closed).pipe(
-        Effect.timeout(500),
-        Effect.ignore,
+      if (!closed()) {
+        const forceDeadline = Date.now() + FORCE_CLOSE_WAIT_MS;
+        attempts.push(yield* signalProcessTree(child, "SIGKILL", targetExited));
+        yield* awaitChildClose(child, closed).pipe(
+          Effect.timeout(Math.max(0, forceDeadline - Date.now())),
+          Effect.ignore,
+        );
+      }
+      const signalSent = attempts.some(
+        (attempt) =>
+          attempt.outcome === "sent" || attempt.outcome === "fallback_sent",
       );
+      const treeConfirmed = attempts.some(
+        (attempt) => attempt.outcome === "sent",
+      );
+      const detail = attempts
+        .flatMap((attempt) => ("detail" in attempt ? [attempt.detail] : []))
+        .join("; ");
+      return {
+        signalSent: liveAtStart && signalSent,
+        treeConfirmed,
+        terminationFailed:
+          liveAtStart && !treeConfirmed && (signalSent || !targetExited()),
+        detail: detail || undefined,
+      };
     });
   });
 }
 
 // --- Implementation --------------------------------------------------------------
 
-const makeManager = Effect.gen(function* () {
+function* makeManager(maxSpillBytesPerSession: number) {
   // Scoped detached forker for sync contexts (read-model kills, process-event
   // settlement, pruning). Completed fibers remove themselves; manager scope
   // close interrupts any work that outlives the bounded disposeAll wait.
@@ -297,7 +465,10 @@ const makeManager = Effect.gen(function* () {
    * races the tool boundary after an id was validated. */
   const settledHistory = new Map<
     string,
-    Pick<KillResult, "title" | "status" | "exit">
+    Pick<
+      KillResult,
+      "title" | "status" | "exit" | "terminationFailed" | "errorText"
+    >
   >();
   /** ids with an in-flight kill() collecting the result (settle → consumed). */
   const killInterest = new Map<string, number>();
@@ -312,6 +483,7 @@ const makeManager = Effect.gen(function* () {
   let reserved = 0;
   let disposed = false;
   let spillDir: string | undefined | null;
+  let sessionSpillBytes = 0;
   let onSettled:
     | ((snap: TerminalSnapshot, consumed: boolean) => void)
     | undefined;
@@ -372,6 +544,27 @@ const makeManager = Effect.gen(function* () {
   const closeEntryScope = (entry: Entry) =>
     Scope.close(entry.scope, Exit.void).pipe(Effect.ignore);
 
+  const removeEntrySpills = (entry: Entry) =>
+    Effect.sync(() => {
+      for (const spill of entry.spillFiles) {
+        try {
+          fs.rmSync(spill.path, { force: true });
+        } catch {
+          // Retain the reservation when deletion fails. The session budget
+          // remains fail-closed and disposeAll still removes the private dir.
+        }
+        if (!fs.existsSync(spill.path)) {
+          sessionSpillBytes = Math.max(
+            0,
+            sessionSpillBytes - spill.reservedBytes,
+          );
+          spill.reservedBytes = 0;
+        }
+      }
+      entry.stdoutBuf.spillPath = undefined;
+      entry.stderrBuf.spillPath = undefined;
+    });
+
   const pruneSettled = () => {
     if (entries.size <= MAX_TRACKED) return;
     const candidates = [...entries.values()]
@@ -387,15 +580,18 @@ const makeManager = Effect.gen(function* () {
     for (const entry of candidates) {
       if (entries.size <= MAX_TRACKED) break;
       entries.delete(entry.snapshot.id);
-      runCleanup(closeEntryScope(entry));
+      runCleanup(
+        closeEntryScope(entry).pipe(Effect.andThen(removeEntrySpills(entry))),
+      );
     }
   };
 
   /** End all spill streams; resolves when their buffers are flushed to disk
    * (bounded), so a settle notification never points at a partial file. */
   const flushSpillStreams = (entry: Entry) => {
-    const streams = entry.spillStreams;
-    entry.spillStreams = [];
+    const streams = entry.spillFiles
+      .map((spill) => spill.file)
+      .filter((stream) => !stream.writableEnded);
     return Effect.forEach(
       streams,
       (stream) =>
@@ -416,8 +612,10 @@ const makeManager = Effect.gen(function* () {
           Effect.sync(() => {
             entry.stdoutBuf.spillPath = undefined;
             entry.stderrBuf.spillPath = undefined;
-            entry.snapshot.errorText ??=
-              "Full-log spill flush timed out; full output may be incomplete";
+            appendSnapshotError(
+              entry.snapshot,
+              "Full-log spill flush timed out; full output may be incomplete",
+            );
           }),
       }),
     );
@@ -432,7 +630,9 @@ const makeManager = Effect.gen(function* () {
     s.status = entry.timedOut
       ? "timed_out"
       : entry.killSignaled
-        ? "killed"
+        ? entry.terminationConfirmed
+          ? "killed"
+          : "failed"
         : entry.processErrored
           ? "failed"
           : s.exitCode === 0
@@ -444,6 +644,10 @@ const makeManager = Effect.gen(function* () {
       title: s.title,
       status: s.status,
       exit: formatExit(s),
+      terminationFailed:
+        entry.terminationFailed ||
+        (entry.killSignaled && !entry.terminationConfirmed),
+      errorText: s.errorText,
     });
     while (settledHistory.size > MAX_SETTLED_HISTORY) {
       const oldest = settledHistory.keys().next().value;
@@ -525,9 +729,21 @@ const makeManager = Effect.gen(function* () {
         flags: "a",
         mode: 0o600,
       });
+      const spillFile: SpillFile = {
+        path: spillPath,
+        file,
+        reservedBytes: 0,
+      };
       let broken = false;
       let capped = false;
-      let writtenBytes = 0;
+      const markUnavailable = (message: string) => {
+        capped = true;
+        const current = entry();
+        if (!current) return;
+        const buf = stream === "stdout" ? current.stdoutBuf : current.stderrBuf;
+        buf.spillPath = undefined;
+        appendSnapshotError(current.snapshot, message);
+      };
       file.on("error", (error) => {
         broken = true;
         resumeSource();
@@ -536,7 +752,8 @@ const makeManager = Effect.gen(function* () {
           const buf =
             stream === "stdout" ? current.stdoutBuf : current.stderrBuf;
           buf.spillPath = undefined;
-          current.snapshot.errorText ??= bounded(
+          appendSnapshotError(
+            current.snapshot,
             `Full-log spill to ${spillPath} failed: ${boundedError(error)}`,
           );
         }
@@ -544,25 +761,29 @@ const makeManager = Effect.gen(function* () {
       return {
         spillPath,
         file,
+        spillFile,
         write: (chunk: string) => {
           // writableEnded guard: late 'data' after the settle flush must not
           // error the ended stream (and falsely report the spill as broken).
           if (broken || capped || file.writableEnded) return true;
           const chunkBytes = Buffer.byteLength(chunk, "utf8");
-          if (writtenBytes + chunkBytes > MAX_SPILL_BYTES_PER_STREAM) {
-            capped = true;
-            const current = entry();
-            if (current) {
-              const buf =
-                stream === "stdout" ? current.stdoutBuf : current.stderrBuf;
-              buf.spillPath = undefined;
-              current.snapshot.errorText ??= bounded(
-                `${stream} full-log spill reached the ${MAX_SPILL_BYTES_PER_STREAM}-byte safety limit`,
-              );
-            }
+          if (
+            spillFile.reservedBytes + chunkBytes >
+            MAX_SPILL_BYTES_PER_STREAM
+          ) {
+            markUnavailable(
+              `Complete ${stream} log is unavailable: the per-stream spill limit of ${MAX_SPILL_BYTES_PER_STREAM} bytes would be exceeded`,
+            );
             return true;
           }
-          writtenBytes += chunkBytes;
+          if (sessionSpillBytes + chunkBytes > maxSpillBytesPerSession) {
+            markUnavailable(
+              `Complete ${stream} log is unavailable: the session spill budget of ${maxSpillBytesPerSession} bytes would be exceeded`,
+            );
+            return true;
+          }
+          spillFile.reservedBytes += chunkBytes;
+          sessionSpillBytes += chunkBytes;
           const accepted = file.write(chunk);
           if (!accepted) file.once("drain", resumeSource);
           return accepted;
@@ -657,8 +878,8 @@ const makeManager = Effect.gen(function* () {
           scope,
           stdoutBuf,
           stderrBuf,
-          spillStreams: [stdoutSpill?.file, stderrSpill?.file].filter(
-            (file): file is fs.WriteStream => file !== undefined,
+          spillFiles: [stdoutSpill?.spillFile, stderrSpill?.spillFile].filter(
+            (file): file is SpillFile => file !== undefined,
           ),
           killSignaled: false,
           timedOut: false,
@@ -666,6 +887,9 @@ const makeManager = Effect.gen(function* () {
           exited: false,
           stdioClosed: false,
           settling: false,
+          terminationInFlight: false,
+          terminationConfirmed: false,
+          terminationFailed: false,
           exitCleanupStarted: false,
           settled,
         };
@@ -732,7 +956,7 @@ const makeManager = Effect.gen(function* () {
             snapshot.exitCode ??= code ?? undefined;
             snapshot.signal ??= signal ?? undefined;
           }
-          settleAfterFlush(entry);
+          if (!entry.terminationInFlight) settleAfterFlush(entry);
         });
 
         // One teardown path: kill(), requestKill, pruning, disposeAll, and
@@ -740,19 +964,40 @@ const makeManager = Effect.gen(function* () {
         yield* Scope.provide(
           Effect.addFinalizer(() =>
             Effect.gen(function* () {
-              // Only claim "killed" when we are actually about to signal a
-              // live process; a natural exit that already happened (still
-              // waiting on 'close') keeps its truthful done/failed status.
-              yield* terminateChild(
+              // Defer a concurrent close settlement until the awaited helper
+              // result tells us whether the process-tree promise was met.
+              entry.terminationInFlight = true;
+              const termination = yield* terminateChild(
                 child,
                 () => entry.stdioClosed,
-                () => {
-                  entry.killSignaled ||=
-                    !entry.timedOut &&
-                    !entry.exited &&
-                    entry.snapshot.status === "running";
-                },
+                () => entry.exited,
               );
+              entry.killSignaled ||=
+                !entry.timedOut &&
+                termination.signalSent &&
+                entry.snapshot.status === "running";
+              entry.terminationConfirmed ||=
+                termination.signalSent && termination.treeConfirmed;
+              entry.terminationFailed ||=
+                !entry.timedOut && termination.terminationFailed;
+              if (
+                !termination.treeConfirmed &&
+                termination.detail &&
+                (termination.signalSent || !entry.exited)
+              ) {
+                appendSnapshotError(
+                  entry.snapshot,
+                  `Process-tree termination could not be confirmed: ${termination.detail}`,
+                );
+              }
+              entry.terminationInFlight = false;
+              if (
+                entry.stdioClosed &&
+                entry.snapshot.status === "running" &&
+                !entry.settling
+              ) {
+                settleAfterFlush(entry);
+              }
               // Give the natural close→flush→settle path a bounded grace,
               // then force the settle: a grandchild holding the pipe open
               // (detached into a new group) must not leave the entry
@@ -769,8 +1014,10 @@ const makeManager = Effect.gen(function* () {
                 // SPILL_FLUSH_TIMEOUT_MS) — settling here first would cite a
                 // spill file that is still being flushed.
                 if (!entry.stdioClosed) {
-                  entry.snapshot.errorText ??=
-                    "stdio did not close after termination; output may be incomplete";
+                  appendSnapshotError(
+                    entry.snapshot,
+                    "stdio did not close after termination; process state and output may be incomplete",
+                  );
                 }
                 entry.settling = true;
                 yield* flushSpillStreams(entry);
@@ -870,10 +1117,15 @@ const makeManager = Effect.gen(function* () {
         // Capture the report BEFORE the ensuring below releases interest and
         // prunes — a just-settled entry must not vanish out from under it.
         return unique.map((id): KillResult => {
-          const snapshot = byId.get(id)?.snapshot;
+          const sourceEntry = byId.get(id);
+          const snapshot = sourceEntry?.snapshot;
           const history = settledHistory.get(id);
           const status = snapshot?.status ?? history?.status ?? "killed";
           const wasRunning = runningIds.includes(id);
+          const terminationFailed = sourceEntry
+            ? sourceEntry.terminationFailed ||
+              (sourceEntry.killSignaled && !sourceEntry.terminationConfirmed)
+            : history?.terminationFailed;
           return {
             id,
             title: snapshot?.title ?? history?.title ?? "?",
@@ -882,6 +1134,8 @@ const makeManager = Effect.gen(function* () {
             // A natural exit can win the race with our SIGTERM; report what
             // actually happened rather than claiming the kill did it.
             killed: wasRunning && status === "killed",
+            terminationFailed,
+            errorText: snapshot?.errorText ?? history?.errorText,
             exit: snapshot
               ? formatExit(snapshot)
               : (history?.exit ?? "unknown"),
@@ -921,6 +1175,7 @@ const makeManager = Effect.gen(function* () {
     yield* Effect.sync(() => {
       const dir = spillDir;
       spillDir = null;
+      sessionSpillBytes = 0;
       if (dir) fs.rmSync(dir, { recursive: true, force: true });
     });
     yield* Effect.sync(() => notify());
@@ -982,9 +1237,18 @@ const makeManager = Effect.gen(function* () {
     disposeAll,
     view,
   });
-});
+}
+
+export function makeTerminalManagerLive(
+  maxSpillBytesPerSession = MAX_SPILL_BYTES_PER_SESSION,
+) {
+  return Layer.effect(
+    TerminalManager,
+    Effect.gen(() => makeManager(maxSpillBytesPerSession)),
+  );
+}
 
 export const TerminalManagerLive: Layer.Layer<TerminalManager> = Layer.effect(
   TerminalManager,
-  makeManager,
+  Effect.gen(() => makeManager(MAX_SPILL_BYTES_PER_SESSION)),
 );

--- a/extensions/background-terminals/src/manager.ts
+++ b/extensions/background-terminals/src/manager.ts
@@ -359,6 +359,16 @@ export async function signalWindowsProcessTree(
       : attempt.outcome === "timed_out"
         ? `taskkill timed out after ${attempt.timeoutMs}ms`
         : `taskkill exited ${attempt.exitCode ?? "without a code"}${attempt.signal ? ` (${attempt.signal})` : ""}`;
+  // A failed graceful taskkill must leave the shell PID alive for the
+  // serialized `/T /F` phase. Killing only the shell here would orphan its
+  // descendants and make the original process-tree handle unusable.
+  if (
+    signal === "SIGTERM" &&
+    attempt.outcome !== "launch_failed" &&
+    !targetExited()
+  ) {
+    return { outcome: "failed", detail };
+  }
   return directSignal(child, signal, targetExited, detail);
 }
 

--- a/extensions/background-terminals/src/manager.ts
+++ b/extensions/background-terminals/src/manager.ts
@@ -568,26 +568,28 @@ function* makeManager(maxSpillBytesPerSession: number) {
   const closeEntryScope = (entry: Entry) =>
     Scope.close(entry.scope, Exit.void).pipe(Effect.ignore);
 
-  const removeEntrySpills = (entry: Entry) =>
-    Effect.sync(() => {
-      for (const spill of entry.spillFiles) {
-        try {
-          fs.rmSync(spill.path, { force: true });
-        } catch {
-          // Retain the reservation when deletion fails. The session budget
-          // remains fail-closed and disposeAll still removes the private dir.
-        }
-        if (!fs.existsSync(spill.path)) {
-          sessionSpillBytes = Math.max(
-            0,
-            sessionSpillBytes - spill.reservedBytes,
-          );
-          spill.reservedBytes = 0;
-        }
+  const removeEntrySpillsNow = (entry: Entry) => {
+    for (const spill of entry.spillFiles) {
+      try {
+        fs.rmSync(spill.path, { force: true });
+      } catch {
+        // Retain the reservation when deletion fails. The session budget
+        // remains fail-closed and disposeAll still removes the private dir.
       }
-      entry.stdoutBuf.spillPath = undefined;
-      entry.stderrBuf.spillPath = undefined;
-    });
+      if (!fs.existsSync(spill.path)) {
+        sessionSpillBytes = Math.max(
+          0,
+          sessionSpillBytes - spill.reservedBytes,
+        );
+        spill.reservedBytes = 0;
+      }
+    }
+    entry.stdoutBuf.spillPath = undefined;
+    entry.stderrBuf.spillPath = undefined;
+  };
+
+  const removeEntrySpills = (entry: Entry) =>
+    Effect.sync(() => removeEntrySpillsNow(entry));
 
   const pruneSettled = () => {
     if (entries.size <= MAX_TRACKED) return;
@@ -604,8 +606,36 @@ function* makeManager(maxSpillBytesPerSession: number) {
     for (const entry of candidates) {
       if (entries.size <= MAX_TRACKED) break;
       entries.delete(entry.snapshot.id);
+      removeEntrySpillsNow(entry);
       runCleanup(
         closeEntryScope(entry).pipe(Effect.andThen(removeEntrySpills(entry))),
+      );
+    }
+  };
+
+  /** Reclaim settled entries before a new child can emit its first chunk. */
+  const prepareForStart = () => {
+    while (entries.size >= MAX_TRACKED) {
+      const candidate = [...entries.values()]
+        .filter(
+          (e) =>
+            e.snapshot.status !== "running" && !killInterest.has(e.snapshot.id),
+        )
+        .sort(
+          (a, b) =>
+            (a.snapshot.settledAt ?? a.snapshot.createdAt) -
+            (b.snapshot.settledAt ?? b.snapshot.createdAt),
+        )[0];
+      if (!candidate) break;
+
+      // Release the spill reservation synchronously. The scope close is still
+      // detached, but no new terminal can observe the old budget as occupied.
+      entries.delete(candidate.snapshot.id);
+      removeEntrySpillsNow(candidate);
+      runCleanup(
+        closeEntryScope(candidate).pipe(
+          Effect.andThen(removeEntrySpills(candidate)),
+        ),
       );
     }
   };
@@ -840,6 +870,7 @@ function* makeManager(maxSpillBytesPerSession: number) {
       );
 
       const doStart = Effect.gen(function* () {
+        yield* Effect.sync(prepareForStart);
         const { shell, args, windowsVerbatimArguments } = shellInvocation(
           options.command,
         );

--- a/extensions/background-terminals/src/manager.ts
+++ b/extensions/background-terminals/src/manager.ts
@@ -48,6 +48,8 @@ const STOP_TIMEOUT_MS = 5_000;
 /** SIGTERM is normally enough; the second deadline covers a wedged process. */
 const FORCE_KILL_AFTER_MS = 2_000;
 const FORCE_CLOSE_WAIT_MS = 500;
+/** Reserve this inside each existing termination phase for helper closure. */
+const TASKKILL_HELPER_CLOSE_WAIT_MS = 100;
 /** After termination, how long to wait for the natural close→flush→settle
  * path before force-settling (a grandchild can hold the stdio pipes open). */
 const SETTLE_GRACE_MS = 1_000;
@@ -252,7 +254,12 @@ export type WindowsTaskkillResult =
       readonly signal: NodeJS.Signals | null;
     }
   | { readonly outcome: "launch_failed"; readonly error: string }
-  | { readonly outcome: "timed_out"; readonly timeoutMs: number };
+  | {
+      readonly outcome: "timed_out";
+      readonly timeoutMs: number;
+      readonly helperClosed: boolean;
+      readonly helperCloseTimeoutMs: number;
+    };
 
 function spawnTaskkill(pid: number, force: boolean) {
   return spawn(
@@ -267,7 +274,9 @@ export function waitForWindowsTaskkill(
   pid: number,
   force: boolean,
   launch: TaskkillSpawner = spawnTaskkill,
-  timeoutMs = force ? FORCE_CLOSE_WAIT_MS : FORCE_KILL_AFTER_MS,
+  timeoutMs = (force ? FORCE_CLOSE_WAIT_MS : FORCE_KILL_AFTER_MS) -
+    TASKKILL_HELPER_CLOSE_WAIT_MS,
+  helperCloseTimeoutMs = TASKKILL_HELPER_CLOSE_WAIT_MS,
 ) {
   return new Promise<WindowsTaskkillResult>((resolve) => {
     let killer: ChildProcess;
@@ -280,10 +289,13 @@ export function waitForWindowsTaskkill(
 
     let finished = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    let helperCloseTimer: ReturnType<typeof setTimeout> | undefined;
+    let timedOut = false;
     const finish = (result: WindowsTaskkillResult) => {
       if (finished) return;
       finished = true;
       if (timer) clearTimeout(timer);
+      if (helperCloseTimer) clearTimeout(helperCloseTimer);
       killer.off("error", onError);
       killer.off("close", onClose);
       resolve(result);
@@ -291,16 +303,35 @@ export function waitForWindowsTaskkill(
     const onError = (error: Error) =>
       finish({ outcome: "launch_failed", error: boundedError(error) });
     const onClose = (exitCode: number | null, signal: NodeJS.Signals | null) =>
-      finish({ outcome: "completed", exitCode, signal });
+      finish(
+        timedOut
+          ? {
+              outcome: "timed_out",
+              timeoutMs,
+              helperClosed: true,
+              helperCloseTimeoutMs,
+            }
+          : { outcome: "completed", exitCode, signal },
+      );
     killer.once("error", onError);
     killer.once("close", onClose);
     timer = setTimeout(() => {
+      timedOut = true;
       try {
         killer.kill("SIGKILL");
       } catch {
         // The helper may already be gone; the bounded result stays the same.
       }
-      finish({ outcome: "timed_out", timeoutMs });
+      helperCloseTimer = setTimeout(
+        () =>
+          finish({
+            outcome: "timed_out",
+            timeoutMs,
+            helperClosed: false,
+            helperCloseTimeoutMs,
+          }),
+        helperCloseTimeoutMs,
+      );
     }, timeoutMs);
   });
 }
@@ -362,7 +393,7 @@ export async function signalWindowsProcessTree(
     attempt.outcome === "launch_failed"
       ? `taskkill failed to launch: ${attempt.error}`
       : attempt.outcome === "timed_out"
-        ? `taskkill timed out after ${attempt.timeoutMs}ms`
+        ? `taskkill timed out after ${attempt.timeoutMs}ms; helper ${attempt.helperClosed ? "closed after SIGKILL" : `did not close within an additional ${attempt.helperCloseTimeoutMs}ms`}`
         : `taskkill exited ${attempt.exitCode ?? "without a code"}${attempt.signal ? ` (${attempt.signal})` : ""}`;
   // A failed graceful taskkill must leave the shell PID alive for the
   // serialized `/T /F` phase. Killing only the shell here would orphan its

--- a/extensions/background-terminals/src/manager.ts
+++ b/extensions/background-terminals/src/manager.ts
@@ -209,12 +209,26 @@ export class TerminalManager extends Context.Service<
 
 // --- Process helpers ------------------------------------------------------------
 
-function shellInvocation(command: string) {
-  if (process.platform === "win32") {
-    const shell = process.env.ComSpec ?? "cmd.exe";
-    return { shell, args: ["/d", "/s", "/c", command] };
+export function shellInvocation(
+  command: string,
+  platform: NodeJS.Platform = process.platform,
+  windowsShell = process.env.ComSpec ?? "cmd.exe",
+) {
+  if (platform === "win32") {
+    // Match Node's `{ shell: true }` cmd.exe invocation. Without the outer
+    // quotes and verbatim arguments, libuv escapes embedded quotes using CRT
+    // rules, which cmd.exe does not understand.
+    return {
+      shell: windowsShell,
+      args: ["/d", "/s", "/c", `"${command}"`],
+      windowsVerbatimArguments: true,
+    };
   }
-  return { shell: "/bin/sh", args: ["-c", command] };
+  return {
+    shell: "/bin/sh",
+    args: ["-c", command],
+    windowsVerbatimArguments: false,
+  };
 }
 
 type ProcessSignalTarget = Pick<ChildProcess, "pid" | "kill">;
@@ -816,7 +830,9 @@ function* makeManager(maxSpillBytesPerSession: number) {
       );
 
       const doStart = Effect.gen(function* () {
-        const { shell, args } = shellInvocation(options.command);
+        const { shell, args, windowsVerbatimArguments } = shellInvocation(
+          options.command,
+        );
         const child = yield* Effect.try({
           try: () =>
             spawn(shell, args, {
@@ -827,6 +843,7 @@ function* makeManager(maxSpillBytesPerSession: number) {
               stdio: ["ignore", "pipe", "pipe"],
               // Own process group on POSIX → group kill takes the whole tree.
               detached: process.platform !== "win32",
+              windowsVerbatimArguments,
             }),
           catch: (error) => new SpawnError({ message: boundedError(error) }),
         });

--- a/extensions/background-terminals/src/manager.ts
+++ b/extensions/background-terminals/src/manager.ts
@@ -179,6 +179,11 @@ export interface TerminalReadModel {
   /** Fire-and-forget kill (dashboard/detail `x`). Not marked consumed: the
    * settle still flows back to the model as a follow-up message. */
   requestKill(id: string): void;
+  /** Keep a settled entry alive while its completion snapshot is pending
+   * delivery outside the manager. */
+  retainResult(id: string): void;
+  /** Release a previously retained completion snapshot and retry pruning. */
+  releaseResult(id: string): void;
   /**
    * Register the settle hook. `consumed` is true when an active bg_kill is
    * collecting the result (so it must not also be delivered as a follow-up).
@@ -496,6 +501,8 @@ function* makeManager(maxSpillBytesPerSession: number) {
   >();
   /** ids with an in-flight kill() collecting the result (settle → consumed). */
   const killInterest = new Map<string, number>();
+  /** Settled entries whose copied completion snapshot is still pending delivery. */
+  const resultInterest = new Set<string>();
   const listeners = new Set<() => void>();
   const idListeners = new Map<string, Set<() => void>>();
   /** bg_watch chunk listeners, keyed by terminal id. */
@@ -596,7 +603,9 @@ function* makeManager(maxSpillBytesPerSession: number) {
     const candidates = [...entries.values()]
       .filter(
         (e) =>
-          e.snapshot.status !== "running" && !killInterest.has(e.snapshot.id),
+          e.snapshot.status !== "running" &&
+          !killInterest.has(e.snapshot.id) &&
+          !resultInterest.has(e.snapshot.id),
       )
       .sort(
         (a, b) =>
@@ -619,7 +628,9 @@ function* makeManager(maxSpillBytesPerSession: number) {
       const candidate = [...entries.values()]
         .filter(
           (e) =>
-            e.snapshot.status !== "running" && !killInterest.has(e.snapshot.id),
+            e.snapshot.status !== "running" &&
+            !killInterest.has(e.snapshot.id) &&
+            !resultInterest.has(e.snapshot.id),
         )
         .sort(
           (a, b) =>
@@ -1214,6 +1225,7 @@ function* makeManager(maxSpillBytesPerSession: number) {
     disposed = true;
     const all = [...entries.values()];
     entries.clear();
+    resultInterest.clear();
     yield* Effect.forEach(
       all,
       (entry) =>
@@ -1277,6 +1289,13 @@ function* makeManager(maxSpillBytesPerSession: number) {
       // UI-initiated kills are not "consumed": the killed result still flows
       // back to the model as a follow-up message (subagents precedent).
       runCleanup(killEntry(entry).pipe(Effect.ignore));
+    },
+    retainResult: (id) => {
+      if (entries.has(id)) resultInterest.add(id);
+    },
+    releaseResult: (id) => {
+      if (!resultInterest.delete(id)) return;
+      pruneSettled();
     },
     setOnSettled: (hook) => {
       onSettled = hook;

--- a/extensions/background-terminals/src/manager.ts
+++ b/extensions/background-terminals/src/manager.ts
@@ -245,6 +245,7 @@ export type ProcessTreeSignalResult =
   | { readonly outcome: "sent" }
   | { readonly outcome: "already_exited"; readonly detail: string }
   | { readonly outcome: "fallback_sent"; readonly detail: string }
+  | { readonly outcome: "unresolved"; readonly detail: string }
   | { readonly outcome: "failed"; readonly detail: string };
 
 export type WindowsTaskkillResult =
@@ -269,7 +270,7 @@ function spawnTaskkill(pid: number, force: boolean) {
   );
 }
 
-/** Resolve only after taskkill has either failed to launch or closed. */
+/** Resolve after taskkill closes or its still-live helper is explicitly detached. */
 export function waitForWindowsTaskkill(
   pid: number,
   force: boolean,
@@ -322,16 +323,15 @@ export function waitForWindowsTaskkill(
       } catch {
         // The helper may already be gone; the bounded result stays the same.
       }
-      helperCloseTimer = setTimeout(
-        () =>
-          finish({
-            outcome: "timed_out",
-            timeoutMs,
-            helperClosed: false,
-            helperCloseTimeoutMs,
-          }),
-        helperCloseTimeoutMs,
-      );
+      helperCloseTimer = setTimeout(() => {
+        killer.unref();
+        finish({
+          outcome: "timed_out",
+          timeoutMs,
+          helperClosed: false,
+          helperCloseTimeoutMs,
+        });
+      }, helperCloseTimeoutMs);
     }, timeoutMs);
   });
 }
@@ -395,6 +395,13 @@ export async function signalWindowsProcessTree(
       : attempt.outcome === "timed_out"
         ? `taskkill timed out after ${attempt.timeoutMs}ms; helper ${attempt.helperClosed ? "closed after SIGKILL" : `did not close within an additional ${attempt.helperCloseTimeoutMs}ms`}`
         : `taskkill exited ${attempt.exitCode ?? "without a code"}${attempt.signal ? ` (${attempt.signal})` : ""}`;
+  if (
+    attempt.outcome === "timed_out" &&
+    !attempt.helperClosed &&
+    !targetExited()
+  ) {
+    return { outcome: "unresolved", detail };
+  }
   // A failed graceful taskkill must leave the shell PID alive for the
   // serialized `/T /F` phase. Killing only the shell here would orphan its
   // descendants and make the original process-tree handle unusable.
@@ -477,12 +484,13 @@ function terminateChild(
     return Effect.gen(function* () {
       const attempts: ProcessTreeSignalResult[] = [];
       const gracefulDeadline = Date.now() + FORCE_KILL_AFTER_MS;
-      attempts.push(yield* signalProcessTree(child, "SIGTERM", targetExited));
+      const graceful = yield* signalProcessTree(child, "SIGTERM", targetExited);
+      attempts.push(graceful);
       yield* awaitChildClose(child, closed).pipe(
         Effect.timeout(Math.max(0, gracefulDeadline - Date.now())),
         Effect.ignore,
       );
-      if (!closed()) {
+      if (!closed() && graceful.outcome !== "unresolved") {
         const forceDeadline = Date.now() + FORCE_CLOSE_WAIT_MS;
         attempts.push(yield* signalProcessTree(child, "SIGKILL", targetExited));
         yield* awaitChildClose(child, closed).pipe(

--- a/extensions/background-terminals/src/output.ts
+++ b/extensions/background-terminals/src/output.ts
@@ -13,13 +13,17 @@
  */
 
 import type { OutputView } from "./domain.ts";
+import { TerminalTextSanitizer } from "../../shared/terminal-text.ts";
 
 export class OutputBuffer {
   private chunks: string[] = [];
+  private modelSafeChunks: string[] = [];
   /** Bytes currently retained across `chunks`. */
   private retainedBytes = 0;
+  private modelSafeRetainedBytes = 0;
   /** Cached join of `chunks`; invalidated on push so 1Hz UI ticks are cheap. */
   private cachedText: string | undefined = "";
+  private cachedModelSafeText: string | undefined = "";
   /** Bumped on every push; lets the UI cache derived line layouts. */
   version = 0;
   totalBytes = 0;
@@ -28,6 +32,7 @@ export class OutputBuffer {
 
   private readonly maxRetainedBytes: number;
   private readonly spill?: (chunk: string) => unknown;
+  private readonly modelSanitizer = new TerminalTextSanitizer();
 
   constructor(maxRetainedBytes: number, spill?: (chunk: string) => unknown) {
     this.maxRetainedBytes = maxRetainedBytes;
@@ -36,6 +41,7 @@ export class OutputBuffer {
 
   push(chunk: string) {
     if (chunk.length === 0) return true;
+    this.retainModelSafeText(this.modelSanitizer.push(chunk));
     let bytes = Buffer.byteLength(chunk, "utf8");
     this.totalBytes += bytes;
     const spillAccepted = this.spill?.(chunk) !== false;
@@ -74,11 +80,38 @@ export class OutputBuffer {
 
   view(): OutputView {
     this.cachedText ??= this.chunks.join("");
+    this.cachedModelSafeText ??= this.modelSafeChunks.join("");
     return {
       text: this.cachedText,
+      modelSafeText: this.cachedModelSafeText,
       totalBytes: this.totalBytes,
       truncatedBytes: this.truncatedBytes,
       spillPath: this.spillPath,
     };
+  }
+
+  private retainModelSafeText(text: string) {
+    if (text.length === 0) return;
+    let bytes = Buffer.byteLength(text, "utf8");
+    if (bytes > this.maxRetainedBytes) {
+      this.modelSafeChunks = [];
+      this.modelSafeRetainedBytes = 0;
+      const raw = Buffer.from(text, "utf8");
+      let start = raw.length - this.maxRetainedBytes;
+      while (start < raw.length && (raw[start] & 0xc0) === 0x80) start++;
+      text = raw.subarray(start).toString("utf8");
+      bytes = raw.length - start;
+    }
+    this.modelSafeChunks.push(text);
+    this.modelSafeRetainedBytes += bytes;
+    while (
+      this.modelSafeRetainedBytes > this.maxRetainedBytes &&
+      this.modelSafeChunks.length > 1
+    ) {
+      const evicted = this.modelSafeChunks.shift();
+      if (evicted === undefined) break;
+      this.modelSafeRetainedBytes -= Buffer.byteLength(evicted, "utf8");
+    }
+    this.cachedModelSafeText = undefined;
   }
 }

--- a/extensions/background-terminals/src/prompt.ts
+++ b/extensions/background-terminals/src/prompt.ts
@@ -6,6 +6,7 @@ import {
   formatSize,
   truncateTail,
 } from "@earendil-works/pi-coding-agent";
+import { sanitizeTerminalText } from "../../shared/terminal-text.ts";
 import {
   formatDuration,
   formatElapsed,
@@ -139,7 +140,8 @@ function outputSection(
   maxLines: number,
 ) {
   if (view.totalBytes === 0) return `${label}: (empty)`;
-  const truncation = truncateTail(view.text, {
+  const sanitized = sanitizeTerminalText(view.text);
+  const truncation = truncateTail(sanitized, {
     maxBytes: Math.min(maxBytes, DEFAULT_MAX_BYTES),
     maxLines: Math.min(maxLines, DEFAULT_MAX_LINES),
   });
@@ -186,12 +188,15 @@ export function buildTerminalBatchResultMessage(
   messages: readonly string[],
   omitted = 0,
 ) {
-  if (messages.length === 1 && omitted === 0) return messages[0]!;
-  const summaries = messages.map(
+  const sanitizedMessages = messages.map(sanitizeTerminalText);
+  if (sanitizedMessages.length === 1 && omitted === 0) {
+    return sanitizedMessages[0]!;
+  }
+  const summaries = sanitizedMessages.map(
     (message) => message.split("\n", 1)[0] || "Background terminal result",
   );
   const header = [
-    `${messages.length} background terminal result${messages.length === 1 ? "" : "s"}:`,
+    `${sanitizedMessages.length} background terminal result${sanitizedMessages.length === 1 ? "" : "s"}:`,
     ...summaries.map((summary) => `- ${summary}`),
     omitted > 0
       ? `- ${omitted} older result${omitted === 1 ? "" : "s"} omitted from this bounded batch; use bg_list/bg_status for retained details.`
@@ -206,7 +211,7 @@ export function buildTerminalBatchResultMessage(
     `${header}${logsHeader}${truncationMarker}`,
     "utf8",
   );
-  const logs = truncateTail(messages.join("\n\n"), {
+  const logs = truncateTail(sanitizedMessages.join("\n\n"), {
     maxBytes: Math.max(1, RESULT_BATCH_MAX - fixedBytes),
     maxLines: DEFAULT_MAX_LINES,
   });
@@ -219,6 +224,10 @@ export function buildKillReport(results: ReadonlyArray<KillResult>) {
     .map((entry) => {
       if (entry.killed) {
         return `Killed ${entry.id} "${entry.title}" (${entry.exit}).`;
+      }
+      if (entry.terminationFailed) {
+        const detail = entry.errorText ? ` ${entry.errorText}.` : "";
+        return `Could not confirm process-tree termination for ${entry.id} "${entry.title}" (${entry.exit}).${detail}`;
       }
       if (entry.wasRunning) {
         // The natural exit won the race with the kill signal.

--- a/extensions/background-terminals/src/prompt.ts
+++ b/extensions/background-terminals/src/prompt.ts
@@ -140,8 +140,7 @@ function outputSection(
   maxLines: number,
 ) {
   if (view.totalBytes === 0) return `${label}: (empty)`;
-  const sanitized = sanitizeTerminalText(view.text);
-  const truncation = truncateTail(sanitized, {
+  const truncation = truncateTail(view.modelSafeText, {
     maxBytes: Math.min(maxBytes, DEFAULT_MAX_BYTES),
     maxLines: Math.min(maxLines, DEFAULT_MAX_LINES),
   });

--- a/extensions/shared/terminal-text.ts
+++ b/extensions/shared/terminal-text.ts
@@ -16,9 +16,118 @@ const ESCAPE_PATTERN = /\u001b(?:[()][0-2A-Z]|[ -/]*[@-~])/g;
 // Keep only ZWNJ/ZWJ (U+200C/U+200D), which carry legitimate shaping and emoji
 // semantics; variation selectors are marks rather than Cf and remain intact.
 const UNSAFE_FORMAT_PATTERN = /(?![\u200c\u200d])\p{Cf}/gu;
+const UNSAFE_FORMAT_CHARACTER = /\p{Cf}/u;
 // eslint-disable-next-line no-control-regex
 const TERMINAL_CONTROL_PATTERN =
   /[\u0000-\u001f\u007f-\u009f]|(?:(?![\u200c\u200d])\p{Cf})/u;
+
+type SanitizerState =
+  | "text"
+  | "escape"
+  | "escape_intermediate"
+  | "csi"
+  | "osc"
+  | "st_string";
+
+/** Stateful terminal-text projection for streams whose retained head can move. */
+export class TerminalTextSanitizer {
+  private state: SanitizerState = "text";
+  private stringEscape = false;
+
+  push(text: string) {
+    let safe = "";
+    for (const character of text) {
+      const code = character.codePointAt(0)!;
+
+      if (this.state === "osc" || this.state === "st_string") {
+        if (character === "\u009c") {
+          this.state = "text";
+          this.stringEscape = false;
+        } else if (this.state === "osc" && character === "\u0007") {
+          this.state = "text";
+          this.stringEscape = false;
+        } else if (this.stringEscape && character === "\\") {
+          this.state = "text";
+          this.stringEscape = false;
+        } else {
+          this.stringEscape = character === "\u001b";
+        }
+        continue;
+      }
+
+      if (this.state === "csi") {
+        if (code >= 0x40 && code <= 0x7e) this.state = "text";
+        else if (code < 0x20 || code > 0x3f) {
+          this.state = "text";
+          safe += this.safeCharacter(character, code);
+        }
+        continue;
+      }
+
+      if (this.state === "escape" || this.state === "escape_intermediate") {
+        if (this.state === "escape") {
+          if (character === "[") {
+            this.state = "csi";
+            continue;
+          }
+          if (character === "]") {
+            this.state = "osc";
+            continue;
+          }
+          if (
+            character === "P" ||
+            character === "X" ||
+            character === "^" ||
+            character === "_"
+          ) {
+            this.state = "st_string";
+            continue;
+          }
+        }
+        if (code >= 0x20 && code <= 0x2f) {
+          this.state = "escape_intermediate";
+        } else if (code >= 0x30 && code <= 0x7e) {
+          this.state = "text";
+        } else {
+          this.state = "text";
+          safe += this.safeCharacter(character, code);
+        }
+        continue;
+      }
+
+      if (character === "\u001b") {
+        this.state = "escape";
+      } else if (character === "\u009b") {
+        this.state = "csi";
+      } else if (character === "\u009d") {
+        this.state = "osc";
+      } else if (
+        character === "\u0090" ||
+        character === "\u0098" ||
+        character === "\u009e" ||
+        character === "\u009f"
+      ) {
+        this.state = "st_string";
+      } else {
+        safe += this.safeCharacter(character, code);
+      }
+    }
+    return safe;
+  }
+
+  private safeCharacter(character: string, code: number) {
+    if (character === "\t") return "  ";
+    if (
+      character === "\n" ||
+      character === "\u200c" ||
+      character === "\u200d"
+    ) {
+      return character;
+    }
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) return "";
+    return UNSAFE_FORMAT_CHARACTER.test(character) ? "" : character;
+  }
+}
 
 /** Strip terminal control sequences and direction-spoofing format controls. */
 export function sanitizeTerminalText(text: string) {

--- a/extensions/shared/terminal-text.ts
+++ b/extensions/shared/terminal-text.ts
@@ -1,21 +1,6 @@
-// OSC may end in BEL or ST. DCS/SOS/PM/APC end only in ST; treating BEL as
-// their terminator would expose the rest of a still-hidden payload. Both
-// patterns consume an unterminated string through the bounded input's end.
-// eslint-disable-next-line no-control-regex
-const OSC_PATTERN =
-  /(?:\u001b\]|\u009d)(?:[^\u0007\u001b\u009c]|\u001b(?!\\))*(?:\u0007|\u001b\\|\u009c|$)/g;
-// eslint-disable-next-line no-control-regex
-const ST_STRING_PATTERN =
-  /(?:\u001b[PX^_]|[\u0090\u0098\u009e\u009f])(?:[^\u001b\u009c]|\u001b(?!\\))*(?:\u001b\\|\u009c|$)/g;
-// eslint-disable-next-line no-control-regex
-const CSI_PATTERN = /(?:\u001b\[|\u009b)[0-?]*[ -/]*[@-~]/g;
-// Remaining two-byte/charset escape forms (for example ESC ( 0).
-// eslint-disable-next-line no-control-regex
-const ESCAPE_PATTERN = /\u001b(?:[()][0-2A-Z]|[ -/]*[@-~])/g;
 // Invisible Unicode format controls can reorder or disguise untrusted text.
 // Keep only ZWNJ/ZWJ (U+200C/U+200D), which carry legitimate shaping and emoji
 // semantics; variation selectors are marks rather than Cf and remain intact.
-const UNSAFE_FORMAT_PATTERN = /(?![\u200c\u200d])\p{Cf}/gu;
 const UNSAFE_FORMAT_CHARACTER = /\p{Cf}/u;
 // eslint-disable-next-line no-control-regex
 const TERMINAL_CONTROL_PATTERN =
@@ -131,14 +116,7 @@ export class TerminalTextSanitizer {
 
 /** Strip terminal control sequences and direction-spoofing format controls. */
 export function sanitizeTerminalText(text: string) {
-  return text
-    .replace(OSC_PATTERN, "")
-    .replace(ST_STRING_PATTERN, "")
-    .replace(CSI_PATTERN, "")
-    .replace(ESCAPE_PATTERN, "")
-    .replace(UNSAFE_FORMAT_PATTERN, "")
-    .replaceAll("\t", "  ")
-    .replace(/[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/g, "");
+  return new TerminalTextSanitizer().push(text);
 }
 
 /** Reject raw terminal or direction-spoofing controls in display patterns. */

--- a/tests/extensions/background-terminals/manager.test.ts
+++ b/tests/extensions/background-terminals/manager.test.ts
@@ -20,6 +20,7 @@ import {
   MAX_RUNNING,
   MAX_TRACKED,
   makeTerminalManagerLive,
+  shellInvocation,
   signalWindowsProcessTree,
   TerminalManager,
   type TerminalManagerShape,
@@ -48,6 +49,16 @@ function fakeTaskkill(
     return child;
   };
 }
+
+test("Windows shell invocation preserves cmd.exe command quoting", () => {
+  const command = "node -e \"process.stdout.write('ok')\"";
+
+  assert.deepEqual(shellInvocation(command, "win32", "cmd.exe"), {
+    shell: "cmd.exe",
+    args: ["/d", "/s", "/c", `"${command}"`],
+    windowsVerbatimArguments: true,
+  });
+});
 
 test("Windows taskkill is awaited and reports a confirmed tree signal", async () => {
   const launches: Array<{ pid: number; force: boolean }> = [];

--- a/tests/extensions/background-terminals/manager.test.ts
+++ b/tests/extensions/background-terminals/manager.test.ts
@@ -928,6 +928,54 @@ test("the session spill budget fails closed across terminals", async () => {
   }
 });
 
+test("a full budget is reclaimed before a replacement terminal starts", async () => {
+  const runtime = ManagedRuntime.make(makeTerminalManagerLive(4));
+  try {
+    const manager = await runtime.runPromise(TerminalManager);
+    const oldest = await runtime.runPromise(
+      manager.start({
+        command: nodeCmd('process.stdout.write("seed")'),
+        title: "seed",
+        cwd,
+      }),
+    );
+    const { snap: oldestDone } = await settlement(manager, oldest.id);
+    assert.ok(oldestDone.stdout.spillPath);
+    const oldestSpill = oldestDone.stdout.spillPath;
+
+    // Leave exactly MAX_TRACKED settled entries, with the budget still held by
+    // the oldest one. The next start must reclaim it before its first chunk.
+    for (let index = 0; index < MAX_TRACKED - 1; index++) {
+      const filler = await runtime.runPromise(
+        manager.start({
+          command: nodeCmd(""),
+          title: `budget-filler-${index}`,
+          cwd,
+        }),
+      );
+      await settlement(manager, filler.id);
+    }
+    assert.equal(manager.view.size(), MAX_TRACKED);
+
+    const replacement = await runtime.runPromise(
+      manager.start({
+        command: nodeCmd('process.stdout.write("next")'),
+        title: "replacement",
+        cwd,
+      }),
+    );
+    const { snap: replacementDone } = await settlement(manager, replacement.id);
+
+    assert.equal(replacementDone.stdout.spillPath !== undefined, true);
+    assert.equal(fs.statSync(replacementDone.stdout.spillPath!).size, 4);
+    assert.doesNotMatch(replacementDone.errorText ?? "", /spill budget/);
+    assert.equal(manager.view.get(oldest.id), undefined);
+    assert.equal(fs.existsSync(oldestSpill), false);
+  } finally {
+    await runtime.dispose();
+  }
+});
+
 test("pruning removes spill files and releases their session budget", async () => {
   const runtime = ManagedRuntime.make(makeTerminalManagerLive(4));
   try {

--- a/tests/extensions/background-terminals/manager.test.ts
+++ b/tests/extensions/background-terminals/manager.test.ts
@@ -85,7 +85,7 @@ test("Windows taskkill is awaited and reports a confirmed tree signal", async ()
   assert.deepEqual(launches, [{ pid: 42, force: true }]);
 });
 
-test("Windows taskkill non-zero exit falls back without claiming tree termination", async () => {
+test("Windows graceful taskkill failure preserves the PID for force escalation", async () => {
   const signals: Array<NodeJS.Signals | number | undefined> = [];
   const result = await signalWindowsProcessTree(
     {
@@ -100,9 +100,29 @@ test("Windows taskkill non-zero exit falls back without claiming tree terminatio
     fakeTaskkill(5, null),
   );
 
+  assert.equal(result.outcome, "failed");
+  assert.match(result.detail, /taskkill exited 5/);
+  assert.deepEqual(signals, []);
+});
+
+test("Windows force taskkill failure falls back without claiming tree termination", async () => {
+  const signals: Array<NodeJS.Signals | number | undefined> = [];
+  const result = await signalWindowsProcessTree(
+    {
+      pid: 43,
+      kill(signal) {
+        signals.push(signal);
+        return true;
+      },
+    },
+    "SIGKILL",
+    () => false,
+    fakeTaskkill(5, null),
+  );
+
   assert.equal(result.outcome, "fallback_sent");
   assert.match(result.detail, /taskkill exited 5/);
-  assert.deepEqual(signals, ["SIGTERM"]);
+  assert.deepEqual(signals, ["SIGKILL"]);
 });
 
 test("Windows taskkill launch failure is explicit and uses the direct fallback", async () => {

--- a/tests/extensions/background-terminals/manager.test.ts
+++ b/tests/extensions/background-terminals/manager.test.ts
@@ -7,29 +7,153 @@
  */
 
 import assert from "node:assert/strict";
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import test from "node:test";
-import { Effect } from "effect";
+<<<<<<< HEAD:tests/extensions/background-terminals/manager.test.ts
+import { Effect, ManagedRuntime } from "effect";
 import type { TerminalSnapshot } from "../../../extensions/background-terminals/src/domain.ts";
 import {
   MAX_RUNNING,
   MAX_TRACKED,
+  makeTerminalManagerLive,
+  signalWindowsProcessTree,
   TerminalManager,
   type TerminalManagerShape,
+<<<<<<< HEAD:tests/extensions/background-terminals/manager.test.ts
+  waitForWindowsTaskkill,
 } from "../../../extensions/background-terminals/src/manager.ts";
-import {
-  createTerminalRuntime,
-  runTool,
-} from "../../../extensions/background-terminals/src/runtime.ts";
+import { createTerminalRuntime, runTool } from "../../../extensions/background-terminals/src/runtime.ts";
 
 const cwd = process.cwd();
 
-/** Quote a `node -e` script for sh -c. */
+/** Base64 keeps node snippets portable across sh and cmd.exe quoting. */
 function nodeCmd(script: string) {
-  return `node -e '${script}'`;
+  const encoded = Buffer.from(script, "utf8").toString("base64");
+  return `node -e "eval(Buffer.from('${encoded}','base64').toString())"`;
 }
+
+function fakeTaskkill(
+  exitCode: number | null,
+  signal: NodeJS.Signals | null,
+  onLaunch?: (pid: number, force: boolean) => void,
+) {
+  return (pid: number, force: boolean) => {
+    onLaunch?.(pid, force);
+    const child = new EventEmitter() as ChildProcess;
+    queueMicrotask(() => child.emit("close", exitCode, signal));
+    return child;
+  };
+}
+
+test("Windows taskkill is awaited and reports a confirmed tree signal", async () => {
+  const launches: Array<{ pid: number; force: boolean }> = [];
+  const child = {
+    pid: 42,
+    kill() {
+      assert.fail("direct-child fallback must not run after taskkill succeeds");
+    },
+  };
+
+  const resultPromise = signalWindowsProcessTree(
+    child,
+    "SIGKILL",
+    () => false,
+    fakeTaskkill(0, null, (pid, force) => launches.push({ pid, force })),
+  );
+  let resolved = false;
+  void resultPromise.then(() => {
+    resolved = true;
+  });
+
+  assert.equal(resolved, false, "result waits for taskkill close");
+  assert.deepEqual(await resultPromise, { outcome: "sent" });
+  assert.deepEqual(launches, [{ pid: 42, force: true }]);
+});
+
+test("Windows taskkill non-zero exit falls back without claiming tree termination", async () => {
+  const signals: Array<NodeJS.Signals | number | undefined> = [];
+  const result = await signalWindowsProcessTree(
+    {
+      pid: 43,
+      kill(signal) {
+        signals.push(signal);
+        return true;
+      },
+    },
+    "SIGTERM",
+    () => false,
+    fakeTaskkill(5, null),
+  );
+
+  assert.equal(result.outcome, "fallback_sent");
+  assert.match(result.detail, /taskkill exited 5/);
+  assert.deepEqual(signals, ["SIGTERM"]);
+});
+
+test("Windows taskkill launch failure is explicit and uses the direct fallback", async () => {
+  const signals: Array<NodeJS.Signals | number | undefined> = [];
+  const result = await signalWindowsProcessTree(
+    {
+      pid: 44,
+      kill(signal) {
+        signals.push(signal);
+        return true;
+      },
+    },
+    "SIGTERM",
+    () => false,
+    () => {
+      throw new Error("taskkill unavailable");
+    },
+  );
+
+  assert.equal(result.outcome, "fallback_sent");
+  assert.match(result.detail, /failed to launch: taskkill unavailable/);
+  assert.deepEqual(signals, ["SIGTERM"]);
+});
+
+test("Windows taskkill treats an already-exited target as a natural race", async () => {
+  let launched = false;
+  let directSignal = false;
+  const result = await signalWindowsProcessTree(
+    {
+      pid: 45,
+      kill() {
+        directSignal = true;
+        return true;
+      },
+    },
+    "SIGTERM",
+    () => true,
+    () => {
+      launched = true;
+      return new EventEmitter() as ChildProcess;
+    },
+  );
+
+  assert.equal(result.outcome, "already_exited");
+  assert.match(result.detail, /before taskkill started/);
+  assert.equal(launched, false);
+  assert.equal(directSignal, false);
+});
+
+test("Windows taskkill wait is bounded and stops a wedged helper", async () => {
+  let helperKilled = false;
+  const killer = new EventEmitter() as ChildProcess;
+  killer.kill = () => {
+    helperKilled = true;
+    return true;
+  };
+
+  const result = await waitForWindowsTaskkill(46, false, () => killer, 1);
+
+  assert.deepEqual(result, { outcome: "timed_out", timeoutMs: 1 });
+  assert.equal(helperKilled, true);
+});
 
 async function withManager(
   run: (
@@ -92,19 +216,20 @@ test("happy path: stdout and stderr captured separately, settles done, hook fire
       settled.push({ id: snap.id, status: snap.status, consumed }),
     );
 
+    const command = nodeCmd(
+      'process.stdout.write("out-line\\n"); process.stderr.write("err-line\\n");',
+    );
     const snap = await runTool(
       runtime,
       manager.start({
-        command: nodeCmd(
-          'process.stdout.write("out-line\\n"); process.stderr.write("err-line\\n");',
-        ),
+        command,
         title: "happy",
         cwd,
       }),
     );
     assert.equal(snap.status, "running");
     assert.ok(snap.pid);
-    assert.equal(snap.command.includes("out-line"), true);
+    assert.equal(snap.command, command);
 
     const { snap: done } = await settlement(manager, snap.id);
     assert.equal(done.status, "done");
@@ -168,10 +293,12 @@ test("optional deadline terminates the process tree and settles timed_out", asyn
       }),
     );
     assert.ok(snap.timeoutAt);
+    assert.ok(snap.pid);
 
     const { snap: timedOut } = await settlement(manager, snap.id);
     assert.equal(timedOut.status, "timed_out");
-    assert.ok(timedOut.signal);
+    if (process.platform !== "win32") assert.ok(timedOut.signal);
+    assert.ok(await pollUntil(() => processGone(snap.pid!)));
     assert.ok(timedOut.settledAt);
   });
 });
@@ -195,10 +322,10 @@ test("kill settles a never-exiting process as killed and resolves after settle; 
     assert.equal(report[0].status, "killed");
     assert.equal(report[0].killed, true);
     assert.equal(report[0].wasRunning, true);
-    assert.match(report[0].exit, /^SIG/);
+    if (process.platform !== "win32") assert.match(report[0].exit, /^SIG/);
     const after = manager.view.get(snap.id);
     assert.equal(after?.status, "killed");
-    assert.ok(after?.signal);
+    if (process.platform !== "win32") assert.ok(after?.signal);
 
     const second = await runTool(runtime, manager.kill([snap.id]));
     assert.equal(second[0].killed, false);
@@ -346,6 +473,48 @@ test("kill terminates the whole process tree (grandchildren die)", {
   });
 });
 
+test("taskkill terminates a Windows descendant process tree", {
+  skip: process.platform !== "win32",
+}, async () => {
+  await withManager(async (manager, runtime) => {
+    const parentScript = [
+      'const { spawn } = require("node:child_process");',
+      'const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });',
+      "process.stdout.write(`child:${child.pid}\\n`);",
+      "setInterval(() => {}, 1000);",
+    ].join(" ");
+    const snap = await runTool(
+      runtime,
+      manager.start({
+        command: nodeCmd(parentScript),
+        title: "windows-tree",
+        cwd,
+      }),
+    );
+
+    assert.ok(
+      await pollUntil(() =>
+        (manager.view.get(snap.id)?.stdout.text ?? "").includes("child:"),
+      ),
+      "descendant pid was printed",
+    );
+    const match = /child:(\d+)/.exec(
+      manager.view.get(snap.id)?.stdout.text ?? "",
+    );
+    assert.ok(match);
+    const descendant = Number(match[1]);
+    assert.equal(processGone(descendant), false);
+
+    const [result] = await runTool(runtime, manager.kill([snap.id]));
+    assert.equal(result.killed, true);
+    assert.equal(result.terminationFailed, false);
+    assert.ok(
+      await pollUntil(() => processGone(descendant)),
+      "taskkill /T removed the descendant",
+    );
+  });
+});
+
 test("a shell exit with inherited pipes open settles naturally and reaps descendants", {
   skip: process.platform === "win32",
 }, async () => {
@@ -441,7 +610,10 @@ test("concurrency cap rejects an extra start; a failed spawn releases its slot",
     );
     assert.equal(spawns.length, MAX_RUNNING);
     await assert.rejects(
-      runTool(runtime, manager.start({ command: "true", title: "extra", cwd })),
+      runTool(
+        runtime,
+        manager.start({ command: nodeCmd(""), title: "extra", cwd }),
+      ),
       new RegExp(`Max ${MAX_RUNNING} background terminals`),
     );
 
@@ -538,7 +710,10 @@ test("runtime.dispose kills running processes; no settle hook fires after dispos
   // start after dispose is rejected (by the runtime itself, or by the
   // manager's disposed guard if the effect still runs).
   await assert.rejects(
-    runTool(runtime, manager.start({ command: "true", title: "late", cwd })),
+    runTool(
+      runtime,
+      manager.start({ command: nodeCmd(""), title: "late", cwd }),
+    ),
     /shutting down|disposed/,
   );
 });
@@ -558,7 +733,7 @@ test("pruning drops the oldest settled entries past MAX_TRACKED, never running o
     for (let i = 0; i < MAX_TRACKED + 4; i++) {
       const snap = await runTool(
         runtime,
-        manager.start({ command: "true", title: `quick-${i}`, cwd }),
+        manager.start({ command: nodeCmd(""), title: `quick-${i}`, cwd }),
       );
       settledIds.push(snap.id);
       await settlement(manager, snap.id);
@@ -623,7 +798,7 @@ test("a process 'error' event settles failed with errorText and no bogus exit co
     const snap = await runTool(
       runtime,
       manager.start({
-        command: "true",
+        command: nodeCmd(""),
         title: "bad-cwd",
         cwd: "/definitely/not/a/real/dir-12345",
       }),
@@ -686,6 +861,90 @@ test("the spill file holds the complete capture when the settle hook fires, beyo
   });
 });
 
+test("the session spill budget fails closed across terminals", async () => {
+  const budget = 8;
+  const runtime = ManagedRuntime.make(makeTerminalManagerLive(budget));
+  try {
+    const manager = await runtime.runPromise(TerminalManager);
+    const first = await runtime.runPromise(
+      manager.start({
+        command: nodeCmd('process.stdout.write("12345678")'),
+        title: "fills-budget",
+        cwd,
+      }),
+    );
+    const { snap: firstDone } = await settlement(manager, first.id);
+    assert.ok(firstDone.stdout.spillPath);
+    assert.equal(fs.statSync(firstDone.stdout.spillPath).size, budget);
+
+    const second = await runtime.runPromise(
+      manager.start({
+        command: nodeCmd('process.stdout.write("abcdefgh")'),
+        title: "over-budget",
+        cwd,
+      }),
+    );
+    const { snap: secondDone } = await settlement(manager, second.id);
+    assert.equal(secondDone.status, "done");
+    assert.equal(secondDone.stdout.text, "abcdefgh");
+    assert.equal(secondDone.stdout.spillPath, undefined);
+    assert.match(
+      secondDone.errorText ?? "",
+      /session spill budget of 8 bytes would be exceeded/,
+    );
+  } finally {
+    await runtime.dispose();
+  }
+});
+
+test("pruning removes spill files and releases their session budget", async () => {
+  const runtime = ManagedRuntime.make(makeTerminalManagerLive(4));
+  try {
+    const manager = await runtime.runPromise(TerminalManager);
+    const oldest = await runtime.runPromise(
+      manager.start({
+        command: nodeCmd('process.stdout.write("seed")'),
+        title: "oldest-spill",
+        cwd,
+      }),
+    );
+    const { snap: oldestDone } = await settlement(manager, oldest.id);
+    assert.ok(oldestDone.stdout.spillPath);
+    const oldestSpill = oldestDone.stdout.spillPath;
+
+    for (let index = 0; index < MAX_TRACKED; index++) {
+      const terminal = await runtime.runPromise(
+        manager.start({
+          command: nodeCmd(""),
+          title: `prune-filler-${index}`,
+          cwd,
+        }),
+      );
+      await settlement(manager, terminal.id);
+    }
+
+    assert.equal(manager.view.get(oldest.id), undefined);
+    assert.ok(
+      await pollUntil(() => !fs.existsSync(oldestSpill)),
+      "pruned spill file was removed",
+    );
+
+    const replacement = await runtime.runPromise(
+      manager.start({
+        command: nodeCmd('process.stdout.write("next")'),
+        title: "reuses-budget",
+        cwd,
+      }),
+    );
+    const { snap: replacementDone } = await settlement(manager, replacement.id);
+    assert.ok(replacementDone.stdout.spillPath);
+    assert.equal(fs.statSync(replacementDone.stdout.spillPath).size, 4);
+    assert.doesNotMatch(replacementDone.errorText ?? "", /spill budget/);
+  } finally {
+    await runtime.dispose();
+  }
+});
+
 test("aborting the kill wait does not cancel the termination", async () => {
   await withManager(async (manager, runtime) => {
     const snap = await runTool(
@@ -733,7 +992,7 @@ test("status returns the snapshot and rejects unknown ids with the known list", 
   await withManager(async (manager, runtime) => {
     const snap = await runTool(
       runtime,
-      manager.start({ command: "true", title: "status", cwd }),
+      manager.start({ command: nodeCmd(""), title: "status", cwd }),
     );
     const seen = await runTool(runtime, manager.status(snap.id));
     assert.equal(seen.id, snap.id);

--- a/tests/extensions/background-terminals/manager.test.ts
+++ b/tests/extensions/background-terminals/manager.test.ts
@@ -13,7 +13,6 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import test from "node:test";
-<<<<<<< HEAD:tests/extensions/background-terminals/manager.test.ts
 import { Effect, ManagedRuntime } from "effect";
 import type { TerminalSnapshot } from "../../../extensions/background-terminals/src/domain.ts";
 import {
@@ -24,10 +23,12 @@ import {
   signalWindowsProcessTree,
   TerminalManager,
   type TerminalManagerShape,
-<<<<<<< HEAD:tests/extensions/background-terminals/manager.test.ts
   waitForWindowsTaskkill,
 } from "../../../extensions/background-terminals/src/manager.ts";
-import { createTerminalRuntime, runTool } from "../../../extensions/background-terminals/src/runtime.ts";
+import {
+  createTerminalRuntime,
+  runTool,
+} from "../../../extensions/background-terminals/src/runtime.ts";
 
 const cwd = process.cwd();
 
@@ -172,18 +173,50 @@ test("Windows taskkill treats an already-exited target as a natural race", async
   assert.equal(directSignal, false);
 });
 
-test("Windows taskkill wait is bounded and stops a wedged helper", async () => {
+test("Windows taskkill timeout waits for the stopped helper to close", async () => {
   let helperKilled = false;
+  let resolveHelperKilled!: () => void;
+  const helperKilledPromise = new Promise<void>((resolve) => {
+    resolveHelperKilled = resolve;
+  });
   const killer = new EventEmitter() as ChildProcess;
   killer.kill = () => {
     helperKilled = true;
+    resolveHelperKilled();
     return true;
   };
 
-  const result = await waitForWindowsTaskkill(46, false, () => killer, 1);
+  const resultPromise = waitForWindowsTaskkill(46, false, () => killer, 1, 100);
+  let resolved = false;
+  void resultPromise.then(() => {
+    resolved = true;
+  });
+  await helperKilledPromise;
 
-  assert.deepEqual(result, { outcome: "timed_out", timeoutMs: 1 });
   assert.equal(helperKilled, true);
+  assert.equal(resolved, false, "the next termination phase cannot overlap");
+  killer.emit("close", null, "SIGKILL");
+  assert.deepEqual(await resultPromise, {
+    outcome: "timed_out",
+    timeoutMs: 1,
+    helperClosed: true,
+    helperCloseTimeoutMs: 100,
+  });
+});
+
+test("Windows taskkill helper close has a second explicit bound", async () => {
+  const killer = new EventEmitter() as ChildProcess;
+  killer.kill = () => true;
+
+  assert.deepEqual(
+    await waitForWindowsTaskkill(47, false, () => killer, 1, 1),
+    {
+      outcome: "timed_out",
+      timeoutMs: 1,
+      helperClosed: false,
+      helperCloseTimeoutMs: 1,
+    },
+  );
 });
 
 async function withManager(

--- a/tests/extensions/background-terminals/manager.test.ts
+++ b/tests/extensions/background-terminals/manager.test.ts
@@ -1024,6 +1024,66 @@ test("pruning removes spill files and releases their session budget", async () =
   }
 });
 
+test("pending completion retains its spill until delivery releases it", async () => {
+  const runtime = ManagedRuntime.make(makeTerminalManagerLive(4));
+  try {
+    const manager = await runtime.runPromise(TerminalManager);
+    const oldest = await runtime.runPromise(
+      manager.start({
+        command: nodeCmd('process.stdout.write("seed")'),
+        title: "pending-completion",
+        cwd,
+      }),
+    );
+    const { snap: oldestDone } = await settlement(manager, oldest.id);
+    assert.ok(oldestDone.stdout.spillPath);
+    const oldestSpill = oldestDone.stdout.spillPath;
+
+    // This models the extension's copied completion waiting in its deferred
+    // delivery map. The manager must not reclaim evidence still referenced by
+    // that pending notification.
+    manager.view.retainResult(oldest.id);
+
+    for (let index = 0; index < MAX_TRACKED - 1; index++) {
+      const filler = await runtime.runPromise(
+        manager.start({
+          command: nodeCmd(""),
+          title: `pending-filler-${index}`,
+          cwd,
+        }),
+      );
+      await settlement(manager, filler.id);
+    }
+    assert.equal(manager.view.size(), MAX_TRACKED);
+
+    const replacement = await runtime.runPromise(
+      manager.start({
+        command: nodeCmd('process.stdout.write("next")'),
+        title: "pending-replacement",
+        cwd,
+      }),
+    );
+    await settlement(manager, replacement.id);
+
+    assert.equal(fs.existsSync(oldestSpill), true);
+    assert.ok(manager.view.get(oldest.id));
+
+    manager.view.releaseResult(oldest.id);
+    const afterDelivery = await runtime.runPromise(
+      manager.start({
+        command: nodeCmd(""),
+        title: "after-delivery",
+        cwd,
+      }),
+    );
+    await settlement(manager, afterDelivery.id);
+    assert.equal(manager.view.get(oldest.id), undefined);
+    assert.equal(fs.existsSync(oldestSpill), false);
+  } finally {
+    await runtime.dispose();
+  }
+});
+
 test("aborting the kill wait does not cancel the termination", async () => {
   await withManager(async (manager, runtime) => {
     const snap = await runTool(

--- a/tests/extensions/background-terminals/manager.test.ts
+++ b/tests/extensions/background-terminals/manager.test.ts
@@ -207,6 +207,11 @@ test("Windows taskkill timeout waits for the stopped helper to close", async () 
 test("Windows taskkill helper close has a second explicit bound", async () => {
   const killer = new EventEmitter() as ChildProcess;
   killer.kill = () => true;
+  let unrefed = false;
+  killer.unref = () => {
+    unrefed = true;
+    return killer;
+  };
 
   assert.deepEqual(
     await waitForWindowsTaskkill(47, false, () => killer, 1, 1),
@@ -217,6 +222,31 @@ test("Windows taskkill helper close has a second explicit bound", async () => {
       helperCloseTimeoutMs: 1,
     },
   );
+  assert.equal(unrefed, true);
+});
+
+test("an unclosed graceful taskkill helper blocks force escalation", async () => {
+  const killer = new EventEmitter() as ChildProcess;
+  killer.kill = () => true;
+  killer.unref = () => killer;
+  const signals: Array<NodeJS.Signals | number | undefined> = [];
+
+  const result = await signalWindowsProcessTree(
+    {
+      pid: 48,
+      kill(signal) {
+        signals.push(signal);
+        return true;
+      },
+    },
+    "SIGTERM",
+    () => false,
+    () => killer,
+  );
+
+  assert.equal(result.outcome, "unresolved");
+  assert.match(result.detail, /did not close/);
+  assert.deepEqual(signals, []);
 });
 
 async function withManager(

--- a/tests/extensions/background-terminals/output.test.ts
+++ b/tests/extensions/background-terminals/output.test.ts
@@ -8,6 +8,7 @@ test("push/view roundtrip preserves text and counts bytes", () => {
   buf.push("world\n");
   const view = buf.view();
   assert.equal(view.text, "hello world\n");
+  assert.equal(view.modelSafeText, "hello world\n");
   assert.equal(view.totalBytes, Buffer.byteLength("hello world\n"));
   assert.equal(view.truncatedBytes, 0);
 });

--- a/tests/extensions/background-terminals/prompt.test.ts
+++ b/tests/extensions/background-terminals/prompt.test.ts
@@ -11,7 +11,9 @@ import {
   buildStatusResult,
   buildTerminalBatchResultMessage,
   buildTerminalResultMessage,
+<<<<<<< HEAD:tests/extensions/background-terminals/prompt.test.ts
 } from "../../../extensions/background-terminals/src/prompt.ts";
+import { OutputBuffer } from "../../../extensions/background-terminals/src/output.ts";
 
 test("start descriptions identify the platform-specific shell contract", () => {
   assert.match(BG_START_TOOL_DESCRIPTION, /sh -c on POSIX/);
@@ -75,11 +77,25 @@ test("kill report distinguishes killed / raced natural exit / already settled", 
       killed: false,
       exit: "exit 1",
     },
+    {
+      id: "bt-4",
+      title: "d",
+      status: "failed",
+      wasRunning: true,
+      killed: false,
+      terminationFailed: true,
+      errorText: "taskkill exited 5",
+      exit: "unknown",
+    },
   ]);
   const lines = report.split("\n");
   assert.equal(lines[0], 'Killed bt-1 "a" (SIGTERM).');
   assert.match(lines[1], /exited on its own before the kill landed \(exit 0\)/);
   assert.match(lines[2], /was already failed \(exit 1\)/);
+  assert.match(
+    lines[3],
+    /Could not confirm process-tree termination.*taskkill exited 5/,
+  );
 });
 
 test("status result marks head-truncated output with a pointer at the full log", () => {
@@ -160,4 +176,45 @@ test("completion output is a shorter tail than the detailed status view", () => 
   assert.match(completion, /line-100/);
   assert.match(completion, /stdout truncated/);
   assert.match(status, /line-1\n/);
+});
+
+test("model-facing output is sanitized before tail truncation", () => {
+  const buffer = new OutputBuffer(64 * 1024);
+  const hidden = "HIDDEN".repeat(4_096);
+  buffer.push("\u001b]52;c;");
+  buffer.push(hidden);
+  buffer.push("\u0007\nvisible line 1\nvisible line 2\n");
+  const stdout = buffer.view();
+  const retainedEvidence = stdout.text;
+  const terminal = snap({ stdout });
+
+  for (const result of [
+    buildStatusResult(terminal),
+    buildTerminalResultMessage(terminal),
+  ]) {
+    assert.ok(!result.includes("HIDDEN"));
+    assert.ok(!result.includes("\u001b]52"));
+    assert.ok(!result.includes("\u0007"));
+    assert.match(result, /visible line 1\nvisible line 2/);
+  }
+
+  assert.equal(
+    stdout.text,
+    retainedEvidence,
+    "raw retained evidence is unchanged",
+  );
+  assert.match(stdout.text, /HIDDEN/);
+});
+
+test("batched completion sanitizes controls without flattening logs", () => {
+  const batch = buildTerminalBatchResultMessage([
+    "Background terminal bt-1 exited.\n\nstdout:\n\u001b[31mred\u001b[0m\nnext line",
+    "Background terminal bt-2 exited.\n\nstdout:\nsafe\u202eevil\u202c",
+  ]);
+
+  assert.ok(!batch.includes("\u001b"));
+  assert.ok(!batch.includes("\u202e"));
+  assert.ok(!batch.includes("\u202c"));
+  assert.match(batch, /stdout:\nred\nnext line/);
+  assert.match(batch, /stdout:\nsafeevil/);
 });

--- a/tests/extensions/background-terminals/prompt.test.ts
+++ b/tests/extensions/background-terminals/prompt.test.ts
@@ -4,6 +4,7 @@ import type {
   OutputView,
   TerminalSnapshot,
 } from "../../../extensions/background-terminals/src/domain.ts";
+import { RETAINED_PER_STREAM } from "../../../extensions/background-terminals/src/manager.ts";
 import {
   BG_START_PARAMETER_DESCRIPTIONS,
   BG_START_TOOL_DESCRIPTION,
@@ -11,9 +12,9 @@ import {
   buildStatusResult,
   buildTerminalBatchResultMessage,
   buildTerminalResultMessage,
-<<<<<<< HEAD:tests/extensions/background-terminals/prompt.test.ts
 } from "../../../extensions/background-terminals/src/prompt.ts";
 import { OutputBuffer } from "../../../extensions/background-terminals/src/output.ts";
+import { sanitizeTerminalText } from "../../../extensions/shared/terminal-text.ts";
 
 test("start descriptions identify the platform-specific shell contract", () => {
   assert.match(BG_START_TOOL_DESCRIPTION, /sh -c on POSIX/);
@@ -31,7 +32,14 @@ test("start descriptions identify the platform-specific shell contract", () => {
 });
 
 function view(overrides: Partial<OutputView> = {}): OutputView {
-  return { text: "", totalBytes: 0, truncatedBytes: 0, ...overrides };
+  const text = overrides.text ?? "";
+  return {
+    text,
+    modelSafeText: overrides.modelSafeText ?? sanitizeTerminalText(text),
+    totalBytes: 0,
+    truncatedBytes: 0,
+    ...overrides,
+  };
 }
 
 function snap(overrides: Partial<TerminalSnapshot> = {}): TerminalSnapshot {
@@ -204,6 +212,23 @@ test("model-facing output is sanitized before tail truncation", () => {
     "raw retained evidence is unchanged",
   );
   assert.match(stdout.text, /HIDDEN/);
+});
+
+test("model-safe output keeps control-string state across the retained head", () => {
+  const buffer = new OutputBuffer(RETAINED_PER_STREAM);
+  buffer.push(`\u001b]52;c;${"x".repeat(RETAINED_PER_STREAM)}`);
+  buffer.push("\nMODEL_HIDDEN_PAYLOAD\n\u0007visible tail\n");
+  const stdout = buffer.view();
+
+  assert.ok(!stdout.text.includes("\u001b]52"), "the OSC opener was evicted");
+  assert.match(stdout.text, /MODEL_HIDDEN_PAYLOAD/);
+  for (const result of [
+    buildStatusResult(snap({ stdout })),
+    buildTerminalResultMessage(snap({ stdout })),
+  ]) {
+    assert.ok(!result.includes("MODEL_HIDDEN_PAYLOAD"));
+    assert.match(result, /visible tail/);
+  }
 });
 
 test("batched completion sanitizes controls without flattening logs", () => {

--- a/tests/extensions/shared/terminal-text.test.ts
+++ b/tests/extensions/shared/terminal-text.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   hasTerminalControls,
   sanitizeTerminalText,
+  TerminalTextSanitizer,
 } from "../../../extensions/shared/terminal-text.ts";
 
 test("terminal sanitizer removes CSI and terminated or unterminated terminal strings", () => {
@@ -24,6 +25,13 @@ test("terminal sanitizer removes CSI and terminated or unterminated terminal str
   assert.equal(sanitizeTerminalText("before\u001b_unterminated APC"), "before");
   assert.equal(sanitizeTerminalText("before\u0090unterminated DCS"), "before");
   assert.equal(sanitizeTerminalText("a\u0085b\tc"), "ab  c");
+});
+
+test("terminal sanitizer preserves hidden-string state across chunks", () => {
+  const sanitizer = new TerminalTextSanitizer();
+  assert.equal(sanitizer.push("before\u001b]52;c;hidden"), "before");
+  assert.equal(sanitizer.push("\nmore hidden\u001b"), "");
+  assert.equal(sanitizer.push("\\after"), "after");
 });
 
 test("terminal sanitizer removes bidi spoofing controls but preserves shaping joiners", () => {


### PR DESCRIPTION
## Summary

- sanitize status, single-result, and batched model-facing terminal output before tail truncation without mutating retained or spill evidence
- enforce a 512 MiB per-session spill budget on top of the per-stream limit, fail closed when complete logs become unavailable, and remove pruned spill files
- await bounded Windows `taskkill` results, serialize graceful and force phases, preserve natural-exit races, and avoid claiming an unconfirmed process-tree kill
- add focused budget and Windows lifecycle coverage, a `windows-latest` CI job, and align the implementation guide with the runtime contract

## Validation

- `bun run check`
- `bun run test` (888 Node tests passed, 1 Windows-only test skipped on macOS; 30 Vitest tests passed)
- workflow YAML parsed locally; the new Windows runner provides the real `taskkill /T` process-tree validation

Closes #72