### PR TITLE
fix(workflows): make terminal delivery recoverable

### DIFF
--- a/extensions/background-terminals/src/result-delivery.ts
+++ b/extensions/background-terminals/src/result-delivery.ts
@@ -1,3 +1,5 @@
+import type { ResultDeliveryQueue } from "../../shared/result-delivery.ts";
+
 /**
  * Deferred one-shot delivery map (same semantics as subagents'): a settled
  * terminal's result is held here until it is either drained into a follow-up
@@ -8,7 +10,7 @@
 export function createDeferredResultDelivery<T extends { id: string }>() {
   const pending = new Map<string, T>();
 
-  return {
+  const queue = {
     defer(result: T) {
       pending.set(result.id, result);
       return pending.size;
@@ -38,6 +40,7 @@ export function createDeferredResultDelivery<T extends { id: string }>() {
       pending.clear();
     },
   };
+  return queue satisfies ResultDeliveryQueue<T>;
 }
 
 /**

--- a/extensions/background-terminals/src/result-delivery.ts
+++ b/extensions/background-terminals/src/result-delivery.ts
@@ -1,4 +1,4 @@
-import type { ResultDeliveryQueue } from "../../shared/result-delivery.ts";
+import type { ConsumableResultDeliveryQueue } from "../../shared/result-delivery.ts";
 
 /**
  * Deferred one-shot delivery map (same semantics as subagents'): a settled
@@ -40,7 +40,7 @@ export function createDeferredResultDelivery<T extends { id: string }>() {
       pending.clear();
     },
   };
-  return queue satisfies ResultDeliveryQueue<T>;
+  return queue satisfies ConsumableResultDeliveryQueue<T>;
 }
 
 /**

--- a/extensions/shared/result-delivery.ts
+++ b/extensions/shared/result-delivery.ts
@@ -1,0 +1,6 @@
+/** Minimum lifecycle contract shared by deferred result queues. */
+export interface ResultDeliveryQueue<T> {
+  defer(result: T): void;
+  size(): number;
+  clear(): void;
+}

--- a/extensions/shared/result-delivery.ts
+++ b/extensions/shared/result-delivery.ts
@@ -4,3 +4,31 @@ export interface ResultDeliveryQueue<T> {
   size(): number;
   clear(): void;
 }
+
+/** One-shot results are removed by either an explicit consumer or delivery. */
+export interface ConsumableResultDeliveryQueue<T, TId = string>
+  extends ResultDeliveryQueue<T> {
+  consume(ids: Iterable<TId>): void;
+}
+
+/** Stable identity carried by a durable, at-least-once result. */
+export interface DurableResultEnvelope {
+  deliveryId: string;
+}
+
+/** Per-result acknowledgement for a durable delivery attempt. */
+export interface DurableResultDeliveryReceipt {
+  deliveryId: string;
+  delivered: boolean;
+  error?: string;
+}
+
+/**
+ * Durable queues can reconstruct pending ownership after restart and retry it
+ * at an explicit lifecycle boundary without changing the stable delivery id.
+ */
+export interface DurableResultDeliveryQueue<T extends DurableResultEnvelope>
+  extends ResultDeliveryQueue<T> {
+  restore(result: T): boolean;
+  retryPending(): Promise<void>;
+}

--- a/extensions/subagents/src/result-delivery.ts
+++ b/extensions/subagents/src/result-delivery.ts
@@ -1,3 +1,5 @@
+import type { ResultDeliveryQueue } from "../../shared/result-delivery.ts";
+
 export interface SubagentResultDeliveryOptions<T> {
   /** True only when the parent has no run or queued continuation in flight. */
   readonly isIdle: () => boolean;
@@ -46,7 +48,7 @@ export function createSubagentResultDelivery<T extends { id: string }>(
     }
   };
 
-  return {
+  const queue = {
     defer(result: T) {
       pending.set(result.id, result);
       if (options.isIdle()) flush();
@@ -61,5 +63,9 @@ export function createSubagentResultDelivery<T extends { id: string }>(
     clear() {
       pending.clear();
     },
+    size() {
+      return pending.size;
+    },
   };
+  return queue satisfies ResultDeliveryQueue<T>;
 }

--- a/extensions/subagents/src/result-delivery.ts
+++ b/extensions/subagents/src/result-delivery.ts
@@ -1,4 +1,4 @@
-import type { ResultDeliveryQueue } from "../../shared/result-delivery.ts";
+import type { ConsumableResultDeliveryQueue } from "../../shared/result-delivery.ts";
 
 export interface SubagentResultDeliveryOptions<T> {
   /** True only when the parent has no run or queued continuation in flight. */
@@ -67,5 +67,5 @@ export function createSubagentResultDelivery<T extends { id: string }>(
       return pending.size;
     },
   };
-  return queue satisfies ResultDeliveryQueue<T>;
+  return queue satisfies ConsumableResultDeliveryQueue<T>;
 }

--- a/extensions/workflows/artifacts.ts
+++ b/extensions/workflows/artifacts.ts
@@ -103,6 +103,24 @@ function writeRunFile(runDir: string, name: string, content: string) {
   writeFileAtomic(path.join(runDir, name), content);
 }
 
+export function persistWorkflowTerminalState(
+  runDir: string,
+  details: WorkflowDetails,
+) {
+  const terminalManifest: WorkflowDetails = {
+    ...details,
+    agents: details.agents.map((agent) => ({ ...agent, transcript: [] })),
+  };
+  delete terminalManifest.result;
+  delete terminalManifest.resultArtifact;
+  delete terminalManifest.transcriptArtifact;
+  writeRunFile(
+    runDir,
+    "workflow.json",
+    safeStringify(terminalManifest, { maxBytes: 1024 * 1024 }),
+  );
+}
+
 /** Persist one successful child result before any handoff/context projection. */
 export function persistWorkflowAgentResult(
   runDir: string,
@@ -148,6 +166,15 @@ export function persistWorkflowJson(
       boundedArtifactTranscript(agent.transcript),
     ]),
   );
+
+  // Publish terminal execution facts before dependent side artifacts. If a
+  // later artifact write fails, readers still see an explained terminal run
+  // instead of the previous `running` manifest. The final manifest below adds
+  // the artifact references once every dependent file has committed.
+  if (details.status !== "running") {
+    persistWorkflowTerminalState(runDir, details);
+  }
+
   writeRunFile(
     runDir,
     "transcripts.json",

--- a/extensions/workflows/index.ts
+++ b/extensions/workflows/index.ts
@@ -2153,8 +2153,8 @@ export default function workflows(pi: ExtensionAPI) {
         try {
           await completion;
         } catch (error) {
-          details.status = "failed";
-          details.finishedAt = Date.now();
+          if (details.status === "running") details.status = "failed";
+          details.finishedAt ??= Date.now();
           details.error = details.error ?? errorText(error);
         } finally {
           recordTerminalRun();

--- a/extensions/workflows/index.ts
+++ b/extensions/workflows/index.ts
@@ -86,6 +86,7 @@ import {
   loadJournal,
   persistWorkflowAgentResult,
   persistWorkflowJson,
+  persistWorkflowTerminalState,
 } from "./artifacts.ts";
 import { RunController } from "./controller.ts";
 import {
@@ -632,6 +633,17 @@ function writeRunFile(runDir: string, name: string, content: string) {
   writeFileAtomic(path.join(runDir, name), content);
 }
 
+function appendArtifactPersistenceFailure(
+  details: WorkflowDetails,
+  error: unknown,
+) {
+  const persistenceFailure = `Artifact persistence failed: ${errorText(error)}`;
+  if (details.status !== "aborted") details.status = "failed";
+  details.error = details.error
+    ? `${details.error}; ${persistenceFailure}`
+    : persistenceFailure;
+}
+
 function compactToolDetails(details: WorkflowDetails): WorkflowDetails {
   return {
     ...details,
@@ -1032,6 +1044,10 @@ export default function workflows(pi: ExtensionAPI) {
       navigationLayerRegistered = false;
     }
     await shutdownActiveWorkflowRuns([...activeRuns.values()]);
+    // Give deferred completions one final delivery attempt. Failed sends stay
+    // durably pending; clearing first would discard an envelope whose initial
+    // persistence may have failed.
+    await resultDelivery.parentSettled();
     try {
       lastContext?.ui.setStatus("workflows", undefined);
       lastContext?.ui.setWidget(widgetKey, undefined);
@@ -1042,7 +1058,6 @@ export default function workflows(pi: ExtensionAPI) {
     widgetVisible = false;
     requestWidgetRender = undefined;
     stripState.focused = false;
-    resultDelivery.clear();
   });
 
   pi.registerCommand("workflows", {
@@ -1259,6 +1274,15 @@ export default function workflows(pi: ExtensionAPI) {
         flush(terminal);
       };
 
+      const persistTerminalRecovery = () => {
+        try {
+          persistWorkflowTerminalState(runDir, details);
+        } catch {
+          // The original persistence error remains authoritative; restart
+          // reconciliation handles the remaining uncertainty.
+        }
+      };
+
       const terminalize = (
         status: WorkflowDetails["status"],
         error?: string,
@@ -1311,7 +1335,8 @@ export default function workflows(pi: ExtensionAPI) {
         try {
           persistence.flush();
         } catch (persistenceError) {
-          details.error = `${error}; artifact persistence failed: ${errorText(persistenceError)}`;
+          appendArtifactPersistenceFailure(details, persistenceError);
+          persistTerminalRecovery();
         }
         flushNow(true);
       };
@@ -2097,8 +2122,8 @@ export default function workflows(pi: ExtensionAPI) {
         try {
           persistence.flush();
         } catch (error) {
-          details.status = "failed";
-          details.error = `Artifact persistence failed: ${errorText(error)}`;
+          appendArtifactPersistenceFailure(details, error);
+          persistTerminalRecovery();
           throw new Error(details.error);
         } finally {
           flushNow(true);

--- a/extensions/workflows/result-delivery.ts
+++ b/extensions/workflows/result-delivery.ts
@@ -1,4 +1,5 @@
 import type { WorkflowDetails } from "./model.ts";
+import type { ResultDeliveryQueue } from "../shared/result-delivery.ts";
 
 export interface WorkflowCompletionEnvelope {
   deliveryId: string;
@@ -177,7 +178,7 @@ export function createWorkflowResultDelivery(
     return flushing;
   };
 
-  return {
+  const queue = {
     /** Register inline interest before the run starts. */
     holdInline(details: WorkflowDetails) {
       persistState(details, "held-for-inline");
@@ -194,15 +195,21 @@ export function createWorkflowResultDelivery(
 
     /** Abort won the wait/terminal arbitration; deliver the result later. */
     releaseInline(envelope: WorkflowCompletionEnvelope) {
-      persistState(envelope.details, "pending", { lastError: undefined });
-      enqueue(envelope);
+      retainPending(
+        envelope,
+        { lastError: undefined },
+        "Initial delivery persistence failed",
+      );
       if (options.isIdle()) void flush(true);
     },
 
-    /** Queue a detached run after terminal status and pending are persisted. */
+    /** Queue a detached run with in-memory retry ownership before persistence. */
     defer(envelope: WorkflowCompletionEnvelope) {
-      persistState(envelope.details, "pending", { lastError: undefined });
-      enqueue(envelope);
+      retainPending(
+        envelope,
+        { lastError: undefined },
+        "Initial delivery persistence failed",
+      );
       if (options.isIdle()) void flush(true);
     },
 
@@ -241,4 +248,5 @@ export function createWorkflowResultDelivery(
       pending.clear();
     },
   };
+  return queue satisfies ResultDeliveryQueue<WorkflowCompletionEnvelope>;
 }

--- a/extensions/workflows/result-delivery.ts
+++ b/extensions/workflows/result-delivery.ts
@@ -1,16 +1,13 @@
 import type { WorkflowDetails } from "./model.ts";
-import type { ResultDeliveryQueue } from "../shared/result-delivery.ts";
+import type {
+  DurableResultDeliveryQueue,
+  DurableResultDeliveryReceipt,
+} from "../shared/result-delivery.ts";
 
 export interface WorkflowCompletionEnvelope {
   deliveryId: string;
   runId: string;
   details: WorkflowDetails;
-}
-
-export interface WorkflowDeliveryReceipt {
-  deliveryId: string;
-  delivered: boolean;
-  error?: string;
 }
 
 export interface WorkflowResultDeliveryOptions {
@@ -19,7 +16,7 @@ export interface WorkflowResultDeliveryOptions {
   deliver: (
     envelopes: readonly WorkflowCompletionEnvelope[],
     wake: boolean,
-  ) => Promise<readonly WorkflowDeliveryReceipt[]>;
+  ) => Promise<readonly DurableResultDeliveryReceipt[]>;
 }
 
 function errorText(error: unknown) {
@@ -106,7 +103,7 @@ export function createWorkflowResultDelivery(
           pending.delete(envelope.deliveryId);
         }
 
-        let receipts: readonly WorkflowDeliveryReceipt[] | undefined;
+        let receipts: readonly DurableResultDeliveryReceipt[] | undefined;
         try {
           receipts = await options.deliver(envelopes, passWake);
         } catch (error) {
@@ -231,6 +228,10 @@ export function createWorkflowResultDelivery(
       return true;
     },
 
+    retryPending() {
+      return flush(true) ?? Promise.resolve();
+    },
+
     parentSettled() {
       return flush(true);
     },
@@ -248,5 +249,5 @@ export function createWorkflowResultDelivery(
       pending.clear();
     },
   };
-  return queue satisfies ResultDeliveryQueue<WorkflowCompletionEnvelope>;
+  return queue satisfies DurableResultDeliveryQueue<WorkflowCompletionEnvelope>;
 }

--- a/tests/extensions/workflows/artifacts.test.ts
+++ b/tests/extensions/workflows/artifacts.test.ts
@@ -1,5 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -9,6 +15,7 @@ import {
   loadJournal,
   persistWorkflowAgentResult,
   persistWorkflowJson,
+  persistWorkflowTerminalState,
 } from "../../../extensions/workflows/artifacts.ts";
 import { JOURNAL_MAX_BYTES } from "../../../extensions/workflows/journal.ts";
 import {
@@ -205,6 +212,100 @@ test("workflow persistence derives a non-authoritative graph from explicit resul
     assert.deepEqual(stored.graph?.edges, [
       { source: "wf_fixture:call:1", target: "wf_fixture:call:2" },
     ]);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("terminal persistence publishes status before dependent artifacts", () => {
+  const directory = mkdtempSync(join(tmpdir(), "pi-workflow-terminal-commit-"));
+  try {
+    const details = workflowDetails();
+    details.status = "failed";
+    details.error = "artifact write failed";
+    details.result = { partial: true };
+
+    persistWorkflowJson(directory, details);
+
+    const stored = JSON.parse(
+      readFileSync(join(directory, "workflow.json"), "utf8"),
+    ) as WorkflowDetails;
+    assert.equal(stored.status, "failed");
+    assert.equal(stored.error, "artifact write failed");
+    assert.equal(stored.resultArtifact, "result.json");
+    assert.deepEqual(
+      JSON.parse(readFileSync(join(directory, "result.json"), "utf8")),
+      { partial: true },
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a dependent artifact write failure cannot leave the prior running manifest", () => {
+  const directory = mkdtempSync(
+    join(tmpdir(), "pi-workflow-terminal-failure-"),
+  );
+  try {
+    const details = workflowDetails();
+    details.status = "completed";
+    details.finishedAt = 2;
+    // The terminal manifest commits before this dependent artifact write.
+    // A directory cannot be atomically replaced by the file writer.
+    mkdirSync(join(directory, "transcripts.json"));
+
+    assert.throws(
+      () => persistWorkflowJson(directory, details),
+      /EISDIR|directory/i,
+    );
+
+    const stored = JSON.parse(
+      readFileSync(join(directory, "workflow.json"), "utf8"),
+    ) as WorkflowDetails;
+    assert.equal(stored.status, "completed");
+    assert.equal(stored.resultArtifact, undefined);
+    assert.equal(stored.transcriptArtifact, undefined);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("terminal recovery state remains explained when dependent artifact writing fails", () => {
+  const directory = mkdtempSync(
+    join(tmpdir(), "pi-workflow-terminal-recovery-"),
+  );
+  try {
+    const details = workflowDetails();
+    details.status = "failed";
+    details.error = "Artifact persistence failed: disk unavailable";
+    persistWorkflowTerminalState(directory, details);
+
+    const stored = JSON.parse(
+      readFileSync(join(directory, "workflow.json"), "utf8"),
+    ) as WorkflowDetails;
+    assert.equal(stored.status, "failed");
+    assert.equal(stored.error, details.error);
+    assert.equal(stored.resultArtifact, undefined);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("terminal recovery preserves an aborted status while recording persistence failure", () => {
+  const directory = mkdtempSync(
+    join(tmpdir(), "pi-workflow-terminal-aborted-recovery-"),
+  );
+  try {
+    const details = workflowDetails();
+    details.status = "aborted";
+    details.error = "Workflow was aborted by the user";
+    persistWorkflowTerminalState(directory, details);
+
+    const stored = JSON.parse(
+      readFileSync(join(directory, "workflow.json"), "utf8"),
+    ) as WorkflowDetails;
+    assert.equal(stored.status, "aborted");
+    assert.equal(stored.error, "Workflow was aborted by the user");
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/tests/extensions/workflows/execute.e2e.test.ts
+++ b/tests/extensions/workflows/execute.e2e.test.ts
@@ -576,6 +576,53 @@ test("failed completion delivery remains durable and retries once with the same 
   );
 });
 
+test("shutdown preserves a failed completion for reload recovery", async () => {
+  sentMessages.length = 0;
+  modelIdle = false;
+  sendFailures = 1;
+  const run = (await workflow.execute(
+    "e2e-shutdown-reload-delivery",
+    {
+      script:
+        'export const meta = { name: "shutdown-reload-delivery" };\nreturn { durable: true };',
+      background: true,
+    },
+    undefined,
+    undefined,
+    ctx,
+  )) as { details: { runId?: unknown } };
+
+  await waitFor(
+    () =>
+      (readWorkflowJson(run.details.runId).delivery as { state?: string })
+        ?.state === "pending",
+    "pending completion before shutdown",
+  );
+  for (const handler of handlers.get("session_shutdown") ?? []) {
+    await handler({}, ctx);
+  }
+  assert.equal(
+    (readWorkflowJson(run.details.runId).delivery as { state?: string }).state,
+    "pending",
+  );
+
+  modelIdle = true;
+  for (const handler of handlers.get("session_start") ?? []) {
+    await handler({}, { ...ctx, mode: "print" } as unknown as ExtensionContext);
+  }
+  await waitFor(
+    () =>
+      sentMessages.filter(
+        (sent) => sent.message.details?.runId === run.details.runId,
+      ).length === 1,
+    "completion after reload recovery",
+  );
+  assert.equal(
+    (readWorkflowJson(run.details.runId).delivery as { state?: string }).state,
+    "delivered",
+  );
+});
+
 test("a failing script reports the error and records the run as failed", async () => {
   await assert.rejects(
     Promise.resolve(

--- a/tests/extensions/workflows/execute.e2e.test.ts
+++ b/tests/extensions/workflows/execute.e2e.test.ts
@@ -191,8 +191,9 @@ assert.match(String(sentMessages[0]?.message.content), /wf_1e9acbad/);
 sentMessages.length = 0;
 
 const workflow = tools.get("workflow")!;
+const workflowStop = tools.get("workflow_stop")!;
 const status = tools.get("workflow_status")!;
-assert.ok(workflow && status);
+assert.ok(workflow && workflowStop && status);
 
 function runDirFor(runId: unknown) {
   assert.equal(typeof runId, "string");
@@ -621,6 +622,75 @@ test("shutdown preserves a failed completion for reload recovery", async () => {
     (readWorkflowJson(run.details.runId).delivery as { state?: string }).state,
     "delivered",
   );
+});
+
+test("cancelled detached delivery preserves aborted status after artifact persistence failure", async () => {
+  sentMessages.length = 0;
+  modelIdle = true;
+  let sessionCreated = false;
+  let releasePrompt = () => {};
+  const promptGate = new Promise<void>((resolve) => {
+    releasePrompt = resolve;
+  });
+  __setWorkflowTestAgentSessionFactory(async () => {
+    sessionCreated = true;
+    return { session: fakeAgentSession("cancelled output", promptGate) };
+  });
+
+  try {
+    const launch = (await workflow.execute(
+      "e2e-cancelled-persistence-failure",
+      {
+        script:
+          'export const meta = { name: "cancelled-persistence-failure" };\n' +
+          'return await agent("wait for cancellation", { agent_type: "reviewer" });',
+        background: true,
+      },
+      undefined,
+      undefined,
+      ctx,
+    )) as { details: { runId?: unknown } };
+    const runId = launch.details.runId;
+    const transcripts = join(runDirFor(runId), "transcripts.json");
+    await waitFor(
+      () => sessionCreated && existsSync(transcripts),
+      "active detached workflow before cancellation",
+    );
+
+    // Make the final artifact write fail after the cancellation path has
+    // selected `aborted`; terminal recovery can still rewrite workflow.json.
+    rmSync(transcripts);
+    mkdirSync(transcripts);
+    writeFileSync(join(transcripts, "blocker"), "keep directory non-empty\n");
+
+    await workflowStop.execute("e2e-cancel-stop", { runId });
+    releasePrompt();
+
+    await waitFor(
+      () => sentMessages.some((sent) => sent.message.details?.runId === runId),
+      "cancelled completion delivery",
+    );
+
+    const persisted = readWorkflowJson(runId);
+    assert.equal(persisted.status, "aborted");
+    assert.match(String(persisted.error), /Workflow was aborted/);
+    assert.match(String(persisted.error), /Artifact persistence failed/);
+
+    const delivered = sentMessages.find(
+      (sent) => sent.message.details?.runId === runId,
+    );
+    assert.ok(delivered);
+    const deliveredDetails = delivered.message.details as {
+      status?: unknown;
+      error?: unknown;
+    };
+    assert.equal(deliveredDetails.status, "aborted");
+    assert.match(String(deliveredDetails.error), /Workflow was aborted/);
+    assert.match(String(deliveredDetails.error), /Artifact persistence failed/);
+  } finally {
+    releasePrompt();
+    __setWorkflowTestAgentSessionFactory(undefined);
+  }
 });
 
 test("a failing script reports the error and records the run as failed", async () => {

--- a/tests/extensions/workflows/execute.e2e.test.ts
+++ b/tests/extensions/workflows/execute.e2e.test.ts
@@ -607,8 +607,24 @@ test("shutdown preserves a failed completion for reload recovery", async () => {
     "pending",
   );
 
+  const reloadedHandlers = new Map<
+    string,
+    Array<(event: unknown, ctx: ExtensionContext) => unknown>
+  >();
+  const reloadedPi = {
+    ...pi,
+    registerTool() {},
+    on(event: string, handler: unknown) {
+      reloadedHandlers.set(event, [
+        ...(reloadedHandlers.get(event) ?? []),
+        handler as (event: unknown, ctx: ExtensionContext) => unknown,
+      ]);
+    },
+  } as unknown as ExtensionAPI;
+  workflows(reloadedPi);
+
   modelIdle = true;
-  for (const handler of handlers.get("session_start") ?? []) {
+  for (const handler of reloadedHandlers.get("session_start") ?? []) {
     await handler({}, { ...ctx, mode: "print" } as unknown as ExtensionContext);
   }
   await waitFor(
@@ -622,6 +638,19 @@ test("shutdown preserves a failed completion for reload recovery", async () => {
     (readWorkflowJson(run.details.runId).delivery as { state?: string }).state,
     "delivered",
   );
+
+  // The original instance represents the process that was replaced. Drain
+  // its intentionally retained in-memory retry so later tests do not batch it
+  // with an unrelated completion; the assertion above was reached solely via
+  // the fresh instance and persisted session state.
+  for (const handler of handlers.get("agent_settled") ?? []) {
+    await handler({}, ctx);
+  }
+  await waitFor(
+    () => sentMessages.length === 2,
+    "discarded predecessor instance retry",
+  );
+  sentMessages.length = 0;
 });
 
 test("cancelled detached delivery preserves aborted status after artifact persistence failure", async () => {

--- a/tests/extensions/workflows/result-delivery.test.ts
+++ b/tests/extensions/workflows/result-delivery.test.ts
@@ -72,6 +72,43 @@ test("failed delivery stays pending and retries with the same per-run id", async
   assert.deepEqual(persisted, ["pending", "pending", "delivered"]);
 });
 
+test("initial persistence failure retains a detached envelope for retry", async () => {
+  const run = details("wf_initial_persist");
+  let failPersistence = true;
+  const calls: string[][] = [];
+  const delivery = createWorkflowResultDelivery({
+    isIdle: () => false,
+    persist: (current) => {
+      if (failPersistence) throw new Error("disk unavailable");
+    },
+    deliver: async (envelopes) => {
+      calls.push(envelopes.map((entry) => entry.deliveryId));
+      return envelopes.map((entry) => ({
+        deliveryId: entry.deliveryId,
+        delivered: true,
+      }));
+    },
+  });
+
+  delivery.defer({
+    deliveryId: run.delivery!.id,
+    runId: run.runId,
+    details: run,
+  });
+  assert.equal(delivery.size(), 1);
+  assert.equal(run.delivery?.state, "pending");
+  assert.match(
+    run.delivery?.lastError ?? "",
+    /initial delivery persistence failed/i,
+  );
+
+  failPersistence = false;
+  await delivery.parentSettled();
+  assert.equal(delivery.size(), 0);
+  assert.equal(run.delivery?.state, "delivered");
+  assert.deepEqual(calls, [["workflow:wf_initial_persist:terminal"]]);
+});
+
 test("partial batch receipts retry only unacknowledged runs", async () => {
   const first = details("wf_a1");
   const second = details("wf_b2");


### PR DESCRIPTION
## Summary

Fixes #71. Makes Workflow terminal state and completion delivery recoverable across persistence, transport, and session lifecycle failures.

- Publish terminal execution facts before dependent artifacts so a partial artifact failure cannot leave an unexplained `running` manifest.
- Preserve pending completion envelopes before persistence/send attempts and retry them with stable delivery ids.
- Flush deferred completions at shutdown and restore pending deliveries on reload.
- Preserve `aborted` status and original cancellation reason when artifact persistence also fails.
- Add a shared minimal `ResultDeliveryQueue` contract for Subagent, Background Terminal, and Workflow delivery implementations.

## Validation

- `bun run check`
- Workflow tests: `node --test --experimental-strip-types tests/extensions/workflows/*.test.ts` (240/240)
- Full suite: Node 910/910 and Vitest 30/30 passed in the validated run

The local environment could not refresh `origin/main` because the SSH connection was closed; the branch was created from the local `main` checkout and pushed to the fork.