### PR TITLE
fix(setup): reject oversized post-edit commands

### DIFF
--- a/extensions/shared/setup-config.ts
+++ b/extensions/shared/setup-config.ts
@@ -513,9 +513,9 @@ export function parseSetupConfig(value: unknown): MyPiSetupConfig {
 /** An empty or invalid value disables the post-edit command (the safe default). */
 function parsePostEditCommand(value: unknown) {
   if (!isRecord(value)) return "";
-  return typeof value.command === "string"
-    ? value.command.trim().slice(0, POST_EDIT_COMMAND_MAX_CHARS)
-    : "";
+  if (typeof value.command !== "string") return "";
+  const command = value.command.trim();
+  return command.length <= POST_EDIT_COMMAND_MAX_CHARS ? command : "";
 }
 
 export function hasSavedSetupConfig() {
@@ -989,7 +989,7 @@ export function formatSetupConfig(config = loadSetupConfig()) {
     `Subagent results: ${config.ui.subagentResultDisplay === "full" ? "full by default" : "compact status summary (Ctrl+O expands full output)"}`,
     `Bash operations: ${config.ui.bashToolDisplay === "full" ? "expanded by default" : "one-line activity summary (Ctrl+O restores native evidence)"}`,
     `Write/Edit operations: ${config.ui.fileMutationDisplay === "full" ? "expanded by default" : "one-line activity summary (Ctrl+O restores native evidence)"}`,
-    `Post-edit command: ${config.postEdit.command ? config.postEdit.command : "off"}`,
+    `Post-edit command: ${config.postEdit.command ? "configured" : "off"}`,
     `Agent role models (Subagents + Workflows): ${SUBAGENT_ROLE_NAMES.map((role) => `${role} ${config.subagents.roleModels[role] ? `${config.subagents.roleModels[role].provider}/${config.subagents.roleModels[role].model}` : "inherit"}`).join(" · ")}`,
   ].join("\n");
 }

--- a/tests/extensions/shared/setup-config.test.ts
+++ b/tests/extensions/shared/setup-config.test.ts
@@ -23,6 +23,7 @@ const {
   DEFAULT_SETUP_CONFIG,
   FOOTER_PRESET_DEFINITIONS,
   formatSetupConfig,
+  POST_EDIT_COMMAND_MAX_CHARS,
   SETUP_CONFIG_PATH,
   loadSetupConfig,
   parseSetupConfig,
@@ -524,7 +525,7 @@ test("legacy model-free recaps are explicitly migrated to disabled suggestions",
   assert.deepEqual(stored.suggestions, { enabled: false });
 });
 
-test("the post-edit command is off by default, trimmed, and length-bounded", () => {
+test("the post-edit command is off by default, trimmed, and fails closed when oversized", () => {
   // Off by default: nothing executes until the user configures a command.
   assert.equal(DEFAULT_SETUP_CONFIG.postEdit.command, "");
 
@@ -538,9 +539,38 @@ test("the post-edit command is off by default, trimmed, and length-bounded", () 
   writeFileSync(SETUP_CONFIG_PATH, JSON.stringify({ postEdit: 42 }));
   assert.equal(loadSetupConfig().postEdit.command, "");
 
+  const maximumLengthCommand = "x".repeat(POST_EDIT_COMMAND_MAX_CHARS);
+  writeFileSync(
+    SETUP_CONFIG_PATH,
+    JSON.stringify({ postEdit: { command: maximumLengthCommand } }),
+  );
+  assert.equal(loadSetupConfig().postEdit.command, maximumLengthCommand);
+
+  writeFileSync(
+    SETUP_CONFIG_PATH,
+    JSON.stringify({
+      postEdit: { command: "x".repeat(POST_EDIT_COMMAND_MAX_CHARS + 1) },
+    }),
+  );
+  assert.equal(loadSetupConfig().postEdit.command, "");
+});
+
+test("an oversized stored post-edit command is rejected and reported", async () => {
   writeFileSync(
     SETUP_CONFIG_PATH,
     JSON.stringify({ postEdit: { command: "x".repeat(900) } }),
   );
-  assert.equal(loadSetupConfig().postEdit.command.length, 500);
+
+  const { config, replaced } = await updateSetupConfig((current) => current);
+
+  assert.equal(config.postEdit.command, "");
+  assert.deepEqual(replaced, ["postEdit.command"]);
+});
+
+test("setup status reports post-edit configuration without exposing the command", () => {
+  const command = "PRIVATE_TOKEN=secret npm run format";
+  const status = formatSetupConfig(parseSetupConfig({ postEdit: { command } }));
+
+  assert.match(status, /Post-edit command: configured/);
+  assert.doesNotMatch(status, new RegExp(command));
 });


### PR DESCRIPTION
## 背景

关联 #158。

当前 Post-edit command 超过 500 个字符时会被截断后继续执行，可能改变 Shell 命令语义；Setup 状态还会完整回显命令内容。

## 改动

- 超过 500 个字符的命令直接禁用，不再截断执行。
- 500 个字符以内的命令保持原有行为。
- Setup 状态改为仅显示 `configured` 或 `off`。
- 增加超长命令、边界长度和命令脱敏测试。

## 验证

- `bun run check` 通过。
- `#158` 相关测试通过。

Closes #158