### PR TITLE
fix(workflows): reject lossy oversized args

### DIFF
--- a/extensions/workflows/execute.e2e.test.ts
+++ b/extensions/workflows/execute.e2e.test.ts
@@ -331,6 +331,49 @@ test("foreground run without agents returns the result and persists artifacts", 
   assert.equal(mine[0]!.status, "completed");
 });
 
+test("oversized workflow args fail before child sessions or journals are created", async () => {
+  let sessionCreations = 0;
+  __setWorkflowTestAgentSessionFactory(async () => {
+    sessionCreations++;
+    return { session: fakeAgentSession("unexpected child session") };
+  });
+
+  const script =
+    'export const meta = { name: "oversized-workflow-args" };\nreturn 1;';
+  const args = [JSON.stringify("x".repeat(300_000)), "x".repeat(300_000)];
+
+  try {
+    for (const rawArgs of args) {
+      const launch = (await workflow.execute(
+        "e2e-oversized-workflow-args",
+        { script, args: rawArgs, background: true },
+        undefined,
+        undefined,
+        ctx,
+      )) as { details: { runId?: unknown } };
+      const runId = launch.details.runId;
+      await waitFor(
+        () => readWorkflowJson(runId).status === "failed",
+        "oversized workflow args failure",
+      );
+
+      const runDir = runDirFor(runId);
+      const persisted = readWorkflowJson(runId);
+      assert.match(
+        String(persisted.error),
+        /Workflow args exceed the .* IPC limit/,
+      );
+      assert.deepEqual(persisted.agents, []);
+      assert.equal(existsSync(join(runDir, "journal.json")), false);
+      assert.equal(readFileSync(join(runDir, "args.json"), "utf8"), rawArgs);
+    }
+  } finally {
+    __setWorkflowTestAgentSessionFactory(undefined);
+  }
+
+  assert.equal(sessionCreations, 0);
+});
+
 test("background runs deliver a follow-up that triggers a turn only when idle", async () => {
   sentMessages.length = 0;
 

--- a/extensions/workflows/sandbox.test.ts
+++ b/extensions/workflows/sandbox.test.ts
@@ -62,6 +62,101 @@ test("sandbox exposes only workflow capabilities and validates results", async (
   assert.equal(peak, 2);
 });
 
+test("oversized workflow args fail closed before executing the script", async () => {
+  let agentCalls = 0;
+  const oversized = Array.from({ length: 3_000 }, () => "x".repeat(100));
+
+  await assert.rejects(
+    run(
+      `
+        const response = await agent("must not run");
+        return { response, args };
+      `,
+      {
+        args: oversized,
+        onAgent: async () => {
+          agentCalls++;
+          return { ok: true, output: "unexpected" };
+        },
+      },
+    ),
+    /Workflow args exceed the .* IPC limit/,
+  );
+  assert.equal(agentCalls, 0);
+});
+
+test("oversized raw string args fail closed instead of being truncated", async () => {
+  await assert.rejects(
+    run(`return args.length;`, { args: "x".repeat(300_000) }),
+    /Workflow args exceed the .* IPC limit/,
+  );
+});
+
+test("workflow args preserve large strings that fit the IPC budget", async () => {
+  const value = "x".repeat(100_000);
+  const result = await run(`return args.value.length;`, { args: { value } });
+
+  assert.equal(result, value.length);
+});
+
+test("workflow args fail closed on depth and node limits", async () => {
+  let tooDeep: Record<string, unknown> = { leaf: true };
+  for (let depth = 0; depth < 17; depth++) tooDeep = { next: tooDeep };
+
+  await assert.rejects(
+    run(`return args;`, { args: tooDeep }),
+    /Workflow args exceed the .*depth limit/,
+  );
+  await assert.rejects(
+    run(`return args;`, { args: Array.from({ length: 10_000 }, () => 1) }),
+    /Workflow args exceed the .*nodes limit/,
+  );
+});
+
+test("workflow args accept exact byte, node, and depth limits", async () => {
+  const maxBytes = 256 * 1024;
+  const envelopeOverhead = Buffer.byteLength(
+    JSON.stringify({ defined: true, value: "" }),
+    "utf8",
+  );
+  const exactBytes = "x".repeat(maxBytes - envelopeOverhead);
+  assert.equal(
+    await run(`return args.length;`, { args: exactBytes }),
+    exactBytes.length,
+  );
+  await assert.rejects(
+    run(`return args.length;`, { args: `${exactBytes}x` }),
+    /bytes limit/,
+  );
+
+  assert.equal(
+    await run(`return args.length;`, {
+      args: Array.from({ length: 9_997 }, () => 1),
+    }),
+    9_997,
+  );
+  await assert.rejects(
+    run(`return args.length;`, {
+      args: Array.from({ length: 9_998 }, () => 1),
+    }),
+    /nodes limit/,
+  );
+
+  let exactDepth: Record<string, unknown> = { leaf: true };
+  for (let depth = 0; depth < 14; depth++) exactDepth = { next: exactDepth };
+  assert.equal(
+    await run(
+      `
+        let current = args;
+        for (let depth = 0; depth < 14; depth++) current = current.next;
+        return current.leaf;
+      `,
+      { args: exactDepth },
+    ),
+    true,
+  );
+});
+
 test("sandbox result serialization handles cycles and bigint", async () => {
   const result = await run(`
     const value = { count: 7n };

--- a/extensions/workflows/sandbox.ts
+++ b/extensions/workflows/sandbox.ts
@@ -3,7 +3,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { MAX_WORKFLOW_AGENT_CALLS } from "../shared/setup-config.ts";
-import { safeStringify, toSerializable } from "./serialization.ts";
+import { encodeCompleteJson, toSerializable } from "./serialization.ts";
 
 const MAX_SOURCE_BYTES = 512 * 1024;
 const MAX_ARGS_BYTES = 256 * 1024;
@@ -147,13 +147,23 @@ export function runWorkflowSandbox(options: RunWorkflowSandboxOptions) {
       ),
     );
 
-  const argsJson = safeStringify(
+  const encodedArgs = encodeCompleteJson(
     { defined: options.args !== undefined, value: options.args },
-    { maxBytes: MAX_ARGS_BYTES, maxDepth: 16, maxNodes: 10_000 },
+    {
+      maxBytes: MAX_ARGS_BYTES,
+      maxDepth: 16,
+      maxNodes: 10_000,
+      maxStringBytes: MAX_ARGS_BYTES,
+    },
   );
-  if (byteLength(argsJson) > MAX_ARGS_BYTES) {
-    return Promise.reject(new Error("Workflow args exceed the IPC limit"));
+  if (!encodedArgs.ok) {
+    return Promise.reject(
+      new Error(
+        `Workflow args exceed the ${MAX_ARGS_BYTES}-byte IPC limit (${encodedArgs.limit} limit at ${encodedArgs.path})`,
+      ),
+    );
   }
+  const argsJson = encodedArgs.json;
 
   return new Promise<unknown>((resolve, reject) => {
     const workerPath = fileURLToPath(


### PR DESCRIPTION
Closes #175

## Summary
- Replace lossy `safeStringify` with complete, bounded argument encoding before the sandbox child starts.
- Fail closed for byte, string, node, and depth limits with a bounded error that identifies the limit and path.
- Preserve large strings that fit the IPC budget instead of silently truncating them.
- Add sandbox and workflow-tool regression coverage for valid JSON strings, raw strings, exact boundaries, and the no-child/no-journal failure path.

## Validation
- `bun run check` (run with Bun 1.3.14; existing Effect type-safety warnings only)
- Node tests: 886 passed
- Vitest: 30 passed
- Focused sandbox tests: 27 passed

Authoritative workflow args are now encoded with `encodeCompleteJson`; lossy projections remain reserved for display/output paths.