### PR TITLE
docs: establish knowledge and evidence contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,14 @@ If those answers are unclear, investigate before adding surface area.
 - Runtime provenance: before diagnosing installed behavior, provider compatibility, a manual Pi smoke, or any UI result, read README section “开发运行时：区分 npm 与当前源码”. Prove both the checkout revision and the single OpenPI source reported by `pi list` before reasoning from source code.
 - Preserve ignored local evidence as user work. Never use `git clean -fdx`; ignored benchmark runs, logs, and harnesses may be the only local copy.
 
+### Knowledge and evidence
+
+- Use GitHub Issues for discussion and work tracking; when research, design, a Decision, or a Benchmark produces reusable knowledge, preserve its canonical record in the appropriate `docs/` category and link the Issue and record both ways.
+- Keep facts, inferences, recommendations, unknowns, exploratory runs, infrastructure failures, and validated results as distinct evidence states. Formal Benchmark records must retain their frozen source/model/task/verifier identities, usage accounting, failure classification, limitations, and evidence manifest.
+- Before publishing or editing a governed record, read [`docs/README.md`](docs/README.md) and the relevant category index. Keep detailed category policy there; keep this always-loaded contract compact.
+- Treat large or sensitive raw evidence as separately identified, content-addressed archive material. Never bulk-add, move, overwrite, clean, or publish ignored local Benchmark assets; preserve credentials and private Session data outside the repository.
+- Do not silently rewrite historical conclusions. Mark a replaced record `superseded` and link its replacement. Distinguish repository validation, merged code, release publication, runtime acceptance, and public publication.
+
 ## Package configuration contract
 
 - `/openpi-setup [natural-language request]` is the single canonical user-facing configuration entry point. `/my-pi-setup` is a compatibility alias only. Do not add extension-specific setup commands for package-owned choices.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,41 @@
+# OpenPI documentation
+
+This directory is the repository's canonical home for durable project knowledge. GitHub Issues remain the public discussion and work-tracking surface; they are not the only copy of a reusable conclusion.
+
+## Choose the record
+
+| Need | Canonical record | Put in it |
+| --- | --- | --- |
+| Discuss a question or track work | GitHub Issue | Context, alternatives, status, decisions still needed |
+| Record sourced investigation | [`research/`](research/) | Facts, sources, evidence boundary, inferences, unknowns |
+| Preserve design exploration | [`design/`](design/) | Alternatives, trade-offs, rejected approaches, evolution |
+| Record a durable project choice | [`decisions/`](decisions/) | Selected constraint, rationale, consequences, superseded choice |
+| Describe stable runtime structure | [`architecture/`](architecture/) | Current ownership, seams, lifecycle and authority boundaries |
+| Report a formal measurement | [`benchmarks/`](benchmarks/) | Protocol, frozen identities, results, limitations, rerun entry point |
+| Describe shipped user behavior | Release notes | Version-specific user-visible changes |
+
+An Issue should link to its canonical document after a conclusion becomes reusable. The document should link back to the Issue, relevant PRs, the source revision, and the evidence receipt. Keep the Issue history intact; a canonical document is a projection, not a replacement.
+
+## Document states
+
+Governed research, design, Decision, architecture and Benchmark records use one of these states:
+
+- `draft`: a working record that is not yet a project constraint;
+- `validated`: checked against the listed sources, code revision, or run receipt at the stated verification date;
+- `superseded`: retained for history but replaced by a newer record.
+
+Each governed record states its creation date, last verification date, applicable OpenPI revision or version, related Issues/PRs, and superseding relationship when relevant. Separate verified facts, inferences, recommendations and unknowns.
+
+## Evidence rules
+
+Formal Benchmark publication has three linked projections:
+
+1. an Issue summary for communication and discussion;
+2. a versioned repository report for protocol and interpretation;
+3. a content-addressed raw-evidence archive for complete machine receipts.
+
+Commit only reviewed, credential-free summaries, manifests, protocols and rerun configuration. Keep large JSONL, logs, Sessions, candidate workspaces, caches and private settings in a separately identified archive with size and SHA-256 receipts. Local ignored Benchmark assets are user-owned evidence and are never bulk-added as part of documentation work.
+
+## Agent entry point
+
+The root `AGENTS.md` contains the always-needed cross-Agent invariants. Read this index when a task produces reusable research, a design choice, a formal Benchmark result, or a publication claim; follow the category-specific index before editing or publishing.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,11 @@
+# Architecture records
+
+This category holds validated descriptions of OpenPI's ownership boundaries,
+lifecycle seams, and runtime contracts. Keep implementation proposals and
+unresolved alternatives in `docs/design/` until they have an explicit decision
+and evidence state.
+
+Each record should identify the source revision, affected Pi primitive, current
+invariants, and links to any related Issue or Decision. Mark a record
+`superseded` when a later record replaces its conclusion; do not silently
+rewrite historical architecture claims.

--- a/docs/benchmarks/BENCHMARK_RESULT_TEMPLATE.md
+++ b/docs/benchmarks/BENCHMARK_RESULT_TEMPLATE.md
@@ -1,0 +1,132 @@
+---
+status: draft
+created: YYYY-MM-DD
+last-verified: YYYY-MM-DD
+applies-to: <OpenPI version or source boundary>
+related-issues: "#<number>"
+related-prs: none
+supersedes: none
+---
+
+# YYYY-MM-DD — <benchmark 名称>
+
+运行生命周期（不替代文档状态）：`planned | running | complete | invalidated`
+
+## 一句话结论
+
+<用一句话写质量结果、主要资源差异和本次决策。>
+
+## 问题与假设
+
+- 比较问题：
+- 主假设：
+- 主质量指标：`artifact_pass_at_deadline`
+- 资源指标：wall time、input、output、cache read/write、total tokens、估算成本、turn、tool calls、nested usage
+- 本次结果允许支持的结论范围：
+
+## 冻结环境
+
+| 项目 | 值 |
+| --- | --- |
+| 日期与时区 |  |
+| Runner commit |  |
+| Pi 版本 |  |
+| OpenPI commit / 配置 |  |
+| Arm A |  |
+| Arm B |  |
+| Provider / model |  |
+| Thinking |  |
+| 任务源 commit |  |
+| 每 cell deadline |  |
+| 重复次数 |  |
+| A/B 顺序 |  |
+| 隔离 |  |
+
+两组之间唯一允许的差异：<填写>。
+
+## 题目
+
+| Task ID | 语言 / 类型 | 要求摘要 | 隐藏验收 | 题源 |
+| --- | --- | --- | --- | --- |
+|  |  |  |  |  |
+
+## 运行前门禁
+
+| 门禁 | 结果 | 证据 / 备注 |
+| --- | --- | --- |
+| Reference calibration |  |  |
+| Arm A route-and-edit canary |  |  |
+| Arm B route-and-edit canary |  |  |
+| 凭据隔离 |  |  |
+| 全进程树隔离与清理 |  |  |
+| Verifier 后注入、断网运行 |  |  |
+
+**身份与分类必须明确：** provider/model、thinking、任务源、verifier、隔离边界、样本量，以及 artifact、protocol、infrastructure/provider、verifier 失败分类。
+
+任何门禁失败时，将 campaign 标记为 `invalidated`，不要继续解释模型优劣。
+
+## 总体结果
+
+| 指标 | Arm A | Arm B | B / A 或差值 |
+| --- | ---: | ---: | ---: |
+| Artifact passes |  |  |  |
+| Protocol completions |  |  |  |
+| Wall time |  |  |  |
+| Input + output tokens |  |  |  |
+| Cache read tokens |  |  |  |
+| Total recorded tokens |  |  |  |
+| 估算成本 |  |  |  |
+| Parent turns |  |  |  |
+| Parent tool calls |  |  |  |
+| Nested tokens |  |  |  |
+
+## 逐题结果
+
+| Task | Arm | Pass | Protocol | Wall | In + out | Cache read | Total | Cost | Turns | Tools | Nested |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: |
+|  |  |  |  |  |  |  |  |  |  |  |  |
+
+## 运行行为
+
+- 实际调用了哪些 OpenPI 能力：
+- 没有调用哪些预期能力：
+- 异常、重试、timeout、provider 或 verifier 事件：
+- Tool footprint / first-request context：
+
+## 分析
+
+### 已观察事实
+
+- <直接来自 ledger、artifact 或 verifier 的事实。>
+
+### 原因推断
+
+- <把推断与事实分开，并写明支持证据和替代解释。>
+
+### 局限
+
+- <样本量、任务代表性、顺序效应、成本口径、缺失数据等。>
+
+## 决策与下一步
+
+- 保留：
+- 改进：
+- 暂不做：
+- 下一次 benchmark：
+- 通过线：
+
+## 原始证据
+
+- Raw evidence：`<仓库外路径或归档 URI>`
+- Runner：`<路径和 commit>`
+- Run manifest SHA-256：
+- Cells ledger SHA-256：
+- Summary SHA-256：
+- Archive file count / logical bytes：
+- Complete archive manifest SHA-256：
+- 其他证据 SHA-256：
+- 凭据检查：`no auth, token, model registry, or private settings persisted`
+
+## Amendments
+
+无。后续解释变化按 `YYYY-MM-DD — <原因>` 追加，不覆盖原结论。

--- a/docs/benchmarks/PI_OPENPI_BENCHMARK_PROTOCOL.md
+++ b/docs/benchmarks/PI_OPENPI_BENCHMARK_PROTOCOL.md
@@ -1,0 +1,553 @@
+# Bare Pi vs Pi + OpenPI benchmark protocol
+
+Protocol frozen: 2026-08-13
+
+This document defines the comparison contract, trust boundary, metrics, task
+ladder, and stopping rules. It is the source of truth for how a run is executed;
+dated outcomes and analysis live in [`runs/`](runs/) and are indexed by
+[`README.md`](README.md).
+
+## Decision
+
+Run the comparison, but do not reuse the old “Single vs four-role Hive” score as
+evidence for OpenPI. The primary comparison must keep one top-level Pi process,
+the exact task prompt, model route, thinking level, deadline, sandbox, and hidden
+verifier identical. The treatment arm differs only by loading a pinned OpenPI
+package with a frozen, safe configuration.
+
+The existing HiveBench work is the best local foundation. It already contains
+task snapshots, post-run private verifier injection, candidate isolation, Pi JSON
+parsing, provenance, and paired reports. It is not yet ready to run full OpenPI
+safely or to make equal-compute claims: most of the Pi support is uncommitted,
+OpenPI children/background tools can cross the current parent-only tool boundary,
+and direct subagent calls do not expose complete nested model usage to the parent
+result.
+
+Recommended order:
+
+1. Freeze and repair the harness trust and accounting boundaries.
+2. Run the three-task Aider pilot below as an integration gate.
+3. Run a preregistered recent repository-task sample as the primary benchmark.
+4. Report natural-use quality separately from resource efficiency.
+
+No publishable model benchmark should be run before the P0 gates in this
+document pass. A clearly labelled local exploratory pilot may run after the
+starter/reference calibration, credential isolation, whole-process filesystem
+containment, route canary, and process-tree cleanup gates pass. Such a pilot is
+useful for deciding whether a full campaign is worth building, but it is not
+headline evidence.
+
+## 1. Question and estimand
+
+### Primary question: package uplift under natural use
+
+> Given the same Pi, model route, reasoning setting, task, wall-clock deadline,
+> and execution environment, how does making the OpenPI package available change
+> the probability that the final repository artifact passes a host-owned verifier?
+
+| Cell property | Arm A: bare Pi | Arm B: Pi + OpenPI |
+| --- | --- | --- |
+| Top-level process | One Pi process | One Pi process |
+| Pi build | Same pinned build | Same pinned build |
+| Prompt | Same exact bytes | Same exact bytes |
+| Model and thinking | Same exact route and value | Same exact route and value |
+| Built-in task deadline | Same | Same |
+| Starter repository | Same immutable snapshot | Same immutable snapshot |
+| Candidate sandbox | Same outer containment | Same outer containment |
+| Verifier | Same, injected after exit | Same, injected after exit |
+| Package exposure | No OpenPI package | One pinned OpenPI package |
+| OpenPI feature use | Impossible | Chosen naturally by the parent agent |
+
+The task prompt must not mention OpenPI, workflows, subagents, parallelism, or
+background terminals. This estimates the value of installing OpenPI, including
+whether the model chooses its capabilities appropriately. It is deliberately not
+an equal-compute estimate: OpenPI may make additional model calls.
+
+### Secondary question: orchestration attribution
+
+After nested telemetry and containment are complete, run a separate ablation in
+which both arms have the same confined search/file/shell tools and the treatment
+adds only orchestration. Do not combine this result with the primary natural-use
+score.
+
+### Feature canaries, not headline evidence
+
+Prompts that explicitly require multiple agents, background processes, a plan, or
+context handoff are useful product reliability tests. They favor OpenPI by design
+and must live in a separate “feature probe” section of the report.
+
+## 2. Frozen implementation under test
+
+The current workspace resolves Pi as `@earendil-works/pi-coding-agent@0.84.1`.
+Before a campaign, record and verify:
+
+- Pi package name, version, tarball integrity, and source commit;
+- OpenPI package version, Git commit, clean/dirty state, and packed tarball SHA-256;
+- benchmark manifest SHA-256 and task-source revisions;
+- provider, model, thinking level, endpoint class, and route policy;
+- container or VM image digests, host architecture, and runtime versions;
+- local exploratory runner, runtime-guard, and safe-snapshot helper SHA-256;
+- the normalized OpenPI configuration and every loaded resource/tool source.
+
+For the local snapshot, the resolved Pi package advertises source commit
+`53fa77ccd8a279eb87e92294ef3687b03ff80112`. That is the comparison baseline;
+“bare Pi” must not silently mean a different upstream release.
+
+OpenPI configuration is part of the treatment and must be frozen. For the first
+natural-use campaign use the package defaults that do not create extra model
+calls before the agent asks for them:
+
+- next-action suggestions disabled;
+- post-edit command disabled;
+- subagent role models inherit the parent route and thinking setting;
+- no optional packages;
+- workflow concurrency `8` and total-call limit `128` (the current defaults),
+  both recorded explicitly;
+- non-interactive/print mode, so footer and theme differences are irrelevant.
+
+## 3. A/B isolation
+
+Each task/arm/repeat is a fresh cell.
+
+1. Create a clean candidate directory from the same content-addressed starter.
+2. Create a unique empty `PI_CODING_AGENT_DIR` for the cell.
+3. Disable sessions, history, discovered packages, skills, prompt templates, and
+   context files. Load only harness-owned resources declared by the arm profile.
+4. Give both arms the same scoped provider credential through the same proxy and
+   route. Never expose general host credentials to candidate tools.
+5. Start the deadline at the same lifecycle boundary. Package initialization in
+   the treatment counts against its deadline.
+6. Capture Pi JSONL and require an authoritative final `message_end` with
+   `stopReason: stop`; verify the returned provider/model against the frozen arm.
+7. Freeze the artifact at deadline, terminate descendants, then verify a fresh
+   immutable copy outside the candidate session.
+
+Use counterbalanced task-level order: even repeats run A then B; odd repeats run B
+then A. Randomize task order with a preregistered seed. Prefer one cell at a time
+to avoid route contention. If concurrency is necessary, launch complete A/B pairs
+under an explicit capacity reservation and record queue time separately.
+
+Warm-state policy must be symmetric. Either use cold caches for every cell or
+prewarm identical public dependencies in the frozen image. Never prewarm only
+OpenPI or retain one arm's conversation/session state.
+
+### 2026-08-15 local runner isolation amendment
+
+The v2 whole-process profile was not a sufficient model boundary: Pi needed the
+agent directory to load credentials, so the same model-controlled Bash process
+could also inspect it. A later attempt to nest a stricter `sandbox-exec` for Bash
+inside the sandboxed Pi process failed with macOS code 71.
+
+The v4 local exploratory runner instead treats Pi and the loaded extension as
+trusted host code and confines the model-facing boundary:
+
+- a symmetric benchmark extension scrubs the selected provider/model config
+  before the first model request;
+- built-in file tools resolve and reject paths outside the candidate, including
+  symlink escapes;
+- each Bash call enters a fresh network-none `sandbox-exec`; system and
+  toolchain roots are read-only, while only the candidate, an empty HOME, and a
+  private TMPDIR are writable;
+- an unreviewed optional tool call is blocked and marks the cell invalid;
+- after Pi or the verifier exits, the runner cleans and confirms its complete
+  process group before reading the candidate;
+- candidate snapshots reject symlinks and multi-link regular files, use
+  no-follow/exclusive opens, and verify directory and file identity across the
+  copy before the hidden verifier is injected;
+- calibration and hidden verification still run in a separate explicit-root,
+  network-none sandbox;
+- the mandatory preflight and runtime guard evidence are archived with the run.
+
+The runner records this as `candidate-tool-boundary-v4`. It is suitable for the
+core-tool local smoke only. Because optional OpenPI tools fail closed, it cannot
+measure capability value and is not equivalent to the preferred ephemeral VM or
+container boundary.
+
+## 4. P0 trust-boundary gate
+
+Pi's own security documentation says it has no built-in sandbox and extensions
+run with the user's permissions. A package is executable code, not a permission
+boundary. The whole Pi + OpenPI process therefore needs containment, not merely a
+confined parent `bash` tool.
+
+This matters locally because OpenPI children create fresh in-process Pi sessions.
+The current HiveBench Pi adapter disables built-ins for the parent and replaces
+them with confined tools, but that alone does not prove the same binding for a
+child. In addition, OpenPI's background-terminal tools spawn host processes, and
+its `fd`/`rg` tools can accept absolute or home-relative paths. A full OpenPI arm
+could otherwise receive more host access than bare Pi and invalidate both safety
+and fairness.
+
+Preferred boundary:
+
+- run the entire cell in an ephemeral VM, microVM, or equivalently isolated
+  container namespace;
+- mount only the candidate workspace and a read-only package/task bundle;
+- deny host filesystem, credential stores, sockets, and metadata services;
+- deny general egress; provide model transport through one scoped proxy only;
+- cap processes, CPU, memory, disk, and wall time; reap the full process tree;
+- run the verifier later in a different network-none environment.
+
+If the first pilot keeps HiveBench's per-tool Docker design, the harness must also
+prove that the same confined tools load in parent and child sessions, and must
+exclude or safe-wrap `bg_*`, `fd`, and `rg`. This is a temporary pilot boundary,
+not evidence that package code itself is sandboxed.
+
+Before every campaign, run parent and child canaries for:
+
+- absolute paths, `..` traversal, `$HOME`, and files outside the candidate root;
+- symlink, hardlink, FIFO, socket, and device access;
+- host environment variables, credentials, and Unix sockets;
+- general network and metadata endpoints;
+- detached/background processes surviving the cell;
+- a legitimate read, declared edit, test command, and persisted artifact.
+
+Any escape, different parent/child binding, or surviving process aborts the
+campaign. All affected rows are invalid; do not classify them as model failures.
+
+## 5. Task ladder
+
+### T0: deterministic harness fixtures
+
+Use HiveBench's fake and tracer manifests once per harness build to validate cell
+creation, A/B ordering, artifact capture, failure classification, resume logic,
+and report generation. They are plumbing tests and receive no capability score.
+
+Relevant assets:
+
+- `<hivebench-checkout>/benchmarks/local-fake.yaml`
+- `<hivebench-checkout>/benchmarks/aider-polyglot-smoke.yaml`
+- `<hivebench-checkout>/benchmarks/aider-polyglot-comparative-tracer.yaml`
+
+### T1: three-task multilingual pilot
+
+Reuse three already-frozen Aider/Exercism cells from
+`<hivebench-checkout>/benchmarks/aider-polyglot-pi-pilot.yaml`:
+
+| Task id | Language | Existing source |
+| --- | --- | --- |
+| `python-bottle-song` | Python | `benchmarks/aider-polyglot-pi-pilot.yaml` |
+| `javascript-connect` | JavaScript | `benchmarks/aider-polyglot-pi-pilot.yaml` |
+| `rust-nucleotide-codons` | Rust | `benchmarks/aider-polyglot-pi-pilot.yaml` |
+
+These span three locally available toolchains while keeping the integration
+pilot small. Go was installed before the 2026-08-13 Luna/max campaign, so that
+campaign added the preregistered `go-book-store` cell before either arm ran.
+Run at least three repeats per arm for regression decisions; a two-repeat
+campaign remains exploratory. The pilot answers only whether the
+two profiles can complete, remain contained, produce accountable telemetry, and
+reach the same hidden verifier. It is underpowered and dominated by small coding
+exercises; do not call its pass delta a general OpenPI uplift.
+
+The full six-task manifest may later serve as a multilingual regression set:
+C++ `parallel-letter-frequency`, Go `book-store`, Java `bank-account`, JavaScript
+`connect`, Python `bottle-song`, and Rust `nucleotide-codons`.
+
+### T2: primary repository-task benchmark
+
+Use a recent frozen slice of
+[SWE-bench-Live/MultiLang](https://github.com/microsoft/swe-bench-live), not a
+hand-picked set of tasks that obviously benefit from delegation. Suggested first
+internal campaign: 30 tasks × 2 arms × 3 repeats = 180 cells.
+
+Pre-register the dataset revision, task IDs, selection seed, and stratification.
+Stratify by language, repository, failing-test count, number of files in the
+reference patch, and a precomputed complexity bucket. Include both compact fixes
+and multi-file diagnosis/implementation work. Cap tasks per repository so one
+codebase cannot dominate the estimate.
+
+The selection program may use reference metadata, but the candidate must never
+receive the gold patch or hidden test patch. Selection must be frozen before any
+arm result is observed.
+
+Use a small
+[SWE-bench Verified](https://www.swebench.com/verified.html) slice only as a
+compatibility signal. OpenAI now warns that the public Verified set is
+increasingly contaminated and saturated, so it should not be the primary evidence
+for a 2026 product claim.
+
+### T3: OpenPI feature probes
+
+Create separate, clearly labeled scenarios for:
+
+- independent parallel investigations with a mergeable final artifact;
+- cross-file implementation, tests, and review;
+- a bounded long-running background command;
+- a long task that exercises plan/resume/context handoff.
+
+These tasks may explain *how* OpenPI works and expose reliability bugs. Because
+they are authored around OpenPI affordances, never pool them with neutral T1/T2
+pass rates.
+
+## 6. Hidden acceptance
+
+Candidate-visible input contains only the issue/task text, starter repository,
+and public build metadata needed for ordinary development. It excludes:
+
+- gold/reference patches;
+- hidden test patches and expected outputs;
+- verifier scripts, task-selection metadata, and result labels;
+- artifacts or conversations from another arm or repeat.
+
+After the agent exits or the deadline fires:
+
+1. Freeze the submitted repository hash and preserve the raw artifact.
+2. Copy it into a fresh verifier workspace.
+3. Inject the pinned verifier files with exclusive/no-follow semantics.
+4. Run exactly one host-owned verification in a network-none image.
+5. Store exit code, bounded logs, image digest, and verifier hash.
+6. Remove verifier files before exposing any artifact to subsequent cells.
+
+Before scoring, prove that each starter fails the required acceptance test and
+that the pinned reference patch passes it twice in the final image. Exclude an
+unreliable task before the campaign. Once scoring begins, never reveal verifier
+feedback, repair an artifact, or selectively retry a failed arm.
+
+For repository tasks, allow ordinary repository-wide candidate edits while
+protecting `.git`, harness controls, and verifier material. An allowlist derived
+from gold-patch paths leaks task structure and blocks legitimate alternative
+solutions.
+
+“Hidden during the run” does not mean uncontaminated. Aider and SWE-bench tasks
+are public. Report dataset age and contamination risk separately from the strong
+claim that the verifier was unavailable to this run.
+
+## 7. Metrics and accounting
+
+### Primary metric
+
+Artifact pass@1 at the fixed deadline, with every assigned task/arm/repeat in the
+denominator (intent to treat). A process saying “done” is not success.
+
+Report task-paired A-vs-B win/loss/tie and the paired pass-rate difference. Keep
+these statuses disjoint:
+
+- `passed`: frozen artifact passed the one hidden verifier;
+- `task_failed`: run completed but artifact failed;
+- `budget_exhausted`: declared wall/token/call budget stopped the cell;
+- `infra_failed`: route, process, sandbox, harness, or verifier infrastructure
+  failed.
+
+The headline intent-to-treat table must retain `budget_exhausted` and
+`infra_failed`. A separate artifact-only diagnostic may exclude confirmed
+infrastructure failures, but it cannot replace the headline result.
+
+### Required secondary metrics
+
+- wall time and queue time;
+- time to first durable edit;
+- parent turns and tool calls;
+- total model invocations across parent and every child;
+- total input, output, cache, and reasoning tokens across the whole process tree;
+- sum of agent-seconds and peak model-call concurrency;
+- exact cost when provider accounting is trustworthy, otherwise `unknown`;
+- child spawn/completion/failure/cancel counts and workflow call count;
+- files changed, diff lines, generated-test count, and test commands;
+- unsafe access attempts and safety-canary outcome;
+- verifier calls, which must be one per scored cell;
+- whether each OpenPI capability was actually used.
+
+Current direct OpenPI subagent results do not provide a trustworthy cumulative
+child-usage total to the parent record. Until this is fixed, nested tokens, cost,
+and agent time must be `unknown`, not zero. The benchmark may still make a
+natural-use artifact-quality claim, but not an efficiency or equal-compute claim.
+
+Add an equal-resource block only after all nested calls are measured and the
+harness can enforce the same predeclared model-call/token/agent-minute budget in
+both arms. Report it separately from the natural-use block.
+
+### Statistical summary
+
+Treat the task, not an individual repeat, as the independent unit. Estimate the
+paired pass delta with a task-cluster bootstrap 95% confidence interval and a
+paired permutation/sign test. Do not inflate sample size by treating repeats of
+the same task as unrelated tasks.
+
+Pre-register a practical margin, suggested `δ = 5` percentage points:
+
+- benefit: lower 95% confidence bound is greater than `+δ`;
+- non-inferior but not proven better: lower bound is greater than `-δ`, while the
+  benefit rule is not met;
+- harm: upper bound is less than `-δ`;
+- otherwise: inconclusive.
+
+A 30-task internal campaign is directional and likely has wide intervals. Publish
+the interval and raw task pairs rather than replacing uncertainty with a binary
+winner label.
+
+## 8. Repeats and stopping rules
+
+- T0: once per harness build and environment image.
+- T1: three repeats per arm, counterbalanced A/B order.
+- T2: three repeats per arm for the preregistered 30-task sample.
+- T3: at least three repeats, reported only as feature reliability.
+
+Do not stop early for apparent benefit or harm and do not peek to choose more
+tasks. No selective retry, rescue prompt, verifier-feedback repair, or model
+substitution is allowed. A deterministic total cost/time cap may end an
+exploratory campaign, but the truncated result is not a definitive comparison.
+
+Abort and restart the entire affected block only when one of these predeclared
+conditions fires:
+
+- any safety canary fails or a descendant survives containment;
+- actual provider/model/thinking differs from the frozen route;
+- reference calibration or verifier determinism fails;
+- task bytes, package hash, sandbox image, or scoring code drift mid-block;
+- infrastructure failures exceed 5% of assigned cells in either arm.
+
+Preserve all partial rows and state the abort reason. After repair, use a new
+campaign ID and rerun the complete affected block rather than only failed cells.
+
+## 9. Reusable local assets
+
+### HiveBench: reuse after freezing
+
+Operator-local checkout: `<hivebench-checkout>`
+
+| Asset | Value for this benchmark | Qualification |
+| --- | --- | --- |
+| `src/runner/manifest.ts` | Typed task/control manifest | Extend with arm profiles; do not encode package exposure as “strategy” |
+| `src/runner/task-sandbox.ts` | Per-cell candidate directories | Reuse |
+| `src/runner/private-verifier-files.ts` | Post-run exclusive verifier injection | Reuse |
+| `src/runner/campaign-cell.ts` | Run then verify lifecycle | Reuse after full-process containment |
+| `src/runner/verifier.ts` | Host-owned verifier | Reuse |
+| `src/safety/*` | Path, environment, Docker, subprocess guards | Reuse and add parent/child/background canaries |
+| `src/adapters/pi-cli.ts` | Non-interactive Pi invocation | Generalize to `bare_pi` and `pi_openpi` profiles |
+| `src/adapters/pi-json.ts` | Final-event, model, and usage validation | Reuse; add nested usage provenance |
+| `benchmarks/pi/hivebench-sandbox-tools.ts` | Confined file/shell tools | Useful for pilot, insufficient as the only package boundary |
+| `src/runner/result-writer.ts`, `run-metadata.ts`, `report.ts` | Raw JSONL, provenance, paired reports | Reuse; add task-cluster statistics and arm/package hashes |
+| `docs/pi-benchmark-protocol.md` | Counterbalancing, calibration, failure taxonomy | Adapt |
+
+At inspection time the HiveBench checkout is at commit
+`c10ea941f4de008d144b557aa055b31db4f62a62`, but the Pi manifests, adapter,
+sandbox extension, scripts, docs, and many tests are modified or untracked. Treat
+this checkout as a valuable incubator, not a reproducible dependency. Commit or
+export a content-addressed clean snapshot before citing a result.
+
+### HiveBench assets that are not fair evidence as-is
+
+`benchmarks/aider-polyglot-pi-sonnet5-comparative.yaml` compares a one-process
+`single_strong` arm with a forced four-role `hive_role_team`. It also gives the
+single arm a 900-second timeout and the Hive arm 420 seconds. That answers a
+different question and creates unequal resources. Its six mostly small exercises
+also tend to punish coordination overhead. Reuse its frozen task/verifier bytes,
+not its arm semantics or old score.
+
+`benchmarks/aider-polyglot-comparative-tracer.yaml` is deterministic plumbing,
+not model evidence. `benchmarks/local-fake.yaml` is likewise a smoke fixture.
+
+### Hive private runtime: do not use as the neutral host
+
+Operator-local checkout: `<private-hive-runtime-checkout>`
+
+No independent coding-agent task harness, frozen task suite, or host-private
+acceptance corpus was found. Its runtime/protocol tests validate Hive itself.
+Using the runtime as both experiment host and treatment-like orchestration layer
+would bias the comparison. Reuse only generic telemetry ideas, not its controller
+or product-specific success contract.
+
+### Hive Work: reuse verifier concepts, not the runner
+
+Operator-local checkout: `<hive-work-checkout>`
+
+- `scripts/check-open-source-benchmarks.mjs` and
+  `docs/benchmarks/open-source-agent-workbench.json` track open-source product
+  evidence/freshness; they do not execute coding tasks.
+- `src/main/autonomous-verifier.ts` and `scripts/check-autonomous-task-*.mjs`
+  contain useful command-verifier, redaction, and failure-taxonomy patterns.
+- The autonomous controller is product-specific and should not host this A/B
+  comparison.
+
+### OpenPI's own tests
+
+OpenPI unit/integration tests are necessary regression gates but not an external
+benchmark. Tasks derived from its tools or documentation belong in T3 and must
+not contribute to the neutral pass-rate estimate.
+
+## 10. Required harness delta before execution
+
+1. Freeze the current HiveBench work into a clean revision or exported bundle.
+2. Replace `strategy`-shaped Pi comparison with explicit `arm_id`/package profiles:
+   `bare_pi` and `pi_openpi`.
+3. Add per-cell isolated agent directories and record the complete resource/tool
+   load graph for parent and child sessions.
+4. Put the full OpenPI process tree behind the outer boundary; add the canaries in
+   Section 4.
+5. Aggregate usage, model identity, elapsed agent time, and termination state from
+   every child/workflow call.
+6. Add a SWE-bench-Live adapter with repo-wide candidate writes and official
+   post-run evaluation.
+7. Add intent-to-treat paired reporting, task-cluster intervals, fixed stop rules,
+   and raw artifact links.
+8. Validate T0 and reference calibration before spending on T1.
+
+## 11. Bias checklist
+
+### Choices that favor OpenPI
+
+- telling the treatment to use subagents/workflows while giving bare Pi no
+  equivalent instruction;
+- selecting only highly parallel/decomposable tasks or tasks authored from OpenPI
+  features;
+- giving OpenPI a different model, deadline, verifier feedback, network, writable
+  surface, or host access;
+- ignoring child tokens, calls, agent-minutes, failures, or orphan processes;
+- excluding OpenPI protocol/infra failures from the denominator;
+- retrying only treatment failures or keeping treatment sessions/caches warm;
+- scoring plans, self-reported completion, or dispatch evidence instead of the
+  artifact;
+- allowing the treatment's child tools to bypass the bare arm's sandbox.
+
+### Choices that favor bare Pi
+
+- using only tiny single-file exercises where orchestration overhead dominates;
+- forcing OpenPI to launch a fixed four-agent team on every task;
+- giving OpenPI a shorter timeout or starting its clock earlier;
+- disabling the exact child/search/background capabilities whose natural value is
+  under test without labeling the result a constrained ablation;
+- counting only parent tokens for OpenPI while interpreting the number as total
+  compute;
+- using a gold-path-derived writable allowlist that blocks alternative multi-file
+  fixes.
+
+## 12. Evidence sources
+
+Primary sources used to define the protocol:
+
+- Pi usage and non-interactive controls:
+  [usage.md at the resolved Pi source commit](https://github.com/earendil-works/pi/blob/53fa77ccd8a279eb87e92294ef3687b03ff80112/packages/coding-agent/docs/usage.md)
+- Pi package loading and package privileges:
+  [packages.md at the resolved Pi source commit](https://github.com/earendil-works/pi/blob/53fa77ccd8a279eb87e92294ef3687b03ff80112/packages/coding-agent/docs/packages.md)
+- Pi JSONL event contract:
+  [json.md at the resolved Pi source commit](https://github.com/earendil-works/pi/blob/53fa77ccd8a279eb87e92294ef3687b03ff80112/packages/coding-agent/docs/json.md)
+- Pi security boundary:
+  [security.md at the resolved Pi source commit](https://github.com/earendil-works/pi/blob/53fa77ccd8a279eb87e92294ef3687b03ff80112/packages/coding-agent/docs/security.md)
+- Aider's official benchmark procedure and Docker warning:
+  [benchmark README at the pinned verifier commit](https://github.com/Aider-AI/aider/blob/5dc9490bb35f9729ef2c95d00a19ccd30c26339c/benchmark/README.md)
+- Frozen Aider/Exercism task corpus:
+  [polyglot-benchmark at the pinned dataset commit](https://github.com/Aider-AI/polyglot-benchmark/tree/7e0611e77b54e2dea774cdc0aa00cf9f7ed6144f)
+- SWE-bench official evaluation harness:
+  [SWE-bench repository](https://github.com/SWE-bench/SWE-bench) and
+  [harness reference](https://www.swebench.com/SWE-bench/reference/harness/)
+- SWE-bench Verified construction:
+  [official Verified page](https://www.swebench.com/verified.html)
+- Current contamination/saturation limitation:
+  [OpenAI: Why we no longer evaluate SWE-bench Verified](https://openai.com/index/why-we-no-longer-evaluate-swe-bench-verified/)
+- Continuously refreshed repository-task source:
+  [Microsoft SWE-bench-Live](https://github.com/microsoft/swe-bench-live)
+
+## 13. Minimum go/no-go checklist
+
+A three-task pilot is allowed only when every item is `yes`:
+
+- [ ] Bare Pi and Pi + OpenPI resolve the same Pi/model/thinking route.
+- [ ] Package, task, image, prompt, verifier, runner, guard, and snapshot hashes are frozen.
+- [ ] Parent and OpenPI child tool-source provenance is recorded.
+- [ ] Parent/child/background security canaries pass.
+- [ ] Nested usage is either complete or explicitly reported `unknown`.
+- [ ] Starter-fails/reference-passes calibration succeeds twice per task.
+- [ ] A/B order, repeats, stop rules, and report schema are preregistered.
+- [ ] Raw JSONL, artifact, verifier output, and run metadata will be retained.
+
+If any answer is `no`, run only T0 deterministic fixtures and fix the harness.

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -1,0 +1,13 @@
+# Benchmark 账本
+
+本目录是 Benchmark 协议与正式结果的 canonical source。GitHub Issue 负责公开摘要和讨论；本目录负责冻结条件、完整解释、限制和复跑入口；完整 JSONL、日志、Session 与候选工作区保存在单独的 operator-local archive，并通过 [`evidence/2026-08-26-openai-luna-high-manifest.sha256`](evidence/2026-08-26-openai-luna-high-manifest.sha256) 等 manifest 定位。
+
+新记录至少声明：`status`、创建/验证日期、适用 revision、相关 Issue/PR、模型与 thinking、任务/verifier 身份、样本量、隔离与失败分类、证据 manifest、局限和下一步。结果不能只由 Issue 摘要替代。
+
+## Canonical records
+
+- [2026-08-26 OpenAI Luna high：Bare Pi vs OpenPI](runs/2026-08-26-openai-luna-high-pi-vs-openpi.md) — 60-cell explicit/adaptive 对照；对应 [Issue #197](https://github.com/tt-a1i/openpi/issues/197)。
+- [Benchmark result template](BENCHMARK_RESULT_TEMPLATE.md) — 新 campaign 的完整记录模板。
+- [Pi/OpenPI benchmark protocol](PI_OPENPI_BENCHMARK_PROTOCOL.md) — 比较合同、信任边界和停止规则。
+
+单次运行的数字、结论与决策只保存在对应 dated record 中，分类 README 不复制第二份事实源。执行合同见 [`PI_OPENPI_BENCHMARK_PROTOCOL.md`](PI_OPENPI_BENCHMARK_PROTOCOL.md)，记录形状与字段要求见 [`BENCHMARK_RESULT_TEMPLATE.md`](BENCHMARK_RESULT_TEMPLATE.md)。历史本地记录在完成安全审查并被选择性纳入 Git 前，不作为 clean-checkout 导航目标。

--- a/docs/benchmarks/evidence/2026-08-26-openai-luna-high-manifest.sha256
+++ b/docs/benchmarks/evidence/2026-08-26-openai-luna-high-manifest.sha256
@@ -1,0 +1,10 @@
+# Public manifest for the 2026-08-26 Luna/high Pi vs OpenPI report.
+# Raw ledgers remain in the operator-local archive; this manifest is the
+# bounded, credential-free identity that the canonical report can cite.
+
+5e5bff56ddf8384eda0c259e6b900bd5f8c572f6ad9d0c68c07f388ddb382d8e  explicit/summary.json
+7537b757c19b9153508ab134e9bb983e5e1fa308def8492bb69ae667a022bfc6  explicit/cells.jsonl
+b458dc7501215994bd04368226256f37f719ec8c4278e5fa76b9a6fb9bce1d0f  explicit/run.json
+13e3914bca058152cbc2c4a2ff8aa49679a2e7b9e898ee47c4c40a5fb716794d  adaptive/summary.json
+9143b0a52ea6b3770479f771ce804b57edd905b0bf199b1fe53545e86be2e057  adaptive/cells.jsonl
+6cc4cdcc27befaa09dcda098a44e08a35f66117e08a9f56236b89436a9fc6a93  adaptive/run.json

--- a/docs/benchmarks/runs/2026-08-26-openai-luna-high-pi-vs-openpi.md
+++ b/docs/benchmarks/runs/2026-08-26-openai-luna-high-pi-vs-openpi.md
@@ -4,7 +4,7 @@ created: 2026-08-26
 last-verified: 2026-08-26
 applies-to: OpenPI commit 2a69d3f32994da4123f1312b7fa84ef3d6119be1
 related-issues: "#197, #198"
-related-prs: none
+related-prs: "#199"
 supersedes: none
 provider-model: openai-codex/gpt-5.6-luna
 thinking: high

--- a/docs/benchmarks/runs/2026-08-26-openai-luna-high-pi-vs-openpi.md
+++ b/docs/benchmarks/runs/2026-08-26-openai-luna-high-pi-vs-openpi.md
@@ -1,0 +1,158 @@
+---
+status: validated
+created: 2026-08-26
+last-verified: 2026-08-26
+applies-to: OpenPI commit 2a69d3f32994da4123f1312b7fa84ef3d6119be1
+related-issues: "#197, #198"
+related-prs: none
+supersedes: none
+provider-model: openai-codex/gpt-5.6-luna
+thinking: high
+task-source: frozen local polyglot benchmark manifest at commit 7e0611e77b54e2dea774cdc0aa00cf9f7ed6144f
+verifier: hidden programmatic verifier injected after agent exit
+isolation: paired isolated cwd with post-exit verifier injection; provider credentials scrubbed before evidence capture
+failure-classification: artifact, protocol, infrastructure, provider, and verifier outcomes are reported separately
+sample-size: 5 tasks x 3 repeats x 2 arms x 2 discovery modes = 60 formal cells
+evidence-manifest: ../evidence/2026-08-26-openai-luna-high-manifest.sha256
+raw-evidence: operator-local archive ref openpi-luna-high-2026-08-26; not bulk-published
+archive-files: 610
+archive-logical-bytes: 23356879
+archive-manifest-sha256: 985bb48c919455b87638803daee1e201205353b4f07e7889c76bb557570bc1b7
+---
+
+# OpenAI GPT-5.6 Luna high: Bare Pi vs OpenPI
+
+## Scope and conclusion
+
+This is a controlled product experiment, not a public leaderboard submission. It compares a bare Pi session with Pi plus a pinned OpenPI package under the same model, task prompt, deadline, verifier and candidate boundary.
+
+The strongest positive signal is the `explicit` discovery mode: OpenPI passed 15/15 cells versus Bare Pi 10/15, while using 45.2% fewer recorded tokens, 33.6% lower recorded cost, and 27.7% less total wall time. The result supports continuing Pi-native, low-residency, explicit capability disclosure as the default direction.
+
+The `adaptive` mode is a separate control: hidden-verifier passes were tied at 12/15, but OpenPI used 149.2% more tokens, 46.5% more cost, and 43.0% more wall time. It remains opt-in until a task naturally requiring extra capabilities shows a verifiable benefit.
+
+## Frozen contract
+
+| Item | Value |
+| --- | --- |
+| Pi | `0.84.1` |
+| OpenPI | `2a69d3f32994da4123f1312b7fa84ef3d6119be1` |
+| OpenPI content SHA-256 | `6740901a9d2106d4ac2811ac4eec680fe8a0ac374d1acdfe1204d151322b5a3b` |
+| Provider/model | `openai-codex/gpt-5.6-luna` |
+| Thinking | `high` |
+| Cell deadline | 600 seconds |
+| Repeats | 3, counterbalanced `AB / BA / AB` |
+| Modes | `explicit`, `adaptive` |
+| Formal cells | 60 |
+| Execution | independent live provider sampling |
+| Candidate boundary | `candidate-tool-boundary-v6-paired-cwd` |
+
+The explicit pair's first provider payloads have identical canonical SHA-256 after removing the per-session `prompt_cache_key`; the cache key itself is session-specific. Adaptive intentionally has a different initial capability schema and is not request-identical.
+
+## Tasks
+
+| Task | What it exercises | Language/type |
+| --- | --- | --- |
+| Go Book Store | discount combinations and minimum order price | Go algorithmic task |
+| Python Bottle Song | strict lyric formatting and singular/plural boundaries | Python formatting task |
+| JavaScript Connect | Hex-board graph connectivity | JavaScript graph task |
+| Rust Nucleotide Codons | IUPAC codon expansion and amino-acid parsing | Rust API/parsing task |
+| Adaptive Policy Discovery | locating authoritative configuration and removing stale hardcoding | synthetic repository-policy probe |
+
+The first four are small Exercism/Aider-style polyglot exercises. The fifth is a synthetic capability-policy probe and is reported as part of this product experiment, not as evidence of general software-engineering coverage.
+
+## Explicit results
+
+| Metric | Bare Pi | OpenPI explicit | Relative change |
+| --- | ---: | ---: | ---: |
+| Hidden verifier pass | 10/15 | **15/15** | **+5 pass / +33.3pp** |
+| Total wall time | 1,934.145s | **1,398.807s** | **-27.7%** |
+| Cell wall median | 130.975s | **77.372s** | **-40.9%** |
+| Total recorded tokens | 906,076 | **496,186** | **-45.2%** |
+| Cell token median | 45,285 | **17,668** | **-61.0%** |
+| Cache read | 557,568 | **274,432** | **-50.8%** |
+| Reasoning tokens | 58,086 | **42,298** | **-27.2%** |
+| Parent turns | 144 | **112** | **-22.2%** |
+| Recorded cost | $0.161608 | **$0.107380** | **-33.6%** |
+| Capability calls | 0 | 0 | 0 |
+
+| Task | Bare Pi | OpenPI explicit |
+| --- | ---: | ---: |
+| Go Book Store | 1/3 | **3/3** |
+| Python Bottle Song | 1/3 | **3/3** |
+| JavaScript Connect | 2/3 | **3/3** |
+| Rust Nucleotide Codons | 3/3 | 3/3 |
+| Adaptive Policy Discovery | 3/3 | 3/3 |
+
+Across 15 paired comparisons, OpenPI won 5 quality comparisons, Bare Pi won 0, and 10 were ties. The two-sided exact sign test over the five non-ties is `p=0.0625`: a strong directional signal for this pilot, not a general significance claim. The paired median difference is wall `-5.171s` and tokens `-5,423`; total improvement also reflects reduced Bare Pi long-tail trajectories.
+
+No explicit OpenPI cell called `openpi_load_tools`, Subagent, or Workflow. The positive result therefore was not purchased by forcing extra agent calls or a larger model budget, and this run provides low-interference evidence for the explicit surface.
+
+## Adaptive control
+
+| Metric | Bare Pi | OpenPI adaptive | Relative change |
+| --- | ---: | ---: | ---: |
+| Protocol-valid pass | **12/15** | 11/15 | -1 pass / -6.7pp |
+| Hidden verifier pass | 12/15 | 12/15 | tied |
+| Total wall time | **1,387.968s** | 1,984.656s | +43.0% |
+| Total recorded tokens | **512,209** | 1,276,658 | +149.2% |
+| Cache read | **274,432** | 939,520 | +242.4% |
+| Parent turns | **109** | 181 | +66.1% |
+| Recorded cost | **$0.109469** | $0.160404 | +46.5% |
+| `openpi_load_tools` calls | 0 | 2 | +2 |
+
+The fixed initial gateway increment was 100 input tokens; most of the adaptive increase came from longer trajectories. One Rust cell attempted an unauthorized `subagent_spawn` after loading delegate capability; the runtime guard blocked it and recorded a violation receipt, so it remains an infrastructure/protocol failure rather than an ordinary task pass.
+
+## Evidence and archive
+
+The bounded, credential-free manifest is [`2026-08-26-openai-luna-high-manifest.sha256`](../evidence/2026-08-26-openai-luna-high-manifest.sha256). It identifies the explicit and adaptive `run.json`, `summary.json`, and `cells.jsonl` files by SHA-256.
+
+Complete raw ledgers, logs, Session JSONL, candidate snapshots and verifier output remain in the operator-local archive reference `openpi-luna-high-2026-08-26`. The two immutable result roots contain 610 files and 23,356,879 logical bytes. The SHA-256 of their complete, path-sorted `sha256  relative-path` manifest stream is `985bb48c919455b87638803daee1e201205353b4f07e7889c76bb557570bc1b7`. They are intentionally not bulk-published here. The archive contains no retained provider credentials or private settings; credential cleanup was verified before durable evidence collection.
+
+The run recorded the following implementation identities:
+
+- runner SHA-256: `7cd821cba20732279fa7800c7ecdbe69f4d31171f3783ea2cea52be4084e3d3e`;
+- runtime guard SHA-256: `7d9dd1ed0ab1b1869c7bed575e200e77b12dbb6b2e7ad52bc9920cb96a369a15`;
+- provider request fingerprint helper SHA-256: `05ab042d9e753112f9044decb1eaed03201becb085e6cd39bf4b04e86578c4bb`;
+- paired workspace SHA-256: `074923bdb02036fca366a04939d8f1f3f9dc01188eb5bc1643a191fd2a0503b0`.
+
+The archive identity, file count, logical size and complete-manifest receipt above let an operator prove which local evidence root was used without publishing private Session inventory. The six promoted summary, cell-ledger and run files are independently verifiable through the repository manifest.
+
+## Reproduction entry point
+
+Use the comparison contract in [`PI_OPENPI_BENCHMARK_PROTOCOL.md`](../PI_OPENPI_BENCHMARK_PROTOCOL.md) with the frozen identities above. The runner is the operator-local `scripts/benchmark-pi-openpi.mjs` whose SHA-256 is recorded above. From the OpenPI checkout used for the rerun, execute one command per discovery mode:
+
+```bash
+node scripts/benchmark-pi-openpi.mjs --out <new-explicit-result-root> --repeats 3 --timeout 600 --model openai-codex/gpt-5.6-luna --thinking high --tasks go-book-store,python-bottle-song,javascript-connect,rust-nucleotide-codons,adaptive-policy-discovery --openpi-capability-discovery explicit
+node scripts/benchmark-pi-openpi.mjs --out <new-adaptive-result-root> --repeats 3 --timeout 600 --model openai-codex/gpt-5.6-luna --thinking high --tasks go-book-store,python-bottle-song,javascript-connect,rust-nucleotide-codons,adaptive-policy-discovery --openpi-capability-discovery adaptive
+```
+
+The operator must supply scoped Pi auth/model configuration through the runner's documented flags; credentials never enter the record. A rerun must create a new dated archive and manifest, and must not overwrite this record or bulk-add ignored raw assets.
+
+## Failure classification
+
+- **Artifact:** hidden verifier outcome for the candidate work.
+- **Protocol:** deadline, cleanup, or required interaction contract.
+- **Infrastructure/provider:** route, authentication, host, or runner faults;
+  these are not model failures.
+- **Verifier:** post-exit verification or oracle faults; report separately from
+  artifact quality.
+- **Capability policy:** blocked unauthorized calls are recorded as protocol
+  evidence, not silently counted as task success.
+
+## Evidence boundary and limitations
+
+- The task set is small: four compact polyglot exercises plus one synthetic policy probe. It does not represent large, multi-module repository work, dependency migrations, long-lived maintenance, or real issue resolution.
+- Three repeats do not turn five task identities into a large independent sample. The result is a product-diagnostic pilot, not a general capability ranking.
+- The explicit pair uses independent live sampling. Identical semantic request payloads do not mean identical model outputs; the observed quality and efficiency difference cannot be assigned to one OpenPI mechanism from this run alone.
+- The run covers one provider route, one model and one thinking level. Cache-read volume is reported separately and is not treated as total-cost savings by itself.
+- No Subagent or Workflow adoption occurred in explicit mode, so this report does not establish orchestration payoff.
+- This is not an official Terminal-Bench, SWE-bench or DeepSWE submission.
+
+These limitations bound the claim without negating the observation: on this frozen multilingual pilot, OpenPI explicit produced the better realized result and lower measured resource use. The next validation slice is real repository-scale tasks with independently reported capability adoption and verifier outcomes.
+
+## Related records
+
+- Public summary and discussion: [Issue #197](https://github.com/tt-a1i/openpi/issues/197)
+- Knowledge/evidence publication contract: [Issue #198](https://github.com/tt-a1i/openpi/issues/198)
+- Comparison protocol: [`PI_OPENPI_BENCHMARK_PROTOCOL.md`](../PI_OPENPI_BENCHMARK_PROTOCOL.md)
+- Prior Benchmark ledger: [`README.md`](../README.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,13 @@
+# Decision records
+
+Decision records capture a project choice that should constrain future implementation. Keep the discussion and alternatives in the linked Issue or design record; keep the selected constraint, rationale and consequences here.
+
+## State
+
+- `draft`: proposed constraint, not yet adopted;
+- `validated`: adopted and checked against the current source boundary;
+- `superseded`: historical decision replaced by a later record.
+
+## Template
+
+Start from [`TEMPLATE.md`](TEMPLATE.md). Every adopted record links to its source Issue/PR and names the revision or version at which it was checked.

--- a/docs/decisions/TEMPLATE.md
+++ b/docs/decisions/TEMPLATE.md
@@ -1,0 +1,31 @@
+---
+status: draft
+created: YYYY-MM-DD
+last-verified: YYYY-MM-DD
+applies-to: <OpenPI version or source boundary>
+related-issues: "#<number>"
+related-prs: none
+supersedes: none
+---
+
+# Decision: <short name>
+
+## Context
+
+What problem or evidence required a durable choice?
+
+## Decision
+
+What constraint is now authoritative?
+
+## Alternatives considered
+
+What credible alternatives were evaluated, and why were they not selected?
+
+## Consequences
+
+What becomes easier, harder, required, or explicitly deferred?
+
+## Evidence and amendments
+
+Link the source Issue, PR, relevant code revision and later amendments. Do not silently rewrite the historical decision.

--- a/docs/research/CLAUDE_CODE_WORKFLOW_FANOUT_POLICY_2026-08-23.md
+++ b/docs/research/CLAUDE_CODE_WORKFLOW_FANOUT_POLICY_2026-08-23.md
@@ -1,8 +1,18 @@
+---
+status: validated
+created: 2026-08-23
+last-verified: 2026-08-23
+applies-to: Claude Code v2.1.219+ research snapshot and OpenPI design comparison
+related-issues: "#45, #84"
+related-prs: none
+supersedes: none
+---
+
 # Claude Code Dynamic Workflow 的编排规模与 OpenPI 借鉴原则
 
 > 日期：2026-08-23
 >
-> 范围：仅使用 Anthropic 官方 Claude Code 文档、官方 Agent SDK Cookbook 和官方示例；不推断未公开的 Runtime 内部算法。本文补充已有的 [Claude Code Workflow 生命周期研究](./CLAUDE_CODE_WORKFLOW_DESIGN_2026-08-23.md)，只回答“Claude 一次启动多少 Agent、为什么、谁决定、有哪些边界”。
+> 范围：仅使用 Anthropic 官方 Claude Code 文档、官方 Agent SDK Cookbook 和官方示例；不推断未公开的 Runtime 内部算法。本文补充已有的 [Claude Code Workflow 运行时合同访谈](./CLAUDE_CODE_WORKFLOW_RUNTIME_CONTRACT_2026-08-23.md)，只回答“Claude 一次启动多少 Agent、为什么、谁决定、有哪些边界”。
 
 ## 结论先行
 

--- a/docs/research/CLAUDE_CODE_WORKFLOW_FANOUT_POLICY_2026-08-23.md
+++ b/docs/research/CLAUDE_CODE_WORKFLOW_FANOUT_POLICY_2026-08-23.md
@@ -4,7 +4,7 @@ created: 2026-08-23
 last-verified: 2026-08-23
 applies-to: Claude Code v2.1.219+ research snapshot and OpenPI design comparison
 related-issues: "#45, #84"
-related-prs: none
+related-prs: "#199"
 supersedes: none
 ---
 

--- a/docs/research/OPENPI_KNOWLEDGE_ASSET_RESEARCH_2026-08-26.md
+++ b/docs/research/OPENPI_KNOWLEDGE_ASSET_RESEARCH_2026-08-26.md
@@ -1,0 +1,34 @@
+---
+status: validated
+created: 2026-08-26
+last-verified: 2026-08-26
+applies-to: OpenPI documentation and evidence workflow
+related-issues: "#45, #84, #197, #198"
+related-prs: none
+supersedes: none
+---
+
+# OpenPI knowledge assets and public evidence
+
+## Question
+
+Can GitHub Issues remain the only place for OpenPI's Benchmark results, research notes, design comparisons and publication records as the project iterates?
+
+## Observed facts
+
+- Issues currently carry discussion, implementation tracking, research, design proposals and Benchmark summaries in the same public timeline.
+- The repository already has a tracked design archive and tracked research records, while the local Benchmark harness, reports and run roots are protected by local ignore rules.
+- A Benchmark result needs more than a headline: the source revision, model/thinking setting, task and verifier identity, sample size, usage accounting, failure classification, limitations and raw-evidence identity determine what the result supports.
+- The latest Luna high result is useful as an internal product signal, but its complete ledgers and Sessions are local operator evidence rather than material to bulk-publish into Git.
+
+## Interpretation
+
+Issues are the right public entry point and collaboration surface, but they are a poor sole knowledge base. A versioned repository report gives a stable citation and code-review boundary; an external evidence archive preserves machine receipts without inflating Git history. A small root index lets both people and Agents choose the correct record without memorizing Issue numbers.
+
+## Recommendation
+
+Use Issues for questions and work tracking, repository documents for reusable conclusions, Decisions for durable constraints, Release notes for shipped behavior, and a separately identified archive for large or sensitive Benchmark evidence. Start forward-only and promote a small number of high-value records before considering broader curation.
+
+## Evidence boundary
+
+This is a repository-structure investigation, not a claim about runtime quality or Benchmark uplift. The linked Issues and repository state are the evidence for the workflow recommendation. Detailed Benchmark measurements remain in the dated Benchmark report and its operator-local receipts.

--- a/docs/research/OPENPI_KNOWLEDGE_ASSET_RESEARCH_2026-08-26.md
+++ b/docs/research/OPENPI_KNOWLEDGE_ASSET_RESEARCH_2026-08-26.md
@@ -4,7 +4,7 @@ created: 2026-08-26
 last-verified: 2026-08-26
 applies-to: OpenPI documentation and evidence workflow
 related-issues: "#45, #84, #197, #198"
-related-prs: none
+related-prs: "#199"
 supersedes: none
 ---
 

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,11 @@
+# Research index
+
+Research records preserve sourced investigation and the boundary between observation and interpretation. They are not a replacement for an Issue discussion or a product Decision.
+
+## Records
+
+- [`CLAUDE_CODE_WORKFLOW_FANOUT_POLICY_2026-08-23.md`](CLAUDE_CODE_WORKFLOW_FANOUT_POLICY_2026-08-23.md) — official-source and runtime-contract research on dynamic fan-out and bounded execution.
+- [`CLAUDE_CODE_WORKFLOW_RUNTIME_CONTRACT_2026-08-23.md`](CLAUDE_CODE_WORKFLOW_RUNTIME_CONTRACT_2026-08-23.md) — version-scoped Workflow contract interview and evidence boundary.
+- [`OPENPI_KNOWLEDGE_ASSET_RESEARCH_2026-08-26.md`](OPENPI_KNOWLEDGE_ASSET_RESEARCH_2026-08-26.md) — repository evidence for the Issue/document/evidence split introduced by #198.
+
+When an investigation changes an implementation choice, link its conclusion to a Decision record. When a source or runtime version changes, append an amendment or mark the record `superseded`; do not silently rewrite the historical claim.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
   },
   "scripts": {
     "prepublishOnly": "bun run check && bun run test",
-    "check": "bun run format:check && bun run lint && bun run typecheck",
+    "check": "bun run format:check && bun run lint && bun run typecheck && bun run docs:check",
+    "docs:check": "node scripts/docs-contract.mjs",
     "prepare": "node scripts/prepare-effect-tsgo.mjs",
     "format": "biome format --write .",
     "format:check": "biome format .",

--- a/scripts/docs-contract.mjs
+++ b/scripts/docs-contract.mjs
@@ -1,0 +1,262 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const errors = [];
+const trackedPaths = new Set(
+  execFileSync("git", ["ls-files"], { cwd: root, encoding: "utf8" })
+    .split("\n")
+    .filter(Boolean),
+);
+
+function absolute(relativePath) {
+  return path.join(root, relativePath);
+}
+
+function read(relativePath) {
+  const target = absolute(relativePath);
+  if (!existsSync(target)) {
+    errors.push(`missing required file: ${relativePath}`);
+    return "";
+  }
+  return readFileSync(target, "utf8");
+}
+
+function parseFrontmatter(relativePath, content) {
+  if (!content.startsWith("---\n")) {
+    errors.push(`missing frontmatter: ${relativePath}`);
+    return new Map();
+  }
+  const end = content.indexOf("\n---", 4);
+  if (end < 0) {
+    errors.push(`unterminated frontmatter: ${relativePath}`);
+    return new Map();
+  }
+  const fields = new Map();
+  for (const line of content.slice(4, end).split("\n")) {
+    const separator = line.indexOf(":");
+    if (separator <= 0) continue;
+    fields.set(
+      line.slice(0, separator).trim(),
+      line.slice(separator + 1).trim(),
+    );
+  }
+  return fields;
+}
+
+function requireFields(relativePath, fields, names) {
+  for (const name of names) {
+    if (!fields.get(name))
+      errors.push(`${relativePath}: missing metadata ${name}`);
+  }
+}
+
+function linkTargets(content) {
+  return new Set(
+    [...content.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)].map((match) =>
+      match[1].trim(),
+    ),
+  );
+}
+
+function isTrackedTarget(target) {
+  const relativePath = path.relative(root, target);
+  return (
+    trackedPaths.has(relativePath) ||
+    [...trackedPaths].some((candidate) =>
+      candidate.startsWith(`${relativePath}${path.sep}`),
+    )
+  );
+}
+
+function checkLinks(relativePath, content) {
+  const source = absolute(relativePath);
+  for (const target of linkTargets(content)) {
+    if (
+      !target ||
+      target.startsWith("#") ||
+      target.startsWith("http://") ||
+      target.startsWith("https://") ||
+      target.startsWith("mailto:")
+    ) {
+      continue;
+    }
+    const fileTarget = target.split("#", 1)[0].split("?", 1)[0];
+    const resolved = path.resolve(path.dirname(source), fileTarget);
+    if (!existsSync(resolved))
+      errors.push(`${relativePath}: broken link ${target}`);
+    else if (!isTrackedTarget(resolved))
+      errors.push(
+        `${relativePath}: link is not available in a clean checkout: ${target}`,
+      );
+  }
+}
+
+const navigation = [
+  {
+    index: "docs/README.md",
+    targets: [
+      { link: "research/", file: "docs/research/README.md" },
+      { link: "design/", file: "docs/design/README.md" },
+      { link: "decisions/", file: "docs/decisions/README.md" },
+      { link: "architecture/", file: "docs/architecture/README.md" },
+      { link: "benchmarks/", file: "docs/benchmarks/README.md" },
+    ],
+  },
+  {
+    index: "docs/research/README.md",
+    targets: [
+      {
+        link: "CLAUDE_CODE_WORKFLOW_FANOUT_POLICY_2026-08-23.md",
+        file: "docs/research/CLAUDE_CODE_WORKFLOW_FANOUT_POLICY_2026-08-23.md",
+      },
+      {
+        link: "OPENPI_KNOWLEDGE_ASSET_RESEARCH_2026-08-26.md",
+        file: "docs/research/OPENPI_KNOWLEDGE_ASSET_RESEARCH_2026-08-26.md",
+      },
+    ],
+  },
+  {
+    index: "docs/decisions/README.md",
+    targets: [{ link: "TEMPLATE.md", file: "docs/decisions/TEMPLATE.md" }],
+  },
+  {
+    index: "docs/benchmarks/README.md",
+    targets: [
+      {
+        link: "runs/2026-08-26-openai-luna-high-pi-vs-openpi.md",
+        file: "docs/benchmarks/runs/2026-08-26-openai-luna-high-pi-vs-openpi.md",
+      },
+      {
+        link: "BENCHMARK_RESULT_TEMPLATE.md",
+        file: "docs/benchmarks/BENCHMARK_RESULT_TEMPLATE.md",
+      },
+      {
+        link: "PI_OPENPI_BENCHMARK_PROTOCOL.md",
+        file: "docs/benchmarks/PI_OPENPI_BENCHMARK_PROTOCOL.md",
+      },
+      {
+        link: "evidence/2026-08-26-openai-luna-high-manifest.sha256",
+        file: "docs/benchmarks/evidence/2026-08-26-openai-luna-high-manifest.sha256",
+      },
+    ],
+  },
+];
+
+const canonicalFiles = [
+  ...new Set(
+    navigation.flatMap(({ index, targets }) => [
+      index,
+      ...targets.map(({ file }) => file),
+    ]),
+  ),
+];
+
+for (const { index, targets } of navigation) {
+  const links = linkTargets(read(index));
+  for (const { link } of targets) {
+    if (!links.has(link))
+      errors.push(`${index}: canonical target is not reachable: ${link}`);
+  }
+}
+
+const privateValuePattern =
+  /\/Users\/|\/private\/var\/|(?:^|[\s"'`])(?:sk-|ghp-)[A-Za-z0-9]|Bearer\s+[A-Za-z0-9]/im;
+for (const relativePath of canonicalFiles) {
+  const content = read(relativePath);
+  if (!trackedPaths.has(relativePath))
+    errors.push(`${relativePath}: canonical file is not tracked by Git`);
+  if (content) checkLinks(relativePath, content);
+  if (privateValuePattern.test(content))
+    errors.push(
+      `${relativePath}: contains a private path or credential-like value`,
+    );
+}
+
+const governedRecords = [
+  "docs/research/OPENPI_KNOWLEDGE_ASSET_RESEARCH_2026-08-26.md",
+  "docs/research/CLAUDE_CODE_WORKFLOW_FANOUT_POLICY_2026-08-23.md",
+  "docs/benchmarks/runs/2026-08-26-openai-luna-high-pi-vs-openpi.md",
+];
+const allowedStatuses = new Set(["draft", "validated", "superseded"]);
+for (const relativePath of governedRecords) {
+  const fields = parseFrontmatter(relativePath, read(relativePath));
+  requireFields(relativePath, fields, [
+    "status",
+    "created",
+    "last-verified",
+    "applies-to",
+    "related-issues",
+    "related-prs",
+    "supersedes",
+  ]);
+  if (!allowedStatuses.has(fields.get("status")))
+    errors.push(`${relativePath}: invalid document status`);
+  for (const field of ["created", "last-verified"]) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(fields.get(field) ?? ""))
+      errors.push(`${relativePath}: invalid ${field} date`);
+  }
+}
+
+const reportPath =
+  "docs/benchmarks/runs/2026-08-26-openai-luna-high-pi-vs-openpi.md";
+const report = read(reportPath);
+const reportFields = parseFrontmatter(reportPath, report);
+requireFields(reportPath, reportFields, [
+  "provider-model",
+  "thinking",
+  "task-source",
+  "verifier",
+  "sample-size",
+  "isolation",
+  "failure-classification",
+  "evidence-manifest",
+  "raw-evidence",
+  "archive-files",
+  "archive-logical-bytes",
+  "archive-manifest-sha256",
+]);
+for (const heading of [
+  "## Scope and conclusion",
+  "## Frozen contract",
+  "## Evidence and archive",
+  "## Reproduction entry point",
+  "## Failure classification",
+  "## Evidence boundary and limitations",
+]) {
+  if (!report.includes(heading))
+    errors.push(`${reportPath}: missing section ${heading}`);
+}
+
+const manifest = read(
+  "docs/benchmarks/evidence/2026-08-26-openai-luna-high-manifest.sha256",
+);
+const manifestLines = manifest
+  .split("\n")
+  .filter((line) => line && !line.startsWith("#"));
+if (
+  manifestLines.length !== 6 ||
+  manifestLines.some((line) => !/^[a-f0-9]{64} {2}\S+$/.test(line))
+) {
+  errors.push("Benchmark evidence manifest must contain six SHA-256 entries");
+}
+
+const agents = read("AGENTS.md");
+if (
+  !agents.includes("### Knowledge and evidence") ||
+  !agents.includes("docs/README.md")
+) {
+  errors.push(
+    "AGENTS.md: missing compact Knowledge and evidence contract pointer",
+  );
+}
+
+if (errors.length > 0) {
+  console.error(errors.map((error) => `- ${error}`).join("\n"));
+  process.exitCode = 1;
+} else {
+  console.log(
+    `docs-contract: passed (${canonicalFiles.length} canonical files, ${manifestLines.length} evidence entries)`,
+  );
+}


### PR DESCRIPTION
## Summary

- establish docs/ as the canonical index for reusable research, design, Decisions, architecture, and formal Benchmark records
- promote the Luna high Pi/OpenPI result with a sanitized protocol, bounded evidence manifest, archive receipt, limitations, and rerun entry point
- add a compact cross-Agent evidence contract and a tracked-file-aware documentation validator
- simplify the Benchmark index so dated records, rather than README prose, remain the single source for run facts and decisions

## Validation

- bun run docs:check
- bun run lint
- bun run typecheck (12 pre-existing Effect warnings)
- bun run test (880 Node tests and 30 Vitest tests)
- Biome format check over all Git-tracked JS/TS/JSON files
- git diff --check

The broad local bun run check still stops at two preserved ignored Benchmark harness files that predate this change. They were intentionally not reformatted or staged; the tracked candidate set passes formatting.

Closes #198