### PR TITLE
perf(model-info): incrementally aggregate session metrics

### DIFF
--- a/benchmarks/model-info-session-metrics.ts
+++ b/benchmarks/model-info-session-metrics.ts
@@ -1,0 +1,270 @@
+import assert from "node:assert/strict";
+import { performance } from "node:perf_hooks";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import type {
+  AssistantMessage,
+  ToolResultMessage,
+  Usage,
+  UserMessage,
+} from "@earendil-works/pi-ai";
+import { createSessionMetricsTracker } from "../extensions/model-info/session-metrics.ts";
+
+type BenchmarkResult = {
+  implementation: "full-scan" | "prefix-tracker";
+  entries: number;
+  toolLoops: number;
+  refreshes: number;
+  visits: number;
+  coldStartVisits: number;
+  totalMs: number;
+  meanRefreshMs: number;
+  p95RefreshMs: number;
+};
+
+function readOption(name: string) {
+  const index = process.argv.indexOf(name);
+  if (index >= 0) return process.argv[index + 1];
+  return process.argv
+    .find((argument) => argument.startsWith(`${name}=`))
+    ?.slice(name.length + 1);
+}
+
+function parsePositiveIntegers(raw: string | undefined, fallback: number[]) {
+  if (!raw) return fallback;
+  const parsed = raw
+    .split(",")
+    .map((value) => Number.parseInt(value, 10))
+    .filter((value) => Number.isSafeInteger(value) && value > 0);
+  if (parsed.length === 0) {
+    throw new Error(`Invalid positive integer list: ${raw}`);
+  }
+  return parsed;
+}
+
+function usage(index: number): Usage {
+  return {
+    input: 100 + index,
+    output: 20,
+    cacheRead: 50 + index,
+    cacheWrite: 10,
+    totalTokens: 180 + index * 2,
+    cost: {
+      input: 0.001,
+      output: 0.001,
+      cacheRead: 0.0001,
+      cacheWrite: 0.0001,
+      total: 0.0022,
+    },
+  };
+}
+
+function userMessage(index: number): UserMessage {
+  return {
+    role: "user",
+    content: `Initial benchmark entry ${index}`,
+    timestamp: index,
+  };
+}
+
+function assistantMessage(index: number, toolCall: boolean): AssistantMessage {
+  return {
+    role: "assistant",
+    content: toolCall
+      ? [
+          {
+            type: "toolCall",
+            id: `benchmark-call-${index}`,
+            name: "benchmark",
+            arguments: {},
+          },
+        ]
+      : [{ type: "text", text: `Initial benchmark response ${index}` }],
+    api: "openai-responses",
+    provider: "openai",
+    model: "benchmark",
+    usage: usage(index),
+    stopReason: toolCall ? "toolUse" : "stop",
+    timestamp: index,
+  };
+}
+
+function toolResultMessage(index: number): ToolResultMessage {
+  return {
+    role: "toolResult",
+    toolCallId: `benchmark-call-${index}`,
+    toolName: "benchmark",
+    content: [{ type: "text", text: "benchmark result" }],
+    isError: false,
+    timestamp: index,
+  };
+}
+
+function appendInitialEntries(manager: SessionManager, entries: number) {
+  for (let index = 0; index < entries; index++) {
+    manager.appendMessage(
+      index % 2 === 0 ? userMessage(index) : assistantMessage(index, false),
+    );
+  }
+}
+
+function appendToolLoop(manager: SessionManager, index: number) {
+  manager.appendMessage(assistantMessage(index, true));
+  manager.appendMessage(toolResultMessage(index));
+}
+
+function entryUsage(entry: ReturnType<SessionManager["getBranch"]>[number]) {
+  if (entry.type === "message") {
+    return entry.message.role === "assistant" ||
+      entry.message.role === "toolResult"
+      ? entry.message.usage
+      : undefined;
+  }
+  return entry.type === "compaction" || entry.type === "branch_summary"
+    ? entry.usage
+    : undefined;
+}
+
+function fullActiveBranchMetrics(
+  entries: ReturnType<SessionManager["getBranch"]>,
+) {
+  let cost = 0;
+  let cacheRead = 0;
+  let promptTokens = 0;
+  for (const entry of entries) {
+    const currentUsage = entryUsage(entry);
+    if (!currentUsage) continue;
+    cost += currentUsage.cost.total;
+    cacheRead += currentUsage.cacheRead;
+    promptTokens +=
+      currentUsage.input + currentUsage.cacheRead + currentUsage.cacheWrite;
+  }
+  return {
+    cost,
+    cachePercent: promptTokens > 0 ? (cacheRead / promptTokens) * 100 : null,
+  };
+}
+
+function measure<T>(samples: number[], operation: () => T) {
+  const started = performance.now();
+  const result = operation();
+  samples.push(performance.now() - started);
+  return result;
+}
+
+function p95(samples: number[]) {
+  const sorted = [...samples].sort((left, right) => left - right);
+  return sorted[Math.ceil(sorted.length * 0.95) - 1] ?? 0;
+}
+
+function summarize(
+  implementation: BenchmarkResult["implementation"],
+  entries: number,
+  toolLoops: number,
+  visits: number,
+  coldStartVisits: number,
+  samples: number[],
+): BenchmarkResult {
+  const totalMs = samples.reduce((total, sample) => total + sample, 0);
+  return {
+    implementation,
+    entries,
+    toolLoops,
+    refreshes: samples.length,
+    visits,
+    coldStartVisits,
+    totalMs: Number(totalMs.toFixed(3)),
+    meanRefreshMs: Number((totalMs / samples.length).toFixed(3)),
+    p95RefreshMs: Number(p95(samples).toFixed(3)),
+  };
+}
+
+function runScenario(entries: number, toolLoops: number) {
+  const fullScanManager = SessionManager.inMemory(
+    "/tmp/openpi-model-info-full-scan-benchmark",
+  );
+  const trackerManager = SessionManager.inMemory(
+    "/tmp/openpi-model-info-prefix-tracker-benchmark",
+  );
+  appendInitialEntries(fullScanManager, entries);
+  appendInitialEntries(trackerManager, entries);
+
+  const fullScanSamples: number[] = [];
+  let fullScanVisits = 0;
+  const fullScan = () =>
+    measure(fullScanSamples, () => {
+      const branch = fullScanManager.getBranch();
+      fullScanVisits += branch.length;
+      return fullActiveBranchMetrics(branch);
+    });
+
+  let trackerVisits = 0;
+  const trackerManagerView = {
+    getSessionId: () => trackerManager.getSessionId(),
+    getLeafId: () => trackerManager.getLeafId(),
+    getEntry: (id: string) => {
+      trackerVisits += 1;
+      return trackerManager.getEntry(id);
+    },
+  };
+  const tracker = createSessionMetricsTracker();
+  const trackerSamples: number[] = [];
+  const syncTracker = () =>
+    measure(trackerSamples, () => tracker.sync(trackerManagerView));
+
+  let trackerMetrics = syncTracker();
+  const trackerColdStartVisits = trackerVisits;
+  const fullScanMetrics = fullScan();
+  const fullScanColdStartVisits = fullScanVisits;
+  assert.deepEqual(trackerMetrics, fullScanMetrics);
+
+  for (let index = 0; index < toolLoops; index++) {
+    // message_end refreshes before Pi persists the assistant response.
+    fullScan();
+    appendToolLoop(fullScanManager, index);
+    appendToolLoop(trackerManager, index);
+  }
+
+  // turn_end runs after all entries have been appended.
+  trackerMetrics = syncTracker();
+  assert.deepEqual(fullScan(), trackerMetrics);
+
+  // agent_settled only performs an ordinary refresh, so the tracker is not
+  // synchronized again; its cached totals remain the current session state.
+  assert.deepEqual(fullScan(), trackerMetrics);
+
+  return [
+    summarize(
+      "full-scan",
+      entries,
+      toolLoops,
+      fullScanVisits,
+      fullScanColdStartVisits,
+      fullScanSamples,
+    ),
+    summarize(
+      "prefix-tracker",
+      entries,
+      toolLoops,
+      trackerVisits,
+      trackerColdStartVisits,
+      trackerSamples,
+    ),
+  ];
+}
+
+const entryCounts = parsePositiveIntegers(
+  readOption("--entries"),
+  [1_000, 10_000, 100_000],
+);
+const toolLoopCounts = parsePositiveIntegers(
+  readOption("--tool-loops"),
+  [1, 10, 100],
+);
+
+for (const entries of entryCounts) {
+  for (const toolLoops of toolLoopCounts) {
+    for (const result of runScenario(entries, toolLoops)) {
+      console.log(JSON.stringify(result));
+    }
+  }
+}

--- a/benchmarks/model-info-session-metrics.ts
+++ b/benchmarks/model-info-session-metrics.ts
@@ -222,11 +222,10 @@ function runScenario(entries: number, toolLoops: number) {
     fullScan();
     appendToolLoop(fullScanManager, index);
     appendToolLoop(trackerManager, index);
+    // turn_end follows persistence for every assistant/tool-result loop.
+    trackerMetrics = syncTracker();
+    assert.deepEqual(fullScan(), trackerMetrics);
   }
-
-  // turn_end runs after all entries have been appended.
-  trackerMetrics = syncTracker();
-  assert.deepEqual(fullScan(), trackerMetrics);
 
   // agent_settled only performs an ordinary refresh, so the tracker is not
   // synchronized again; its cached totals remain the current session state.

--- a/extensions/model-info/index.ts
+++ b/extensions/model-info/index.ts
@@ -7,36 +7,10 @@ import {
   MODEL_INFO_CHANNEL,
   REFRESH_CHANNEL,
 } from "../shared/dashboard-state.ts";
+import { createSessionMetricsTracker } from "./session-metrics.ts";
 
 const CHARS_PER_ESTIMATED_TOKEN = 4;
 const LIVE_UPDATE_INTERVAL_MS = 200;
-
-function getSessionMetrics(ctx: ExtensionContext) {
-  let cost = 0;
-  let cacheRead = 0;
-  let promptTokens = 0;
-
-  for (const entry of ctx.sessionManager.getBranch()) {
-    let usage;
-    if (entry.type === "message") {
-      const message = entry.message;
-      if (message.role === "assistant" || message.role === "toolResult") {
-        usage = message.usage;
-      }
-    } else if (entry.type === "compaction" || entry.type === "branch_summary") {
-      usage = entry.usage;
-    }
-    if (!usage) continue;
-    cost += usage.cost.total;
-    cacheRead += usage.cacheRead;
-    promptTokens += usage.input + usage.cacheRead + usage.cacheWrite;
-  }
-
-  return {
-    cost,
-    cachePercent: promptTokens > 0 ? (cacheRead / promptTokens) * 100 : null,
-  };
-}
 
 function estimateContentTokens(characters: number) {
   return Math.ceil(characters / CHARS_PER_ESTIMATED_TOKEN);
@@ -54,6 +28,7 @@ export default function modelInfo(pi: ExtensionAPI) {
   let runContentStreamMs = 0;
   let lastLiveUpdate = 0;
   let currentContext: ExtensionContext | undefined;
+  const sessionMetrics = createSessionMetricsTracker();
 
   const publish = () => pi.events.emit(MODEL_INFO_CHANNEL, { ...state });
 
@@ -61,7 +36,6 @@ export default function modelInfo(pi: ExtensionAPI) {
     currentContext = ctx;
     const model = ctx.model;
     const usage = ctx.getContextUsage();
-    const metrics = getSessionMetrics(ctx);
 
     state = {
       ...state,
@@ -72,10 +46,12 @@ export default function modelInfo(pi: ExtensionAPI) {
       contextTokens: usage?.tokens ?? null,
       contextWindow: usage?.contextWindow ?? model?.contextWindow ?? 0,
       contextPercent: usage?.percent ?? null,
-      cachePercent: metrics.cachePercent,
-      cost: metrics.cost,
     };
     publish();
+  }
+
+  function syncSessionMetrics(ctx: ExtensionContext) {
+    state = { ...state, ...sessionMetrics.sync(ctx.sessionManager) };
   }
 
   function resetMessageTracking() {
@@ -97,6 +73,8 @@ export default function modelInfo(pi: ExtensionAPI) {
     runContentTokens = 0;
     runContentStreamMs = 0;
     state = { ...state, tokensPerSecond: null, generating: false };
+    sessionMetrics.reset();
+    syncSessionMetrics(ctx);
     refresh(ctx);
   });
 
@@ -213,14 +191,23 @@ export default function modelInfo(pi: ExtensionAPI) {
     refresh(ctx);
   });
 
-  pi.on("turn_end", (_event, ctx) => refresh(ctx));
+  pi.on("turn_end", (_event, ctx) => {
+    syncSessionMetrics(ctx);
+    refresh(ctx);
+  });
 
   // Compaction and branch moves rewrite history, so the cached percentage is
   // stale the moment they land. Pi reports unknown occupancy until the next
   // assistant reply, which is the honest state to show.
-  pi.on("session_compact", (_event, ctx) => refresh(ctx));
+  pi.on("session_compact", (_event, ctx) => {
+    syncSessionMetrics(ctx);
+    refresh(ctx);
+  });
 
-  pi.on("session_tree", (_event, ctx) => refresh(ctx));
+  pi.on("session_tree", (_event, ctx) => {
+    syncSessionMetrics(ctx);
+    refresh(ctx);
+  });
 
   pi.on("agent_settled", (_event, ctx) => {
     state = { ...state, generating: false };
@@ -230,5 +217,6 @@ export default function modelInfo(pi: ExtensionAPI) {
   pi.on("session_shutdown", () => {
     stopRefreshListener();
     currentContext = undefined;
+    sessionMetrics.reset();
   });
 }

--- a/extensions/model-info/session-metrics.ts
+++ b/extensions/model-info/session-metrics.ts
@@ -1,0 +1,96 @@
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+import type { Usage } from "@earendil-works/pi-ai";
+
+type SessionMetricsManager = {
+  getSessionId(): string;
+  getLeafId(): string | null;
+  getEntry(id: string): SessionEntry | undefined;
+};
+
+type PrefixMetrics = Readonly<{
+  cost: number;
+  cacheRead: number;
+  promptTokens: number;
+}>;
+
+const EMPTY_PREFIX: PrefixMetrics = Object.freeze({
+  cost: 0,
+  cacheRead: 0,
+  promptTokens: 0,
+});
+
+function getUsage(entry: SessionEntry): Usage | undefined {
+  if (entry.type === "message") {
+    return entry.message.role === "assistant" ||
+      entry.message.role === "toolResult"
+      ? entry.message.usage
+      : undefined;
+  }
+  return entry.type === "compaction" || entry.type === "branch_summary"
+    ? entry.usage
+    : undefined;
+}
+
+function addUsage(prefix: PrefixMetrics, entry: SessionEntry): PrefixMetrics {
+  const usage = getUsage(entry);
+  if (!usage) return prefix;
+  return Object.freeze({
+    cost: prefix.cost + usage.cost.total,
+    cacheRead: prefix.cacheRead + usage.cacheRead,
+    promptTokens:
+      prefix.promptTokens + usage.input + usage.cacheRead + usage.cacheWrite,
+  });
+}
+
+function toMetrics(prefix: PrefixMetrics) {
+  return {
+    cost: prefix.cost,
+    cachePercent:
+      prefix.promptTokens > 0
+        ? (prefix.cacheRead / prefix.promptTokens) * 100
+        : null,
+  };
+}
+
+export function createSessionMetricsTracker() {
+  let sessionId: string | undefined;
+  let prefixes = new Map<string, PrefixMetrics>();
+
+  const reset = () => {
+    sessionId = undefined;
+    prefixes = new Map();
+  };
+
+  const sync = (manager: SessionMetricsManager) => {
+    const nextSessionId = manager.getSessionId();
+    if (sessionId !== nextSessionId) reset();
+    sessionId = nextSessionId;
+
+    const leafId = manager.getLeafId();
+    if (!leafId) return toMetrics(EMPTY_PREFIX);
+
+    const cachedLeaf = prefixes.get(leafId);
+    if (cachedLeaf) return toMetrics(cachedLeaf);
+
+    const suffix: SessionEntry[] = [];
+    let currentId: string | null = leafId;
+    while (currentId && !prefixes.has(currentId)) {
+      const entry = manager.getEntry(currentId);
+      if (!entry) break;
+      suffix.push(entry);
+      currentId = entry.parentId;
+    }
+
+    let prefix = currentId
+      ? (prefixes.get(currentId) ?? EMPTY_PREFIX)
+      : EMPTY_PREFIX;
+    for (const entry of suffix.reverse()) {
+      prefix = addUsage(prefix, entry);
+      prefixes.set(entry.id, prefix);
+    }
+
+    return toMetrics(prefixes.get(leafId) ?? EMPTY_PREFIX);
+  };
+
+  return { sync, reset };
+}

--- a/tests/extensions/model-info/index.test.ts
+++ b/tests/extensions/model-info/index.test.ts
@@ -133,19 +133,23 @@ class ModelInfoHarness {
   readonly publications: ModelInfoState[] = [];
   readonly manager: InstrumentedSessionManager;
   contextTokens = 100;
+  private model = {
+    provider: "openai",
+    id: "test-model",
+    name: "Test model",
+    contextWindow: 1_000,
+    reasoning: false,
+  };
   private readonly context: ExtensionContext;
 
   constructor(entries: SessionEntry[]) {
     this.manager = new InstrumentedSessionManager(entries);
     this.manager.leafId = entries.at(-1)?.id ?? null;
+    const thisHarness = this;
     this.context = {
       sessionManager: this.manager,
-      model: {
-        provider: "openai",
-        id: "test-model",
-        name: "Test model",
-        contextWindow: 1_000,
-        reasoning: false,
+      get model() {
+        return thisHarness.model;
       },
       getContextUsage: () => ({
         tokens: this.contextTokens,
@@ -196,6 +200,11 @@ class ModelInfoHarness {
       listener(undefined);
     }
   }
+
+  async selectModel(model: typeof this.model) {
+    this.model = model;
+    await this.emit("model_select", { model });
+  }
 }
 
 test("synchronizes initial history and waits for turn_end before counting an assistant message", async () => {
@@ -234,7 +243,7 @@ test("synchronizes initial history and waits for turn_end before counting an ass
   assert.equal(harness.manager.branchReads, 0);
 });
 
-test("refresh and agent events publish live context without traversing history", async () => {
+test("repeated ordinary events publish live state without traversing history", async () => {
   const harness = new ModelInfoHarness([
     user("user", null),
     assistant("assistant", "user", usage({ input: 10 })),
@@ -246,14 +255,42 @@ test("refresh and agent events publish live context without traversing history",
   harness.refresh();
   assert.equal(harness.state.contextTokens, 250);
 
+  harness.contextTokens = 375;
+  harness.refresh();
+  assert.equal(harness.state.contextTokens, 375);
+
   harness.contextTokens = 500;
-  await harness.emit("agent_start");
+  await harness.selectModel({
+    provider: "anthropic",
+    id: "new-model",
+    name: "New model",
+    contextWindow: 2_000,
+    reasoning: true,
+  });
   assert.equal(harness.state.contextTokens, 500);
+  assert.equal(harness.state.provider, "anthropic");
+  assert.equal(harness.state.modelId, "new-model");
+  assert.equal(harness.state.modelName, "New model");
+  assert.equal(harness.state.thinking, "low");
+
+  harness.contextTokens = 625;
+  await harness.emit("agent_start");
+  assert.equal(harness.state.contextTokens, 625);
   assert.equal(harness.state.generating, true);
 
   harness.contextTokens = 750;
-  await harness.emit("agent_settled");
+  await harness.emit("agent_start");
   assert.equal(harness.state.contextTokens, 750);
+  assert.equal(harness.state.generating, true);
+
+  harness.contextTokens = 875;
+  await harness.emit("agent_settled");
+  assert.equal(harness.state.contextTokens, 875);
+  assert.equal(harness.state.generating, false);
+
+  harness.contextTokens = 950;
+  await harness.emit("agent_settled");
+  assert.equal(harness.state.contextTokens, 950);
   assert.equal(harness.state.generating, false);
   assert.equal(harness.manager.visitCount(), visitsAfterStart);
   assert.equal(harness.manager.branchReads, 0);

--- a/tests/extensions/model-info/index.test.ts
+++ b/tests/extensions/model-info/index.test.ts
@@ -1,0 +1,316 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+  SessionEntry,
+} from "@earendil-works/pi-coding-agent";
+import type { Usage } from "@earendil-works/pi-ai";
+import modelInfo from "../../../extensions/model-info/index.ts";
+import {
+  MODEL_INFO_CHANNEL,
+  REFRESH_CHANNEL,
+  type ModelInfoState,
+} from "../../../extensions/shared/dashboard-state.ts";
+
+const timestamp = "2026-08-27T00:00:00.000Z";
+type MessageEntry = Extract<SessionEntry, { type: "message" }>;
+
+function usage(overrides: Partial<Usage> = {}): Usage {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    },
+    ...overrides,
+  };
+}
+
+function assistant(
+  id: string,
+  parentId: string | null,
+  messageUsage: Usage,
+): MessageEntry {
+  return {
+    type: "message",
+    id,
+    parentId,
+    timestamp,
+    message: {
+      role: "assistant",
+      content: [],
+      api: "openai-responses",
+      provider: "openai",
+      model: "test",
+      usage: messageUsage,
+      stopReason: "stop",
+      timestamp: 0,
+    },
+  };
+}
+
+function user(id: string, parentId: string | null): MessageEntry {
+  return {
+    type: "message",
+    id,
+    parentId,
+    timestamp,
+    message: { role: "user", content: [], timestamp: 0 },
+  };
+}
+
+function compaction(
+  id: string,
+  parentId: string | null,
+  entryUsage: Usage,
+): SessionEntry {
+  return {
+    type: "compaction",
+    id,
+    parentId,
+    timestamp,
+    summary: "summary",
+    firstKeptEntryId: "kept",
+    tokensBefore: 0,
+    usage: entryUsage,
+  };
+}
+
+class InstrumentedSessionManager {
+  readonly entries = new Map<string, SessionEntry>();
+  readonly visits = new Map<string, number>();
+  branchReads = 0;
+  leafId: string | null = null;
+
+  constructor(entries: SessionEntry[]) {
+    for (const entry of entries) this.entries.set(entry.id, entry);
+  }
+
+  getSessionId() {
+    return "session-a";
+  }
+
+  getLeafId() {
+    return this.leafId;
+  }
+
+  getEntry(id: string) {
+    this.visits.set(id, (this.visits.get(id) ?? 0) + 1);
+    return this.entries.get(id);
+  }
+
+  // The real SessionManager still exposes this method. Returning an empty
+  // branch makes a future full-branch scan observable without faking metrics.
+  getBranch() {
+    this.branchReads += 1;
+    return [];
+  }
+
+  append(entry: SessionEntry) {
+    this.entries.set(entry.id, entry);
+    this.leafId = entry.id;
+  }
+
+  visitCount() {
+    return [...this.visits.values()].reduce((total, count) => total + count, 0);
+  }
+}
+
+class ModelInfoHarness {
+  readonly handlers = new Map<
+    string,
+    (event: unknown, ctx: ExtensionContext) => unknown
+  >();
+  readonly listeners = new Map<string, Set<(value: unknown) => void>>();
+  readonly publications: ModelInfoState[] = [];
+  readonly manager: InstrumentedSessionManager;
+  contextTokens = 100;
+  private readonly context: ExtensionContext;
+
+  constructor(entries: SessionEntry[]) {
+    this.manager = new InstrumentedSessionManager(entries);
+    this.manager.leafId = entries.at(-1)?.id ?? null;
+    this.context = {
+      sessionManager: this.manager,
+      model: {
+        provider: "openai",
+        id: "test-model",
+        name: "Test model",
+        contextWindow: 1_000,
+        reasoning: false,
+      },
+      getContextUsage: () => ({
+        tokens: this.contextTokens,
+        contextWindow: 1_000,
+        percent: this.contextTokens / 10,
+      }),
+    } as unknown as ExtensionContext;
+
+    const api = {
+      getThinkingLevel: () => "low",
+      events: {
+        on: (channel: string, handler: (value: unknown) => void) => {
+          const handlers = this.listeners.get(channel) ?? new Set();
+          handlers.add(handler);
+          this.listeners.set(channel, handlers);
+          return () => handlers.delete(handler);
+        },
+        emit: (channel: string, value: unknown) => {
+          if (channel === MODEL_INFO_CHANNEL) {
+            this.publications.push(value as ModelInfoState);
+          }
+          for (const listener of this.listeners.get(channel) ?? []) {
+            listener(value);
+          }
+        },
+      },
+      on: (
+        event: string,
+        handler: (event: unknown, ctx: ExtensionContext) => unknown,
+      ) => this.handlers.set(event, handler),
+    } as unknown as ExtensionAPI;
+
+    modelInfo(api);
+  }
+
+  get state() {
+    const state = this.publications.at(-1);
+    assert.ok(state, "model info should have been published");
+    return state;
+  }
+
+  async emit(event: string, payload: unknown = {}) {
+    await this.handlers.get(event)?.(payload, this.context);
+  }
+
+  refresh() {
+    for (const listener of this.listeners.get(REFRESH_CHANNEL) ?? []) {
+      listener(undefined);
+    }
+  }
+}
+
+test("synchronizes initial history and waits for turn_end before counting an assistant message", async () => {
+  const initialUsage = usage({
+    input: 10,
+    cacheRead: 5,
+    cost: { input: 1, output: 0, cacheRead: 0, cacheWrite: 0, total: 1 },
+  });
+  const persistedUsage = usage({
+    input: 20,
+    cacheRead: 10,
+    cost: { input: 3, output: 0, cacheRead: 0, cacheWrite: 0, total: 3 },
+  });
+  const harness = new ModelInfoHarness([
+    user("user", null),
+    assistant("initial", "user", initialUsage),
+  ]);
+
+  await harness.emit("session_start");
+  assert.equal(harness.state.cost, 1);
+  assert.equal(harness.state.cachePercent, (5 / 15) * 100);
+  const visitsAfterStart = harness.manager.visitCount();
+  assert.ok(visitsAfterStart > 0);
+  assert.equal(harness.manager.branchReads, 0);
+
+  await harness.emit("message_end", {
+    message: assistant("pending", "initial", persistedUsage).message,
+  });
+  assert.equal(harness.state.cost, 1);
+  assert.equal(harness.manager.visitCount(), visitsAfterStart);
+
+  harness.manager.append(assistant("pending", "initial", persistedUsage));
+  await harness.emit("turn_end");
+  assert.equal(harness.state.cost, 4);
+  assert.equal(harness.manager.visitCount(), visitsAfterStart + 1);
+  assert.equal(harness.manager.branchReads, 0);
+});
+
+test("refresh and agent events publish live context without traversing history", async () => {
+  const harness = new ModelInfoHarness([
+    user("user", null),
+    assistant("assistant", "user", usage({ input: 10 })),
+  ]);
+  await harness.emit("session_start");
+  const visitsAfterStart = harness.manager.visitCount();
+
+  harness.contextTokens = 250;
+  harness.refresh();
+  assert.equal(harness.state.contextTokens, 250);
+
+  harness.contextTokens = 500;
+  await harness.emit("agent_start");
+  assert.equal(harness.state.contextTokens, 500);
+  assert.equal(harness.state.generating, true);
+
+  harness.contextTokens = 750;
+  await harness.emit("agent_settled");
+  assert.equal(harness.state.contextTokens, 750);
+  assert.equal(harness.state.generating, false);
+  assert.equal(harness.manager.visitCount(), visitsAfterStart);
+  assert.equal(harness.manager.branchReads, 0);
+});
+
+test("tree and compaction events synchronize the active leaf before publishing", async () => {
+  const harness = new ModelInfoHarness([
+    user("user", null),
+    assistant(
+      "first",
+      "user",
+      usage({
+        cost: { input: 2, output: 0, cacheRead: 0, cacheWrite: 0, total: 2 },
+      }),
+    ),
+  ]);
+  await harness.emit("session_start");
+
+  harness.manager.append(
+    assistant(
+      "tree-leaf",
+      "first",
+      usage({
+        cost: { input: 3, output: 0, cacheRead: 0, cacheWrite: 0, total: 3 },
+      }),
+    ),
+  );
+  await harness.emit("session_tree");
+  assert.equal(harness.state.cost, 5);
+
+  harness.manager.append(
+    compaction(
+      "compact",
+      "tree-leaf",
+      usage({
+        cost: { input: 5, output: 0, cacheRead: 0, cacheWrite: 0, total: 5 },
+      }),
+    ),
+  );
+  await harness.emit("session_compact");
+  assert.equal(harness.state.cost, 10);
+  assert.equal(harness.manager.branchReads, 0);
+});
+
+test("shutdown removes refresh work and clears the current context", async () => {
+  const harness = new ModelInfoHarness([
+    user("user", null),
+    assistant("assistant", "user", usage({ input: 10 })),
+  ]);
+  await harness.emit("session_start");
+  const publicationsBeforeShutdown = harness.publications.length;
+  const visitsBeforeShutdown = harness.manager.visitCount();
+
+  await harness.emit("session_shutdown");
+  harness.contextTokens = 500;
+  harness.refresh();
+
+  assert.equal(harness.publications.length, publicationsBeforeShutdown);
+  assert.equal(harness.manager.visitCount(), visitsBeforeShutdown);
+});

--- a/tests/extensions/model-info/session-metrics.test.ts
+++ b/tests/extensions/model-info/session-metrics.test.ts
@@ -251,7 +251,7 @@ test("does not revisit entries for a repeated sync of the same leaf", () => {
   assert.equal(manager.visitCount(), visitsAfterFirstSync);
 });
 
-test("visits each appended suffix entry once", () => {
+test("visits each appended suffix entry once without revisiting cached ancestors", () => {
   const manager = new InstrumentedSessionManager([
     message("user", null, "user"),
     message("assistant", "user", "assistant", usage({ input: 10 })),
@@ -259,6 +259,10 @@ test("visits each appended suffix entry once", () => {
   manager.setLeaf("assistant");
   const tracker = createSessionMetricsTracker();
   tracker.sync(manager);
+  const cachedAncestorVisits = {
+    user: manager.visits.get("user"),
+    assistant: manager.visits.get("assistant"),
+  };
 
   manager.append(
     message("tool", "assistant", "toolResult", usage({ input: 5 })),
@@ -268,6 +272,8 @@ test("visits each appended suffix entry once", () => {
 
   assert.equal(manager.visits.get("tool"), 1);
   assert.equal(manager.visits.get("next"), 1);
+  assert.equal(manager.visits.get("user"), cachedAncestorVisits.user);
+  assert.equal(manager.visits.get("assistant"), cachedAncestorVisits.assistant);
 });
 
 test("returns cached totals when switching to a cached ancestor", () => {
@@ -287,7 +293,7 @@ test("returns cached totals when switching to a cached ancestor", () => {
   assert.equal(manager.visitCount(), visitsAfterInitialSync);
 });
 
-test("visits an unseen sibling once after its cached ancestor", () => {
+test("visits an unseen sibling once without revisiting its cached ancestors", () => {
   const manager = new InstrumentedSessionManager([
     message("user", null, "user"),
     message("assistant", "user", "assistant", usage({ input: 10 })),
@@ -297,11 +303,17 @@ test("visits an unseen sibling once after its cached ancestor", () => {
   manager.setLeaf("tool");
   const tracker = createSessionMetricsTracker();
   tracker.sync(manager);
+  const cachedAncestorVisits = {
+    user: manager.visits.get("user"),
+    assistant: manager.visits.get("assistant"),
+  };
 
   manager.setLeaf("sibling");
 
   assert.deepEqual(tracker.sync(manager), fullActiveBranchMetrics(manager));
   assert.equal(manager.visits.get("sibling"), 1);
+  assert.equal(manager.visits.get("user"), cachedAncestorVisits.user);
+  assert.equal(manager.visits.get("assistant"), cachedAncestorVisits.assistant);
 });
 
 test("counts compaction and branch-summary usage", () => {

--- a/tests/extensions/model-info/session-metrics.test.ts
+++ b/tests/extensions/model-info/session-metrics.test.ts
@@ -1,0 +1,386 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+import type { Usage } from "@earendil-works/pi-ai";
+import { createSessionMetricsTracker } from "../../../extensions/model-info/session-metrics.ts";
+
+const timestamp = "2026-08-27T00:00:00.000Z";
+
+function usage(overrides: Partial<Usage> = {}): Usage {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    },
+    ...overrides,
+  };
+}
+
+function message(
+  id: string,
+  parentId: string | null,
+  role: "user" | "assistant" | "toolResult",
+  messageUsage?: Usage,
+): SessionEntry {
+  if (role === "assistant") {
+    return {
+      type: "message",
+      id,
+      parentId,
+      timestamp,
+      message: {
+        role,
+        content: [],
+        api: "openai-responses",
+        provider: "openai",
+        model: "test",
+        usage: messageUsage ?? usage(),
+        stopReason: "stop",
+        timestamp: 0,
+      },
+    };
+  }
+
+  if (role === "toolResult") {
+    return {
+      type: "message",
+      id,
+      parentId,
+      timestamp,
+      message: {
+        role,
+        toolCallId: `${id}-call`,
+        toolName: "test",
+        content: [],
+        isError: false,
+        timestamp: 0,
+        ...(messageUsage ? { usage: messageUsage } : {}),
+      },
+    };
+  }
+
+  return {
+    type: "message",
+    id,
+    parentId,
+    timestamp,
+    message: { role, content: [], timestamp: 0 },
+  };
+}
+
+function compaction(
+  id: string,
+  parentId: string | null,
+  entryUsage?: Usage,
+): SessionEntry {
+  return {
+    type: "compaction",
+    id,
+    parentId,
+    timestamp,
+    summary: "summary",
+    firstKeptEntryId: "kept",
+    tokensBefore: 0,
+    ...(entryUsage ? { usage: entryUsage } : {}),
+  };
+}
+
+function branchSummary(
+  id: string,
+  parentId: string | null,
+  entryUsage?: Usage,
+): SessionEntry {
+  return {
+    type: "branch_summary",
+    id,
+    parentId,
+    timestamp,
+    fromId: "from",
+    summary: "summary",
+    ...(entryUsage ? { usage: entryUsage } : {}),
+  };
+}
+
+function entryUsage(entry: SessionEntry) {
+  if (entry.type === "message") {
+    return entry.message.role === "assistant" ||
+      entry.message.role === "toolResult"
+      ? entry.message.usage
+      : undefined;
+  }
+  return entry.type === "compaction" || entry.type === "branch_summary"
+    ? entry.usage
+    : undefined;
+}
+
+class InstrumentedSessionManager {
+  readonly entries = new Map<string, SessionEntry>();
+  readonly visits = new Map<string, number>();
+  sessionId = "session-a";
+  leafId: string | null = null;
+
+  constructor(entries: SessionEntry[]) {
+    for (const entry of entries) this.entries.set(entry.id, entry);
+  }
+
+  getSessionId() {
+    return this.sessionId;
+  }
+
+  getLeafId() {
+    return this.leafId;
+  }
+
+  getEntry(id: string) {
+    this.visits.set(id, (this.visits.get(id) ?? 0) + 1);
+    return this.entries.get(id);
+  }
+
+  setLeaf(id: string | null) {
+    this.leafId = id;
+  }
+
+  append(entry: SessionEntry) {
+    this.entries.set(entry.id, entry);
+    this.leafId = entry.id;
+  }
+
+  visitCount() {
+    return [...this.visits.values()].reduce((total, count) => total + count, 0);
+  }
+}
+
+function fullActiveBranchMetrics(manager: InstrumentedSessionManager) {
+  const entries: SessionEntry[] = [];
+  let currentId = manager.leafId;
+  while (currentId) {
+    const entry = manager.entries.get(currentId);
+    if (!entry) break;
+    entries.push(entry);
+    currentId = entry.parentId;
+  }
+
+  let cost = 0;
+  let cacheRead = 0;
+  let promptTokens = 0;
+  for (const entry of entries.reverse()) {
+    const currentUsage = entryUsage(entry);
+    if (!currentUsage) continue;
+    cost += currentUsage.cost.total;
+    cacheRead += currentUsage.cacheRead;
+    promptTokens +=
+      currentUsage.input + currentUsage.cacheRead + currentUsage.cacheWrite;
+  }
+  return {
+    cost,
+    cachePercent: promptTokens > 0 ? (cacheRead / promptTokens) * 100 : null,
+  };
+}
+
+test("matches a full scan of the active branch", () => {
+  const manager = new InstrumentedSessionManager([
+    message("user", null, "user"),
+    message(
+      "assistant",
+      "user",
+      "assistant",
+      usage({
+        input: 100,
+        cacheRead: 50,
+        cacheWrite: 25,
+        cost: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 },
+      }),
+    ),
+    message(
+      "tool",
+      "assistant",
+      "toolResult",
+      usage({
+        input: 10,
+        cacheRead: 5,
+        cacheWrite: 0,
+        cost: { input: 1, output: 0, cacheRead: 0, cacheWrite: 0, total: 1 },
+      }),
+    ),
+  ]);
+  manager.setLeaf("tool");
+
+  assert.deepEqual(
+    createSessionMetricsTracker().sync(manager),
+    fullActiveBranchMetrics(manager),
+  );
+});
+
+test("returns null cache percentage for zero and missing usage", () => {
+  const manager = new InstrumentedSessionManager([
+    message("user", null, "user"),
+    message("assistant", "user", "assistant", usage()),
+    message("tool", "assistant", "toolResult"),
+    compaction("compaction", "tool"),
+    branchSummary("summary", "compaction"),
+  ]);
+  manager.setLeaf("summary");
+
+  assert.deepEqual(createSessionMetricsTracker().sync(manager), {
+    cost: 0,
+    cachePercent: null,
+  });
+});
+
+test("does not revisit entries for a repeated sync of the same leaf", () => {
+  const manager = new InstrumentedSessionManager([
+    message("user", null, "user"),
+    message("assistant", "user", "assistant", usage({ input: 10 })),
+  ]);
+  manager.setLeaf("assistant");
+  const tracker = createSessionMetricsTracker();
+
+  tracker.sync(manager);
+  const visitsAfterFirstSync = manager.visitCount();
+
+  tracker.sync(manager);
+
+  assert.equal(manager.visitCount(), visitsAfterFirstSync);
+});
+
+test("visits each appended suffix entry once", () => {
+  const manager = new InstrumentedSessionManager([
+    message("user", null, "user"),
+    message("assistant", "user", "assistant", usage({ input: 10 })),
+  ]);
+  manager.setLeaf("assistant");
+  const tracker = createSessionMetricsTracker();
+  tracker.sync(manager);
+
+  manager.append(
+    message("tool", "assistant", "toolResult", usage({ input: 5 })),
+  );
+  manager.append(message("next", "tool", "assistant", usage({ input: 3 })));
+  tracker.sync(manager);
+
+  assert.equal(manager.visits.get("tool"), 1);
+  assert.equal(manager.visits.get("next"), 1);
+});
+
+test("returns cached totals when switching to a cached ancestor", () => {
+  const manager = new InstrumentedSessionManager([
+    message("user", null, "user"),
+    message("assistant", "user", "assistant", usage({ input: 10 })),
+    message("tool", "assistant", "toolResult", usage({ input: 5 })),
+  ]);
+  manager.setLeaf("tool");
+  const tracker = createSessionMetricsTracker();
+  tracker.sync(manager);
+  const visitsAfterInitialSync = manager.visitCount();
+
+  manager.setLeaf("assistant");
+
+  assert.deepEqual(tracker.sync(manager), fullActiveBranchMetrics(manager));
+  assert.equal(manager.visitCount(), visitsAfterInitialSync);
+});
+
+test("visits an unseen sibling once after its cached ancestor", () => {
+  const manager = new InstrumentedSessionManager([
+    message("user", null, "user"),
+    message("assistant", "user", "assistant", usage({ input: 10 })),
+    message("tool", "assistant", "toolResult", usage({ input: 5 })),
+    message("sibling", "assistant", "assistant", usage({ input: 7 })),
+  ]);
+  manager.setLeaf("tool");
+  const tracker = createSessionMetricsTracker();
+  tracker.sync(manager);
+
+  manager.setLeaf("sibling");
+
+  assert.deepEqual(tracker.sync(manager), fullActiveBranchMetrics(manager));
+  assert.equal(manager.visits.get("sibling"), 1);
+});
+
+test("counts compaction and branch-summary usage", () => {
+  const manager = new InstrumentedSessionManager([
+    compaction(
+      "compaction",
+      null,
+      usage({
+        input: 20,
+        cacheRead: 30,
+        cacheWrite: 10,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 2 },
+      }),
+    ),
+    branchSummary(
+      "summary",
+      "compaction",
+      usage({
+        input: 40,
+        cacheRead: 20,
+        cacheWrite: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 3 },
+      }),
+    ),
+  ]);
+  manager.setLeaf("summary");
+
+  assert.deepEqual(createSessionMetricsTracker().sync(manager), {
+    cost: 5,
+    cachePercent: (50 / 120) * 100,
+  });
+});
+
+test("recomputes all metrics after an explicit reset", () => {
+  const manager = new InstrumentedSessionManager([
+    message("user", null, "user"),
+    message("assistant", "user", "assistant", usage({ input: 10 })),
+  ]);
+  manager.setLeaf("assistant");
+  const tracker = createSessionMetricsTracker();
+  tracker.sync(manager);
+  const visitsAfterFirstSync = manager.visitCount();
+
+  tracker.reset();
+
+  assert.deepEqual(tracker.sync(manager), fullActiveBranchMetrics(manager));
+  assert.equal(manager.visitCount(), visitsAfterFirstSync + 2);
+});
+
+test("resets automatically when a new session reuses entry ids", () => {
+  const manager = new InstrumentedSessionManager([
+    message(
+      "entry",
+      null,
+      "assistant",
+      usage({
+        input: 10,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 1 },
+      }),
+    ),
+  ]);
+  manager.setLeaf("entry");
+  const tracker = createSessionMetricsTracker();
+  assert.deepEqual(tracker.sync(manager), { cost: 1, cachePercent: 0 });
+
+  manager.sessionId = "session-b";
+  manager.entries.set(
+    "entry",
+    message(
+      "entry",
+      null,
+      "assistant",
+      usage({
+        input: 20,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 9 },
+      }),
+    ),
+  );
+
+  assert.deepEqual(tracker.sync(manager), { cost: 9, cachePercent: 0 });
+  assert.equal(manager.visits.get("entry"), 2);
+});


### PR DESCRIPTION
## Summary

- cache active-branch usage prefixes by Pi session entry id so repeated model-info refreshes no longer rescan the full branch
- synchronize cumulative metrics only at persisted-history lifecycle edges while keeping live context/UI refreshes history-free
- cover branch changes, session resets, lifecycle ordering, and repeated ordinary refreshes with deterministic tests
- add a real SessionManager benchmark for 1k/10k/100k entries and 1/10/100 tool turns

## Verification

- `node --test --experimental-strip-types tests/extensions/model-info/session-metrics.test.ts tests/extensions/model-info/index.test.ts` — 13 passed
- `bun run check` — passed
- `bun run test` — 917 Node tests and 30 Vitest tests passed
- `bun benchmarks/model-info-session-metrics.ts` — full default matrix completed
- 100k entries / 100 tool turns: 20,220,200 full-scan visits vs 100,200 prefix-tracker visits, including the 100,000-entry cold start

Manual TUI smoke was not run because the local `pi list` had no package installed; no unconfigured model call was made.

Closes #188
