### PR TITLE
fix(workflows): bound stalled provider turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ return agent("Synthesize the verified findings", {
 | `pipeline()` | 每个 item 完成上阶段后立即进入下一阶段；多阶段 fan-out 的默认选择          |
 | `parallel()` | 并发 barrier；只在下一阶段确实需要全部结果时使用                           |
 
-Workflow 默认并发 8 个 Agent，单次最多 128 次调用；可配置到 64 和 1024。前台运行可实时查看，后台运行完成后自动回传；`/workflows` 展示阶段、Agent、Transcript、Graph、用量与产物。
+Workflow 默认并发 8 个 Agent，单次最多 128 次调用；可配置到 64 和 1024。前台运行可实时查看，后台运行完成后自动回传；`/workflows` 展示阶段、Agent、Transcript、Graph、用量与产物。每个 Child Provider turn 必须在 45 秒内产生模型可见的 thinking、text、tool call 或完成事件，并在持续输出时按进展续期；空 stream start 与 transport heartbeat 不算进展。用户显式配置了更宽的 Pi `httpIdleTimeoutMs` 时沿用该上限。超时会 abort 当前 Child、保留已有 Transcript/usage/evidence，并让 sibling 与后续阶段继续结算。
 
 ---
 

--- a/extensions/subagents/src/manager.ts
+++ b/extensions/subagents/src/manager.ts
@@ -64,7 +64,7 @@ const ENTRY_CLOSE_TIMEOUT_MS = 10_000;
  * First-response watchdog: a run whose provider accepts the request but
  * never emits an assistant event is settled as a failure so it cannot
  * occupy a concurrency slot forever. Matches the workflow runner's
- * FIRST_RESPONSE_TIMEOUT_MS (extensions/workflows/runner.ts).
+ * MODEL_PROGRESS_TIMEOUT_MS (extensions/workflows/runner.ts).
  */
 export const FIRST_RESPONSE_TIMEOUT_MS = 45_000;
 const ERROR_TEXT_MAX_LENGTH = 4_096;

--- a/extensions/workflows/runner.ts
+++ b/extensions/workflows/runner.ts
@@ -873,7 +873,6 @@ export async function runAgent(
       markModelProgress = watchdog.markProgress;
       completeModelTurn = watchdog.completeTurn;
       cancelModelProgressWatchdog = watchdog.cancel;
-      watchdog.armTurn();
       await Promise.race([
         watchdog.waitFor(
           childSession.prompt(buildWorkflowAgentPrompt(options.prompt)),

--- a/extensions/workflows/runner.ts
+++ b/extensions/workflows/runner.ts
@@ -46,7 +46,7 @@ import { safeStringify, truncateUtf8 } from "./serialization.ts";
 import { bindWorkflowToolRenderer } from "./tool-renderer.ts";
 
 const AGENT_OUTPUT_MAX_BYTES = 64 * 1024;
-export const FIRST_RESPONSE_TIMEOUT_MS = 45_000;
+export const MODEL_PROGRESS_TIMEOUT_MS = 45_000;
 const TRANSCRIPT_ENTRY_MAX_BYTES = 16 * 1024;
 const TRANSCRIPT_TOTAL_MAX_BYTES = 256 * 1024;
 const TRANSCRIPT_MAX_ENTRIES = 200;
@@ -110,8 +110,8 @@ export interface RunAgentOptions {
   replayFilesystemBoundary?: ReplayFilesystemBoundaryOptions;
   /** Test-only override for the per-tool execution timeout. */
   toolCallTimeoutMs?: number;
-  /** Test-only override for the first assistant response-event timeout. */
-  firstResponseTimeoutMs?: number;
+  /** Test-only override for the per-provider-turn model-progress timeout. */
+  modelProgressTimeoutMs?: number;
   /** Test-only override for the end-to-end abort/shutdown deadline. */
   shutdownTimeoutMs?: number;
   /** Test seam for lifecycle races; production always uses createAgentSession. */
@@ -461,35 +461,82 @@ function formatTimeout(timeoutMs: number) {
     : `${timeoutMs} ms`;
 }
 
-/** Abort a provider call that opens but never emits its first assistant event. */
-export function createFirstResponseWatchdog(
-  onTimeout: () => Promise<unknown>,
+export function resolveModelProgressTimeoutMs(
+  settingsManager: SettingsManager,
+  override?: number,
+) {
+  if (override !== undefined) return override;
+  const configured =
+    settingsManager.getProjectSettings().httpIdleTimeoutMs ??
+    settingsManager.getGlobalSettings().httpIdleTimeoutMs;
+  return typeof configured === "number" && Number.isFinite(configured)
+    ? Math.max(MODEL_PROGRESS_TIMEOUT_MS, Math.floor(configured))
+    : MODEL_PROGRESS_TIMEOUT_MS;
+}
+
+/** Abort any provider turn that stops producing model-visible progress. */
+export function createModelProgressWatchdog(
+  onTimeout: (error: Error) => Promise<unknown>,
   options: { timeoutMs?: number; model?: string } = {},
 ) {
-  const timeoutMs = options.timeoutMs ?? FIRST_RESPONSE_TIMEOUT_MS;
+  const timeoutMs = options.timeoutMs ?? MODEL_PROGRESS_TIMEOUT_MS;
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let activeTurn = false;
+  let closed = false;
+  let rejectTimeout!: (error: Error) => void;
   const timeout = new Promise<never>((_resolve, reject) => {
+    rejectTimeout = reject;
+  });
+
+  const clear = () => {
+    if (timer) clearTimeout(timer);
+    timer = undefined;
+  };
+  const schedule = () => {
+    clear();
+    if (!activeTurn || closed) return;
     // This timer owns the awaited watchdog outcome. Keep it referenced so a
     // short-lived Node 22 process cannot exit with the promise still pending.
     timer = setTimeout(() => {
       timer = undefined;
+      activeTurn = false;
+      closed = true;
       const model = options.model ? ` for ${options.model}` : "";
-      reject(
-        new Error(
-          `Agent received no assistant response event${model} within ${formatTimeout(timeoutMs)}; the provider request may be stalled. Retry the workflow.`,
-        ),
+      const error = new Error(
+        `Agent provider turn${model} produced no model-visible progress for ${formatTimeout(timeoutMs)}; the provider request may be stalled. Retry the workflow.`,
       );
-      void onTimeout().catch(() => {});
+      rejectTimeout(error);
+      try {
+        void onTimeout(error).catch(() => {});
+      } catch {
+        // The timeout result remains authoritative even if abort throws before
+        // returning its promise; bounded shutdown below gets another chance.
+      }
     }, timeoutMs);
-  });
-
+  };
+  const armTurn = () => {
+    if (closed) return;
+    activeTurn = true;
+    schedule();
+  };
+  const markProgress = () => {
+    if (!activeTurn || closed) return;
+    schedule();
+  };
+  const completeTurn = () => {
+    activeTurn = false;
+    clear();
+  };
   const cancel = () => {
-    if (timer) clearTimeout(timer);
-    timer = undefined;
+    closed = true;
+    activeTurn = false;
+    clear();
   };
 
   return {
-    markResponse: cancel,
+    armTurn,
+    markProgress,
+    completeTurn,
     cancel,
     async waitFor<T>(operation: Promise<T>) {
       try {
@@ -501,13 +548,24 @@ export function createFirstResponseWatchdog(
   };
 }
 
-function isAssistantResponseEvent(event: AgentSessionEvent) {
-  return (
-    (event.type === "message_start" ||
-      event.type === "message_update" ||
-      event.type === "message_end") &&
-    event.message.role === "assistant"
-  );
+function isModelVisibleProgress(event: AgentSessionEvent) {
+  if (event.type !== "message_update" || event.message.role !== "assistant") {
+    return false;
+  }
+  // Raw transport heartbeats never become AgentSession events. Empty stream,
+  // text, and thinking starts likewise cannot keep a provider turn alive.
+  const update = event.assistantMessageEvent;
+  if (
+    update.type === "text_delta" ||
+    update.type === "thinking_delta" ||
+    update.type === "toolcall_delta"
+  ) {
+    return update.delta.length > 0;
+  }
+  if (update.type === "text_end" || update.type === "thinking_end") {
+    return update.content.length > 0;
+  }
+  return update.type === "toolcall_start" || update.type === "toolcall_end";
 }
 
 export async function runAgent(
@@ -519,6 +577,8 @@ export async function runAgent(
   let session: AgentSession | undefined;
   let unsubscribeToolGuards: (() => void) | undefined;
   let aborted = false;
+  let terminalCause: "abort" | "model-progress-timeout" | undefined;
+  let modelProgressTimeoutMessage: string | undefined;
   let abortOperation: Promise<unknown> | undefined;
   let rejectForAbort: ((error: Error) => void) | undefined;
   const abortRace = new Promise<never>((_resolve, reject) => {
@@ -534,6 +594,7 @@ export async function runAgent(
   const onAbort = () => {
     if (aborted) return;
     aborted = true;
+    terminalCause ??= "abort";
     if (session) {
       try {
         abortOperation ??= session.abort();
@@ -721,10 +782,13 @@ export async function runAgent(
     }
   };
 
-  let markFirstResponse = () => {};
-  let cancelFirstResponseWatchdog = () => {};
+  let armModelProgress = () => {};
+  let markModelProgress = () => {};
+  let completeModelTurn = () => {};
+  let cancelModelProgressWatchdog = () => {};
   const unsubscribe = childSession.subscribe((event) => {
     if (settled) return;
+    if (event.type === "turn_start") armModelProgress();
     if (event.type === "tool_execution_start") {
       toolRenderer.start(
         event.toolCallId,
@@ -747,7 +811,10 @@ export async function runAgent(
         event.isError,
       );
     }
-    if (isAssistantResponseEvent(event)) markFirstResponse();
+    if (isModelVisibleProgress(event)) markModelProgress();
+    if (event.type === "message_end" && event.message.role === "assistant") {
+      completeModelTurn();
+    }
     if (event.type === "message_end") {
       assistantSettlement = observeAssistantSettlement(
         assistantSettlement,
@@ -784,19 +851,29 @@ export async function runAgent(
   let cleanupErrors: string[] = [];
   try {
     if (!aborted) {
-      const watchdog = createFirstResponseWatchdog(
-        () => {
+      const watchdog = createModelProgressWatchdog(
+        (error) => {
+          terminalCause ??= "model-progress-timeout";
+          if (terminalCause === "model-progress-timeout") {
+            modelProgressTimeoutMessage ??= error.message;
+          }
           abortOperation ??= childSession.abort();
           void abortOperation.catch(() => {});
           return abortOperation;
         },
         {
-          timeoutMs: options.firstResponseTimeoutMs,
+          timeoutMs: resolveModelProgressTimeoutMs(
+            options.settingsManager,
+            options.modelProgressTimeoutMs,
+          ),
           model: modelId,
         },
       );
-      markFirstResponse = watchdog.markResponse;
-      cancelFirstResponseWatchdog = watchdog.cancel;
+      armModelProgress = watchdog.armTurn;
+      markModelProgress = watchdog.markProgress;
+      completeModelTurn = watchdog.completeTurn;
+      cancelModelProgressWatchdog = watchdog.cancel;
+      watchdog.armTurn();
       await Promise.race([
         watchdog.waitFor(
           childSession.prompt(buildWorkflowAgentPrompt(options.prompt)),
@@ -807,7 +884,7 @@ export async function runAgent(
   } catch (error) {
     promptErrorMessage = errorText(error);
   } finally {
-    cancelFirstResponseWatchdog();
+    cancelModelProgressWatchdog();
     options.signal?.removeEventListener("abort", onAbort);
     settled = true;
     unsubscribe();
@@ -834,7 +911,11 @@ export async function runAgent(
       ? `Cleanup failed: ${cleanupErrors.join("; ")}`
       : undefined;
 
-  if (aborted || assistantSettlement?.stopReason === "aborted") {
+  if (
+    terminalCause === "abort" ||
+    (terminalCause === undefined &&
+      assistantSettlement?.stopReason === "aborted")
+  ) {
     return {
       ok: false,
       output,
@@ -851,7 +932,9 @@ export async function runAgent(
   }
 
   const failureMessage =
-    agentFailureMessage(assistantSettlement, promptErrorMessage) ??
+    (terminalCause === "model-progress-timeout"
+      ? modelProgressTimeoutMessage
+      : agentFailureMessage(assistantSettlement, promptErrorMessage)) ??
     cleanupError;
   if (failureMessage !== undefined) {
     return {

--- a/tests/extensions/workflows/runner.test.ts
+++ b/tests/extensions/workflows/runner.test.ts
@@ -605,6 +605,26 @@ test("cancel during a hanging tool ignores late events and progress writers", as
   prompt.resolve();
 });
 
+test("slow preflight does not arm the provider-turn watchdog", async () => {
+  let run = async () => {};
+  const harness = runnerHarness({ prompt: () => run() });
+  run = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const completed = assistantTextMessage("completed after preflight");
+    harness.emit({ type: "turn_start" });
+    harness.messages.push(completed);
+    harness.emit({ type: "message_end", message: completed });
+  };
+
+  const outcome = await runHarnessAgent(harness, {
+    modelProgressTimeoutMs: 10,
+  });
+
+  assert.equal(outcome.ok, true);
+  assert.equal(outcome.output, "completed after preflight");
+  assert.equal(harness.aborts(), 0);
+});
+
 test("a later provider turn with no visible progress is aborted and cannot become success", async () => {
   const prompt = deferred<void>();
   let emitAbort = () => {};

--- a/tests/extensions/workflows/runner.test.ts
+++ b/tests/extensions/workflows/runner.test.ts
@@ -15,10 +15,11 @@ import {
 import { Type } from "typebox";
 import {
   agentFailureMessage,
-  createFirstResponseWatchdog,
+  createModelProgressWatchdog,
   guardWorkflowChildTools,
   observeAssistantSettlement,
   recordToolExecutionTiming,
+  resolveModelProgressTimeoutMs,
   runAgent,
   type ToolExecutionTiming,
   transcriptFromMessages,
@@ -129,7 +130,7 @@ function runHarnessAgent(
     prompt: "fixture",
     cwd: process.cwd(),
     loader: {} as Parameters<typeof runAgent>[0]["loader"],
-    settingsManager: {} as Parameters<typeof runAgent>[0]["settingsManager"],
+    settingsManager: SettingsManager.inMemory(),
     modelRegistry: { find: () => undefined } as unknown as Parameters<
       typeof runAgent
     >[0]["modelRegistry"],
@@ -604,18 +605,126 @@ test("cancel during a hanging tool ignores late events and progress writers", as
   prompt.resolve();
 });
 
-test("late prompt completion after first-response timeout cannot become success", async () => {
+test("a later provider turn with no visible progress is aborted and cannot become success", async () => {
   const prompt = deferred<void>();
-  const harness = runnerHarness({ prompt: () => prompt.promise });
-  const outcome = await runHarnessAgent(harness, {
-    firstResponseTimeoutMs: 5,
+  let emitAbort = () => {};
+  const harness = runnerHarness({
+    prompt: () => prompt.promise,
+    abort: async () => emitAbort(),
+  });
+  emitAbort = () => {
+    const aborted = {
+      ...assistantTextMessage(""),
+      content: [],
+      stopReason: "aborted" as const,
+      errorMessage: "Request was aborted",
+    };
+    harness.messages.push(aborted);
+    harness.emit({ type: "message_end", message: aborted });
+  };
+  const outcomePromise = runHarnessAgent(harness, {
+    modelProgressTimeoutMs: 10,
     shutdownTimeoutMs: 20,
   });
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const first = {
+    ...assistantTextMessage("first turn evidence"),
+    content: [
+      { type: "text" as const, text: "first turn evidence" },
+      {
+        type: "toolCall" as const,
+        id: "read-1",
+        name: "read",
+        arguments: { path: "fixture.txt" },
+      },
+    ],
+    stopReason: "toolUse" as const,
+  };
+  const result = {
+    role: "toolResult" as const,
+    toolCallId: "read-1",
+    toolName: "read",
+    content: [{ type: "text" as const, text: "retained tool evidence" }],
+    isError: false,
+    timestamp: 1_100,
+  };
+  harness.emit({ type: "turn_start" });
+  harness.messages.push(first);
+  harness.emit({ type: "message_start", message: first });
+  harness.emit({ type: "message_end", message: first });
+  harness.emit({
+    type: "tool_execution_start",
+    toolCallId: "read-1",
+    toolName: "read",
+    args: { path: "fixture.txt" },
+  });
+  harness.messages.push(result);
+  harness.emit({
+    type: "tool_execution_end",
+    toolCallId: "read-1",
+    toolName: "read",
+    result,
+    isError: false,
+  });
+  harness.emit({ type: "turn_end", message: first, toolResults: [result] });
+  harness.emit({ type: "turn_start" });
+  harness.emit({ type: "message_start", message: assistantTextMessage("") });
+
+  const outcome = await settleWithin(outcomePromise);
+  const late = assistantTextMessage("late success");
+  harness.messages.push(late);
+  harness.emit({ type: "message_end", message: late });
   prompt.resolve();
+
   assert.equal(outcome.ok, false);
-  assert.match(outcome.error ?? "", /no assistant response event/i);
+  assert.equal(outcome.aborted, false);
+  assert.match(outcome.error ?? "", /no model-visible progress/i);
+  assert.equal(outcome.output, "first turn evidence");
+  assert.equal(outcome.usage.turns, 2);
+  assert.equal(
+    outcome.transcript.some(
+      (entry) =>
+        entry.role === "toolResult" && entry.text === "retained tool evidence",
+    ),
+    true,
+  );
   assert.equal(harness.aborts(), 1);
   assert.equal(harness.disposals(), 1);
+});
+
+test("model-visible deltas extend a provider turn until assistant completion", async () => {
+  let run = async () => {};
+  const harness = runnerHarness({ prompt: () => run() });
+  run = async () => {
+    const partial = assistantTextMessage("");
+    harness.emit({ type: "turn_start" });
+    harness.emit({ type: "message_start", message: partial });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const progressing = assistantTextMessage("working");
+    harness.emit({
+      type: "message_update",
+      message: progressing,
+      assistantMessageEvent: {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "working",
+        partial: progressing,
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const completed = assistantTextMessage("done");
+    harness.messages.push(completed);
+    harness.emit({ type: "message_end", message: completed });
+  };
+
+  const outcome = await runHarnessAgent(harness, {
+    modelProgressTimeoutMs: 30,
+  });
+
+  assert.equal(outcome.ok, true);
+  assert.equal(outcome.output, "done");
+  assert.equal(harness.aborts(), 0);
 });
 
 test("cleanup timeout is surfaced instead of reporting agent success", async () => {
@@ -626,45 +735,76 @@ test("cleanup timeout is surfaced instead of reporting agent success", async () 
   assert.equal(harness.disposals(), 1);
 });
 
-test("first-response watchdog aborts a silent provider request", async () => {
+test("model-progress watchdog aborts a silent provider turn", async () => {
   let aborted = false;
-  const watchdog = createFirstResponseWatchdog(
+  const watchdog = createModelProgressWatchdog(
     async () => {
       aborted = true;
     },
     { timeoutMs: 10, model: "fixture-model" },
   );
+  watchdog.armTurn();
 
   await assert.rejects(
     watchdog.waitFor(new Promise<never>(() => {})),
-    /no assistant response event for fixture-model within 10 ms.*stalled/i,
+    /provider turn for fixture-model.*no model-visible progress for 10 ms.*stalled/i,
   );
   assert.equal(aborted, true);
 });
 
-test("first assistant response disarms the watchdog without limiting the run", async () => {
-  const watchdog = createFirstResponseWatchdog(
-    async () => {
-      throw new Error("watchdog should have been disarmed");
-    },
-    { timeoutMs: 10 },
+test("model-progress timeout preserves the default and honors wider Pi idle settings", () => {
+  assert.equal(
+    resolveModelProgressTimeoutMs(SettingsManager.inMemory()),
+    45_000,
   );
-  watchdog.markResponse();
+  assert.equal(
+    resolveModelProgressTimeoutMs(
+      SettingsManager.inMemory({ httpIdleTimeoutMs: 120_000 }),
+    ),
+    120_000,
+  );
+  assert.equal(
+    resolveModelProgressTimeoutMs(
+      SettingsManager.inMemory({ httpIdleTimeoutMs: 120_000 }),
+      5,
+    ),
+    5,
+  );
+});
+
+test("model progress refreshes its turn while completion leaves tool time unrestricted", async () => {
+  let timedOut = false;
+  const watchdog = createModelProgressWatchdog(
+    async () => {
+      timedOut = true;
+    },
+    { timeoutMs: 30 },
+  );
+  watchdog.armTurn();
 
   const result = await watchdog.waitFor(
-    new Promise<string>((resolve) => setTimeout(() => resolve("done"), 20)),
+    (async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      watchdog.markProgress();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      watchdog.completeTurn();
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      return "done";
+    })(),
   );
   assert.equal(result, "done");
+  assert.equal(timedOut, false);
 });
 
 test("explicit watchdog cancellation disarms a pending operation", async () => {
   let timedOut = false;
-  const watchdog = createFirstResponseWatchdog(
+  const watchdog = createModelProgressWatchdog(
     async () => {
       timedOut = true;
     },
     { timeoutMs: 5 },
   );
+  watchdog.armTurn();
   void watchdog.waitFor(new Promise<never>(() => {}));
   watchdog.cancel();
 

--- a/tests/extensions/workflows/sandbox.test.ts
+++ b/tests/extensions/workflows/sandbox.test.ts
@@ -204,7 +204,7 @@ test("sandbox VM still rejects non-yielding synchronous code", async () => {
   await assert.rejects(run(`while (true) {}`), /timed out/);
 });
 
-test("workflow agent invocations have no per-request wall timer", async () => {
+test("workflow sandbox imposes no fixed whole-agent wall timer", async () => {
   let signalAborted = false;
   const result = await run(`return (await agent("delayed")).output;`, {
     onAgent: async (_prompt, _options, signal) => {


### PR DESCRIPTION
## Summary

- replace the one-shot first-response watchdog with a per-provider-turn model-visible progress watchdog
- arm the watchdog only from Pi's actual `turn_start`, so authentication, automatic compaction, and `before_agent_start` preflight are not timed as provider stalls
- refresh the deadline only for actual text, thinking, or tool-call progress, while leaving tool execution to its existing timeout
- preserve the first terminal cause so a watchdog-triggered abort cannot be misreported as an ordinary cancellation
- honor a wider explicit Pi `httpIdleTimeoutMs` setting and document the runtime behavior

Closes #171.

## Validation

- `bun run check`
- workflow runner tests: 24/24 passed
- Vitest: 30/30 passed
- isolated worktree suite: 21/21 passed

The full Node run completed 884/885 tests; one unrelated Git-backed worktree test timed out under full-suite concurrency and passed when rerun in isolation.