### PR TITLE
perf(sessions): bound Git stats to visible rows

### DIFF
--- a/benchmarks/session-git-stats.ts
+++ b/benchmarks/session-git-stats.ts
@@ -1,0 +1,236 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { createSessionStatsLoader } from "../extensions/sessions/git-stats.ts";
+import type { SessionInfoLike } from "../extensions/sessions/sessions.ts";
+
+const run = (args: string[], cwd: string, signal?: AbortSignal) =>
+  new Promise<string>((resolve, reject) => {
+    execFile(
+      "git",
+      args,
+      { cwd, encoding: "utf8", signal },
+      (error, stdout) => {
+        if (error) reject(error);
+        else resolve(stdout);
+      },
+    );
+  });
+
+async function createRepository(root: string, index: number) {
+  const cwd = join(root, `repo-${index}`);
+  await mkdir(cwd);
+  await run(["init", "-q"], cwd);
+  await run(["config", "user.email", "benchmark@openpi.local"], cwd);
+  await run(["config", "user.name", "OpenPI benchmark"], cwd);
+  await writeFile(join(cwd, "tracked.txt"), "baseline\n");
+  await run(["add", "tracked.txt"], cwd);
+  await run(["commit", "-qm", "benchmark fixture"], cwd);
+  await writeFile(join(cwd, "tracked.txt"), "baseline\nworking\n");
+  return cwd;
+}
+
+function makeSessions(
+  count: number,
+  repositories: readonly string[],
+  sameWorkspace: boolean,
+) {
+  const now = Date.now();
+  return Array.from({ length: count }, (_, index): SessionInfoLike => {
+    const modified = new Date(now - index * 1_000);
+    return {
+      id: `session-${index}`,
+      cwd: sameWorkspace
+        ? repositories[0]!
+        : repositories[index % repositories.length]!,
+      created: new Date(modified.getTime() - 24 * 60 * 60 * 1_000),
+      modified,
+      firstMessage: "benchmark",
+      path: join(root, `session-${index}.jsonl`),
+    };
+  });
+}
+
+async function measure(
+  count: number,
+  repositories: readonly string[],
+  sameWorkspace: boolean,
+) {
+  const sessions = makeSessions(count, repositories, sameWorkspace);
+  const targets = sessions.slice(0, Math.min(12, sessions.length));
+  let calls = 0;
+  const loader = createSessionStatsLoader({
+    runGit: (args, cwd, signal) => {
+      calls++;
+      return run(args, cwd, signal);
+    },
+  });
+
+  const coldStarted = performance.now();
+  await loader.reconcile(targets, sessions, () => undefined);
+  const coldMs = performance.now() - coldStarted;
+  const coldCalls = calls;
+
+  const warmStarted = performance.now();
+  await loader.reconcile(targets, sessions, () => undefined);
+  const warmMs = performance.now() - warmStarted;
+
+  console.log(
+    JSON.stringify({
+      phase: "viewport",
+      sessions: count,
+      mode: sameWorkspace ? "same-workspace" : "multi-workspace",
+      visible: targets.length,
+      coldCalls,
+      coldMs: Number(coldMs.toFixed(1)),
+      warmCalls: calls - coldCalls,
+      warmMs: Number(warmMs.toFixed(1)),
+      cacheEntries: loader.cache.size,
+    }),
+  );
+}
+
+async function measureCancellation(repositories: readonly string[]) {
+  const sessions = makeSessions(1_000, repositories, false);
+  let started = 0;
+  let resolveStarted!: () => void;
+  const enoughStarted = new Promise<void>((resolve) => {
+    resolveStarted = resolve;
+  });
+  const loader = createSessionStatsLoader({
+    maxConcurrency: 4,
+    runGit: (_args, _cwd, signal) => {
+      started++;
+      if (started === 4) resolveStarted();
+      return new Promise<string>((resolve, reject) => {
+        const timer = setTimeout(() => resolve(""), 1_000);
+        signal.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+          },
+          { once: true },
+        );
+      });
+    },
+  });
+  const loading = loader.reconcile(
+    sessions.slice(0, 12),
+    sessions,
+    () => undefined,
+  );
+  await enoughStarted;
+  const cancelStarted = performance.now();
+  loader.cancel();
+  await loading;
+  console.log(
+    JSON.stringify({
+      phase: "cancel",
+      sessions: sessions.length,
+      visible: 12,
+      started,
+      cancelMs: Number((performance.now() - cancelStarted).toFixed(1)),
+      cacheEntries: loader.cache.size,
+    }),
+  );
+}
+
+async function measureCanonicalDiscovery() {
+  const now = Date.now();
+  const sessions = Array.from(
+    { length: 1_000 },
+    (_, index): SessionInfoLike => ({
+      id: `canonical-${index}`,
+      cwd: join(root, `canonical-workspace-${index}`),
+      created: new Date(now - 24 * 60 * 60 * 1_000),
+      modified: new Date(now - index),
+      firstMessage: "benchmark",
+      path: join(root, `canonical-session-${index}.jsonl`),
+    }),
+  );
+  let canonicalCalls = 0;
+  let canonicalActive = 0;
+  let canonicalMaxActive = 0;
+  const loader = createSessionStatsLoader({
+    canonicalizeConcurrency: 8,
+    canonicalizeCwd: async (cwd) => {
+      canonicalCalls++;
+      canonicalActive++;
+      canonicalMaxActive = Math.max(canonicalMaxActive, canonicalActive);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      canonicalActive--;
+      return cwd;
+    },
+    runGit: async () => "",
+  });
+  const started = performance.now();
+  await loader.reconcile(sessions.slice(0, 12), sessions, () => undefined);
+  const coldMs = performance.now() - started;
+  await loader.reconcile(sessions.slice(12, 24), sessions, () => undefined);
+  console.log(
+    JSON.stringify({
+      phase: "canonical",
+      sessions: sessions.length,
+      uniqueWorkspaces: sessions.length,
+      canonicalCalls,
+      canonicalMaxActive,
+      coldMs: Number(coldMs.toFixed(1)),
+      repeatedUniverseCalls: canonicalCalls - sessions.length,
+    }),
+  );
+
+  let cancelStarts = 0;
+  let resolveStarted!: () => void;
+  const enoughStarted = new Promise<void>((resolve) => {
+    resolveStarted = resolve;
+  });
+  const releases: Array<() => void> = [];
+  const cancellable = createSessionStatsLoader({
+    canonicalizeConcurrency: 4,
+    canonicalizeCwd: (cwd) => {
+      cancelStarts++;
+      if (cancelStarts === 4) resolveStarted();
+      return new Promise<string>((resolve) => {
+        releases.push(() => resolve(cwd));
+      });
+    },
+    runGit: async () => "",
+  });
+  const loading = cancellable.reconcile(
+    sessions.slice(0, 12),
+    sessions,
+    () => undefined,
+  );
+  await enoughStarted;
+  const cancelStarted = performance.now();
+  cancellable.cancel();
+  for (const release of releases) release();
+  await loading;
+  console.log(
+    JSON.stringify({
+      phase: "canonical-cancel",
+      sessions: sessions.length,
+      started: cancelStarts,
+      cancelMs: Number((performance.now() - cancelStarted).toFixed(1)),
+      cacheEntries: cancellable.cache.size,
+    }),
+  );
+}
+
+const root = await mkdtemp(join(tmpdir(), "openpi-session-git-stats-"));
+try {
+  const repositories = await Promise.all(
+    Array.from({ length: 12 }, (_, index) => createRepository(root, index)),
+  );
+  for (const count of [10, 120, 1_000]) {
+    await measure(count, repositories, false);
+    await measure(count, repositories, true);
+  }
+  await measureCancellation(repositories);
+  await measureCanonicalDiscovery();
+} finally {
+  await rm(root, { recursive: true, force: true });
+}

--- a/extensions/sessions/git-stats.ts
+++ b/extensions/sessions/git-stats.ts
@@ -1,4 +1,6 @@
 import { execFile } from "node:child_process";
+import { realpath } from "node:fs/promises";
+import { resolve } from "node:path";
 import type { SessionInfoLike } from "./sessions.ts";
 
 export interface SessionStats {
@@ -7,8 +9,15 @@ export interface SessionStats {
   del: number;
 }
 
+export type SessionStatsState =
+  | { status: "pending" }
+  | { status: "ready"; stats: SessionStats }
+  | { status: "unavailable" };
+
+type CachedSessionStats = Exclude<SessionStatsState, { status: "pending" }>;
+
 interface StatsLoaderOptions {
-  cache?: Map<string, SessionStats>;
+  cache?: Map<string, CachedSessionStats>;
   maxCache?: number;
   maxConcurrency?: number;
   runGit?: (
@@ -16,6 +25,8 @@ interface StatsLoaderOptions {
     cwd: string,
     signal: AbortSignal,
   ) => Promise<string>;
+  canonicalizeCwd?: (cwd: string) => Promise<string>;
+  canonicalizeConcurrency?: number;
 }
 
 interface QueueEntry {
@@ -27,6 +38,7 @@ interface QueueEntry {
 const GIT_STATS_TIMEOUT_MS = 3_000;
 const DEFAULT_MAX_CACHE = 256;
 const DEFAULT_MAX_CONCURRENCY = 4;
+const DEFAULT_CANONICALIZE_CONCURRENCY = 8;
 
 const abortError = () => {
   const error = new Error("Session stats load was cancelled.");
@@ -97,7 +109,7 @@ function createQueue(maxConcurrency: number) {
 }
 
 const runGit = (args: string[], cwd: string, signal: AbortSignal) =>
-  new Promise<string>((resolve) => {
+  new Promise<string>((resolveOutput, reject) => {
     try {
       execFile(
         "git",
@@ -108,10 +120,13 @@ const runGit = (args: string[], cwd: string, signal: AbortSignal) =>
           timeout: GIT_STATS_TIMEOUT_MS,
           signal,
         },
-        (error, stdout) => resolve(error ? "" : stdout),
+        (error, stdout) => {
+          if (error) reject(error);
+          else resolveOutput(stdout);
+        },
       );
-    } catch {
-      resolve("");
+    } catch (error) {
+      reject(error);
     }
   });
 
@@ -133,94 +148,265 @@ const calculateStats = (outputs: readonly string[]) => {
 };
 
 export function createSessionStatsLoader(options: StatsLoaderOptions = {}) {
-  const cache = options.cache ?? new Map<string, SessionStats>();
+  const cache = options.cache ?? new Map<string, CachedSessionStats>();
   const maxCache = options.maxCache ?? DEFAULT_MAX_CACHE;
   const execute = options.runGit ?? runGit;
+  const canonicalize = options.canonicalizeCwd ?? realpath;
+  const canonicalizeConcurrency = Math.max(
+    1,
+    options.canonicalizeConcurrency ?? DEFAULT_CANONICALIZE_CONCURRENCY,
+  );
   const queue = createQueue(
     Math.max(1, options.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY),
   );
-  const loading = new Map<string, AbortSignal>();
+  interface Request {
+    key: string;
+    cwd: string;
+    after: string;
+    before: string;
+    includeWorktreeDiff: boolean;
+  }
+  interface ActiveRequest {
+    controller: AbortController;
+    promise: Promise<void>;
+  }
 
-  const loadOne = async (
-    session: SessionInfoLike,
-    isLatestForCwd: boolean,
+  const active = new Map<string, ActiveRequest>();
+  const pathKeys = new Map<string, string>();
+  const canonicalCwds = new Map<string, Promise<string>>();
+  let canonicalUniverse:
+    | {
+        universe: readonly SessionInfoLike[];
+        controller: AbortController;
+        promise: Promise<Map<string, string>>;
+      }
+    | undefined;
+  let requestedPaths = new Set<string>();
+  let reconcileGeneration = 0;
+  let notify = () => {};
+
+  const canonicalCwd = (cwd: string) => {
+    const absolute = resolve(cwd);
+    let pending = canonicalCwds.get(absolute);
+    if (!pending) {
+      pending = canonicalize(absolute).catch(() => absolute);
+      canonicalCwds.set(absolute, pending);
+    }
+    return pending;
+  };
+
+  const buildCanonicalWorkspaceMap = async (
+    sessions: readonly SessionInfoLike[],
     signal: AbortSignal,
-    onUpdate: () => void,
   ) => {
-    const key = session.path;
-    if (cache.has(key)) return;
-    const currentLoad = loading.get(key);
-    if (currentLoad && !currentLoad.aborted) return;
-    loading.set(key, signal);
+    const workspaces = [
+      ...new Set(sessions.map((session) => resolve(session.cwd))),
+    ];
+    const result = new Map<string, string>();
+    let index = 0;
+    const worker = async () => {
+      while (!signal.aborted) {
+        const cwd = workspaces[index++];
+        if (!cwd) return;
+        result.set(cwd, await canonicalCwd(cwd));
+      }
+    };
+    await Promise.all(
+      Array.from(
+        { length: Math.min(canonicalizeConcurrency, workspaces.length) },
+        worker,
+      ),
+    );
+    if (signal.aborted) throw abortError();
+    return result;
+  };
 
+  const canonicalWorkspaceMap = (sessions: readonly SessionInfoLike[]) => {
+    if (
+      canonicalUniverse?.universe === sessions &&
+      !canonicalUniverse.controller.signal.aborted
+    ) {
+      return canonicalUniverse.promise;
+    }
+    canonicalUniverse?.controller.abort();
+    const controller = new AbortController();
+    const promise = buildCanonicalWorkspaceMap(sessions, controller.signal);
+    canonicalUniverse = { universe: sessions, controller, promise };
+    return promise;
+  };
+
+  const latestPathsByCwd = (
+    sessions: readonly SessionInfoLike[],
+    canonical: ReadonlyMap<string, string>,
+  ) => {
+    const latest = new Map<string, SessionInfoLike>();
+    for (const session of sessions) {
+      const cwd = canonical.get(resolve(session.cwd)) ?? resolve(session.cwd);
+      const current = latest.get(cwd);
+      if (!current || session.modified.getTime() > current.modified.getTime()) {
+        latest.set(cwd, session);
+      }
+    }
+    return new Map(
+      [...latest].map(([cwd, session]) => [cwd, session.path] as const),
+    );
+  };
+
+  const requestFor = (
+    session: SessionInfoLike,
+    latest: ReadonlyMap<string, string>,
+    canonical: ReadonlyMap<string, string>,
+  ): Request => {
+    const cwd = canonical.get(resolve(session.cwd)) ?? resolve(session.cwd);
     const after = session.created
       ? session.created.toISOString()
       : new Date(session.modified.getTime() - 24 * 3600 * 1000).toISOString();
     const before = session.modified.toISOString();
-
-    try {
-      const outputs = await Promise.all([
-        queue
-          .run(
-            () =>
-              execute(
-                [
-                  "log",
-                  `--after=${after}`,
-                  `--before=${before}`,
-                  "--numstat",
-                  "--pretty=format:",
-                ],
-                session.cwd,
-                signal,
-              ),
-            signal,
-          )
-          .catch(() => ""),
-        isLatestForCwd
-          ? queue
-              .run(
-                () => execute(["diff", "--numstat"], session.cwd, signal),
-                signal,
-              )
-              .catch(() => "")
-          : Promise.resolve(""),
-      ]);
-      if (signal.aborted || loading.get(key) !== signal) return;
-
-      if (cache.size >= maxCache) {
-        const oldest = cache.keys().next().value;
-        if (oldest !== undefined) cache.delete(oldest);
-      }
-      cache.set(key, calculateStats(outputs));
-      onUpdate();
-    } finally {
-      if (loading.get(key) === signal) loading.delete(key);
-    }
+    const includeWorktreeDiff = latest.get(cwd) === session.path;
+    return {
+      key: JSON.stringify([cwd, after, before, includeWorktreeDiff]),
+      cwd,
+      after,
+      before,
+      includeWorktreeDiff,
+    };
   };
 
-  const load = (
-    sessions: SessionInfoLike[],
-    signal: AbortSignal,
+  const putCache = (key: string, value: CachedSessionStats) => {
+    if (cache.has(key)) cache.delete(key);
+    while (cache.size >= Math.max(1, maxCache)) {
+      const oldest = cache.keys().next().value;
+      if (oldest === undefined) break;
+      cache.delete(oldest);
+    }
+    cache.set(key, value);
+  };
+
+  const start = (request: Request) => {
+    const controller = new AbortController();
+    const promise = Promise.all([
+      queue.run(
+        () =>
+          execute(
+            [
+              "log",
+              `--after=${request.after}`,
+              `--before=${request.before}`,
+              "--numstat",
+              "--pretty=format:",
+            ],
+            request.cwd,
+            controller.signal,
+          ),
+        controller.signal,
+      ),
+      request.includeWorktreeDiff
+        ? queue.run(
+            () =>
+              execute(["diff", "--numstat"], request.cwd, controller.signal),
+            controller.signal,
+          )
+        : Promise.resolve(""),
+    ])
+      .then((outputs) => {
+        if (!controller.signal.aborted) {
+          putCache(request.key, {
+            status: "ready",
+            stats: calculateStats(outputs),
+          });
+          notify();
+        }
+      })
+      .catch(() => {
+        const cancelled = controller.signal.aborted;
+        if (!cancelled) {
+          putCache(request.key, { status: "unavailable" });
+          notify();
+          controller.abort();
+        }
+      })
+      .finally(() => {
+        if (active.get(request.key)?.controller === controller) {
+          active.delete(request.key);
+        }
+      });
+    const entry = { controller, promise };
+    active.set(request.key, entry);
+    return entry;
+  };
+
+  const cancelKey = (key: string) => {
+    const entry = active.get(key);
+    if (!entry) return;
+    active.delete(key);
+    entry.controller.abort();
+  };
+
+  const reconcile = async (
+    targets: readonly SessionInfoLike[],
+    universe: readonly SessionInfoLike[],
     onUpdate: () => void,
   ) => {
-    const latestByCwd = new Map<string, string>();
-    for (const session of sessions) {
-      if (!latestByCwd.has(session.cwd)) {
-        latestByCwd.set(session.cwd, session.path);
-      }
+    notify = onUpdate;
+    const generation = ++reconcileGeneration;
+    requestedPaths = new Set(targets.map((session) => session.path));
+    if (targets.length === 0) {
+      for (const key of [...active.keys()]) cancelKey(key);
+      pathKeys.clear();
+      return;
     }
-    return Promise.all(
-      sessions.map((session) =>
-        loadOne(
-          session,
-          latestByCwd.get(session.cwd) === session.path,
-          signal,
-          onUpdate,
-        ),
-      ),
-    ).then(() => undefined);
+
+    let canonical: ReadonlyMap<string, string>;
+    try {
+      canonical = await canonicalWorkspaceMap(universe);
+    } catch {
+      return;
+    }
+    if (generation !== reconcileGeneration) return;
+    const latest = latestPathsByCwd(universe, canonical);
+    const requests = targets.map((session) => ({
+      session,
+      request: requestFor(session, latest, canonical),
+    }));
+    const wanted = new Set(requests.map(({ request }) => request.key));
+
+    for (const key of active.keys()) {
+      if (!wanted.has(key)) cancelKey(key);
+    }
+
+    pathKeys.clear();
+    const pending: Promise<void>[] = [];
+    for (const { session, request } of requests) {
+      pathKeys.set(session.path, request.key);
+      if (cache.has(request.key)) continue;
+      const current = active.get(request.key) ?? start(request);
+      pending.push(current.promise);
+    }
+    await Promise.all(pending);
   };
 
-  return { cache, load };
+  const get = (session: SessionInfoLike): SessionStatsState | undefined => {
+    if (!requestedPaths.has(session.path)) return undefined;
+    const key = pathKeys.get(session.path);
+    if (!key) return { status: "pending" };
+    const cached = cache.get(key);
+    if (cached) {
+      cache.delete(key);
+      cache.set(key, cached);
+      return cached;
+    }
+    if (active.has(key)) return { status: "pending" };
+    return undefined;
+  };
+
+  const cancel = () => {
+    reconcileGeneration++;
+    canonicalUniverse?.controller.abort();
+    canonicalUniverse = undefined;
+    for (const key of [...active.keys()]) cancelKey(key);
+    pathKeys.clear();
+    requestedPaths.clear();
+  };
+
+  return { cache, get, reconcile, cancel };
 }

--- a/extensions/sessions/index.ts
+++ b/extensions/sessions/index.ts
@@ -22,7 +22,10 @@ import {
   wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import { hintLine } from "../shared/screen-chrome.ts";
-import { createSessionStatsLoader, type SessionStats } from "./git-stats.js";
+import {
+  createSessionStatsLoader,
+  type SessionStatsState,
+} from "./git-stats.js";
 import {
   createSessionPreviewCache,
   measureSessionPreviewBytes,
@@ -44,6 +47,7 @@ import {
   type PreviewBlock,
   type PreviewMessageLike,
   parseLimit,
+  selectSessionStatsWindow,
   type SessionInfoLike,
   type SessionPreview,
 } from "./sessions.js";
@@ -301,20 +305,16 @@ const renderPreviewBlock = (
   return renderTextBlock(`◇ ${block.label}`, block.text, width, theme, "muted");
 };
 
-/** Cached across picker openings, while the loader bounds process-wide Git work. */
-const statsLoader = createSessionStatsLoader();
-const statsCache = statsLoader.cache;
-
 const formatItemLabel = (
   session: SessionInfoLike,
   width: number,
   theme: any,
-  statsCache: Map<string, SessionStats>,
+  statsState: SessionStatsState | undefined,
 ): string => {
   const itemWidth = width - 4;
   const timeStr = formatRelativeTime(session.modified);
 
-  const stats = statsCache.get(session.path);
+  const stats = statsState?.status === "ready" ? statsState.stats : undefined;
   let statsStr = "";
   let statsLen = 0;
   if (stats && (stats.add > 0 || stats.mod > 0 || stats.del > 0)) {
@@ -329,6 +329,12 @@ const formatItemLabel = (
       (stats.del > 0 ? `${stats.del}`.length + 1 : 0) +
       parts.length -
       1;
+  } else if (statsState?.status === "pending") {
+    statsStr = theme.fg("dim", "…");
+    statsLen = 1;
+  } else if (statsState?.status === "unavailable") {
+    statsStr = theme.fg("warning", "?");
+    statsLen = 1;
   }
 
   const title = buildSessionLabel(session);
@@ -580,8 +586,12 @@ async function showSessionPicker(
       let previewTimer: ReturnType<typeof setTimeout> | undefined;
       let previewController: AbortController | undefined;
       let previewSeq = 0;
-      let statsController = new AbortController();
-      let statsGeneration = 0;
+      // Stats use a picker-scoped, per-query first-observation cache. Rows that
+      // become visible later may observe later repository state; reopening the
+      // picker refreshes every row without polling repositories while idle.
+      const statsLoader = createSessionStatsLoader();
+      let statsUniverseVersion = 0;
+      let statsWindowSignature = "";
       let workspaceLoadSeq = 0;
       let disposed = false;
       let settled = false;
@@ -602,8 +612,7 @@ async function showSessionPicker(
         if (disposed) return;
         disposed = true;
         workspaceLoadSeq++;
-        statsGeneration++;
-        statsController.abort();
+        statsLoader.cancel();
         cancelPreviewLoad();
         previewCache.clear();
         activePreview = undefined;
@@ -614,27 +623,26 @@ async function showSessionPicker(
         disposePicker();
         done(result);
       };
-      const cancelStatsLoad = () => {
-        statsGeneration++;
-        statsController.abort();
-      };
-      const triggerStatsLoad = (list: SessionInfoLike[]) => {
-        cancelStatsLoad();
-        statsController = new AbortController();
-        const generation = statsGeneration;
-        const signal = statsController.signal;
-        void statsLoader.load(list, signal, () => {
-          if (disposed || signal.aborted || generation !== statsGeneration)
-            return;
-          tui.requestRender();
+      const ensureStatsWindowLoad = (visibleCount: number) => {
+        const targets = selectSessionStatsWindow(
+          filteredEntries.map((entry) => entry.session),
+          selectedPath,
+          visibleCount,
+        );
+        const signature = `${statsUniverseVersion}:${targets
+          .map((session) => session.path)
+          .join("\0")}`;
+        if (signature === statsWindowSignature) return;
+        statsWindowSignature = signature;
+        void statsLoader.reconcile(targets, sorted, () => {
+          if (!disposed) tui.requestRender();
         });
       };
 
-      triggerStatsLoad(sorted);
-
       const loadWorkspaceSessions = async (allWorkspaces: boolean) => {
         const loadSeq = ++workspaceLoadSeq;
-        cancelStatsLoad();
+        statsLoader.cancel();
+        statsWindowSignature = "";
         cancelPreviewLoad();
         previewCache.clear();
         activePreview = undefined;
@@ -650,11 +658,11 @@ async function showSessionPicker(
           if (disposed || loadSeq !== workspaceLoadSeq) return;
 
           sorted = sortSessions(results);
+          statsUniverseVersion++;
           for (const s of sorted) {
             sessionByPath.set(s.path, s);
           }
           entries = buildSessionSearchEntries(sorted);
-          triggerStatsLoad(sorted);
 
           filteredEntries = filterSessionEntries(entries, filter);
           const matchedIndex = filteredEntries.findIndex(
@@ -744,7 +752,12 @@ async function showSessionPicker(
       ): SelectItem[] =>
         current.map((entry) => ({
           value: entry.session.path,
-          label: formatItemLabel(entry.session, listWidth, theme, statsCache),
+          label: formatItemLabel(
+            entry.session,
+            listWidth,
+            theme,
+            statsLoader.get(entry.session),
+          ),
         }));
 
       const rebuild = () => {
@@ -780,20 +793,21 @@ async function showSessionPicker(
           );
           container.addChild(new Spacer(1));
         } else {
-          const items = buildItems(filteredEntries, width);
-          selectList = new SelectList(
-            items,
-            Math.max(1, Math.min(maxVisible, Math.max(items.length, 1))),
-            {
-              selectedPrefix: (text) =>
-                theme.fg(focus === "list" ? "accent" : "muted", text),
-              selectedText: (text) =>
-                theme.fg(focus === "list" ? "accent" : "muted", text),
-              description: (text) => theme.fg("muted", text),
-              scrollInfo: (text) => theme.fg("dim", text),
-              noMatch: () => theme.fg("warning", "  No matching sessions"),
-            },
+          const effectiveVisible = Math.max(
+            1,
+            Math.min(maxVisible, Math.max(filteredEntries.length, 1)),
           );
+          ensureStatsWindowLoad(effectiveVisible);
+          const items = buildItems(filteredEntries, width);
+          selectList = new SelectList(items, effectiveVisible, {
+            selectedPrefix: (text) =>
+              theme.fg(focus === "list" ? "accent" : "muted", text),
+            selectedText: (text) =>
+              theme.fg(focus === "list" ? "accent" : "muted", text),
+            description: (text) => theme.fg("muted", text),
+            scrollInfo: (text) => theme.fg("dim", text),
+            noMatch: () => theme.fg("warning", "  No matching sessions"),
+          });
           const selectedIndex = filteredEntries.findIndex(
             (entry) => entry.session.path === selectedPath,
           );
@@ -863,23 +877,21 @@ async function showSessionPicker(
           leftLines.push("");
           leftLines.push(theme.fg("muted", "  Loading sessions..."));
         } else {
-          const items = buildItems(filteredEntries, layout.listWidth);
-          selectList = new SelectList(
-            items,
-            Math.max(
-              listHeight,
-              Math.min(maxVisible, Math.max(items.length, 1)),
-            ),
-            {
-              selectedPrefix: (text) =>
-                theme.fg(focus === "list" ? "accent" : "muted", text),
-              selectedText: (text) =>
-                theme.fg(focus === "list" ? "accent" : "muted", text),
-              description: (text) => theme.fg("muted", text),
-              scrollInfo: (text) => theme.fg("dim", text),
-              noMatch: () => theme.fg("warning", "  No matching sessions"),
-            },
+          const effectiveVisible = Math.max(
+            listHeight,
+            Math.min(maxVisible, Math.max(filteredEntries.length, 1)),
           );
+          ensureStatsWindowLoad(effectiveVisible);
+          const items = buildItems(filteredEntries, layout.listWidth);
+          selectList = new SelectList(items, effectiveVisible, {
+            selectedPrefix: (text) =>
+              theme.fg(focus === "list" ? "accent" : "muted", text),
+            selectedText: (text) =>
+              theme.fg(focus === "list" ? "accent" : "muted", text),
+            description: (text) => theme.fg("muted", text),
+            scrollInfo: (text) => theme.fg("dim", text),
+            noMatch: () => theme.fg("warning", "  No matching sessions"),
+          });
           const selectedIndex = filteredEntries.findIndex(
             (entry) => entry.session.path === selectedPath,
           );

--- a/extensions/sessions/sessions.ts
+++ b/extensions/sessions/sessions.ts
@@ -162,6 +162,30 @@ export function filterSessionInfos(
   );
 }
 
+/**
+ * Mirror pi-tui SelectList's centered viewport so background stats work is
+ * limited to rows the picker can actually render. Keep the formula locked by
+ * tests because SelectList does not expose its visible range.
+ */
+export function selectSessionStatsWindow(
+  sessions: readonly SessionInfoLike[],
+  selectedPath: string,
+  maxVisible: number,
+) {
+  if (sessions.length === 0) return [];
+  const visible = Math.max(1, Math.min(maxVisible, sessions.length));
+  const found = sessions.findIndex((session) => session.path === selectedPath);
+  const selectedIndex = found >= 0 ? found : 0;
+  const startIndex = Math.max(
+    0,
+    Math.min(
+      selectedIndex - Math.floor(visible / 2),
+      sessions.length - visible,
+    ),
+  );
+  return sessions.slice(startIndex, startIndex + visible);
+}
+
 export function getSessionPaneLayout(width: number): SessionPaneLayout {
   if (width < 80) {
     return { mode: "single", listWidth: width, previewWidth: 0 };

--- a/tests/extensions/sessions/git-stats.test.ts
+++ b/tests/extensions/sessions/git-stats.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import { createSessionStatsLoader } from "../../../extensions/sessions/git-stats.ts";
 import type { SessionInfoLike } from "../../../extensions/sessions/sessions.ts";
@@ -13,82 +16,323 @@ const makeSessions = (count: number): SessionInfoLike[] =>
     path: `/tmp/session-${index}.jsonl`,
   }));
 
-test("large session lists bound Git subprocesses and reuse cached stats", async () => {
-  let active = 0;
-  let maxActive = 0;
-  let calls = 0;
+test("Git work is bounded by the requested viewport at 10, 120, and 1,000 sessions", async () => {
+  for (const count of [10, 120, 1_000]) {
+    let active = 0;
+    let maxActive = 0;
+    let calls = 0;
+    const loader = createSessionStatsLoader({
+      maxConcurrency: 4,
+      runGit: async () => {
+        calls++;
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        active--;
+        return "3\t1\tfile.ts\n";
+      },
+    });
+    const sessions = makeSessions(count);
+    const targets = sessions.slice(0, Math.min(12, count));
+
+    await loader.reconcile(targets, sessions, () => undefined);
+
+    assert.equal(calls, targets.length * 2);
+    assert.equal(maxActive, Math.min(4, calls));
+    assert.deepEqual(loader.get(targets[0]!), {
+      status: "ready",
+      stats: { add: 4, mod: 2, del: 0 },
+    });
+    if (count > targets.length) {
+      assert.equal(loader.get(sessions.at(-1)!), undefined);
+    }
+
+    await loader.reconcile(targets, sessions, () => undefined);
+    assert.equal(
+      calls,
+      targets.length * 2,
+      "cached targets must not rerun Git",
+    );
+  }
+});
+
+test("only the globally latest session for a workspace includes its working diff", async () => {
+  const sessions = makeSessions(20).map((entry, index) => ({
+    ...entry,
+    cwd: "/tmp/shared-project",
+    modified: new Date(Date.UTC(2026, 0, 2, 0, 0, 20 - index)),
+  }));
+  const calls: string[][] = [];
+  const loader = createSessionStatsLoader({
+    runGit: async (args) => {
+      calls.push(args);
+      return args[0] === "diff" ? "10\t0\tworking.ts\n" : "2\t0\thistory.ts\n";
+    },
+  });
+
+  await loader.reconcile([sessions[10]!], sessions, () => undefined);
+  assert.deepEqual(
+    calls.map((args) => args[0]),
+    ["log"],
+  );
+  assert.deepEqual(loader.get(sessions[10]!), {
+    status: "ready",
+    stats: { add: 2, mod: 0, del: 0 },
+  });
+
+  await loader.reconcile([sessions[0]!], sessions, () => undefined);
+  assert.deepEqual(
+    calls.map((args) => args[0]),
+    ["log", "log", "diff"],
+  );
+  assert.deepEqual(loader.get(sessions[0]!), {
+    status: "ready",
+    stats: { add: 12, mod: 0, del: 0 },
+  });
+});
+
+test("overlapping viewport work is retained while work that leaves is cancelled", async () => {
+  const sessions = makeSessions(30);
+  const started: string[] = [];
+  const aborted: string[] = [];
+  let resolveStarted!: () => void;
+  const enoughStarted = new Promise<void>((resolve) => {
+    resolveStarted = resolve;
+  });
+  let releaseNew!: () => void;
+  const newCanFinish = new Promise<void>((resolve) => {
+    releaseNew = resolve;
+  });
   const loader = createSessionStatsLoader({
     maxConcurrency: 4,
+    runGit: (args, cwd, signal) => {
+      const id = `${cwd}:${args[0]}`;
+      started.push(id);
+      if (started.length === 4) resolveStarted();
+      return new Promise<string>((resolve, reject) => {
+        signal.addEventListener(
+          "abort",
+          () => {
+            aborted.push(id);
+            reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+          },
+          { once: true },
+        );
+        if (cwd.endsWith("project-12") || cwd.endsWith("project-13")) {
+          void newCanFinish.then(() => resolve("1\t0\tnew.ts\n"));
+        }
+      });
+    },
+  });
+
+  const first = loader.reconcile(
+    sessions.slice(0, 12),
+    sessions,
+    () => undefined,
+  );
+  await enoughStarted;
+  const second = loader.reconcile(
+    sessions.slice(2, 14),
+    sessions,
+    () => undefined,
+  );
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal(aborted.length, 4);
+  assert.equal(
+    started.filter((entry) => entry.startsWith("/tmp/project-2:")).length,
+    2,
+    "overlapping work must not restart",
+  );
+
+  loader.cancel();
+  releaseNew();
+  await Promise.all([first, second]);
+  assert.equal(loader.cache.size, 0, "cancelled work must not populate cache");
+});
+
+test("duplicate query identities share work and Git failures remain unavailable", async () => {
+  const duplicateA = makeSessions(1)[0]!;
+  const duplicateB = {
+    ...duplicateA,
+    id: "duplicate",
+    path: "/tmp/duplicate.jsonl",
+  };
+  const newest = {
+    ...duplicateA,
+    id: "newest",
+    path: "/tmp/newest.jsonl",
+    modified: new Date("2026-01-01T02:00:00.000Z"),
+  };
+  let calls = 0;
+  const shared = createSessionStatsLoader({
     runGit: async () => {
+      calls++;
+      return "1\t0\tfile.ts\n";
+    },
+  });
+
+  await shared.reconcile(
+    [duplicateA, duplicateB],
+    [newest, duplicateA, duplicateB],
+    () => undefined,
+  );
+  assert.equal(calls, 1);
+  assert.deepEqual(shared.get(duplicateA), shared.get(duplicateB));
+
+  const failed = createSessionStatsLoader({
+    runGit: async () => {
+      throw new Error("git unavailable");
+    },
+  });
+  await failed.reconcile([duplicateA], [duplicateA], () => undefined);
+  assert.deepEqual(failed.get(duplicateA), { status: "unavailable" });
+});
+
+test("one failed Git command aborts its sibling before settling unavailable", async () => {
+  const session = makeSessions(1)[0]!;
+  let diffSignal: AbortSignal | undefined;
+  const loader = createSessionStatsLoader({
+    runGit: (args, _cwd, signal) => {
+      if (args[0] === "log") return Promise.reject(new Error("log failed"));
+      diffSignal = signal;
+      return new Promise<string>((_resolve, reject) => {
+        signal.addEventListener(
+          "abort",
+          () =>
+            reject(Object.assign(new Error("aborted"), { name: "AbortError" })),
+          { once: true },
+        );
+      });
+    },
+  });
+
+  await loader.reconcile([session], [session], () => undefined);
+
+  assert.equal(diffSignal?.aborted, true);
+  assert.deepEqual(loader.get(session), { status: "unavailable" });
+});
+
+test("real and symlink workspace paths share one canonical latest bucket", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openpi-git-stats-alias-"));
+  const workspace = join(root, "workspace");
+  const alias = join(root, "alias");
+  try {
+    await mkdir(workspace);
+    await symlink(workspace, alias);
+    const [newest, older] = makeSessions(2).map((entry, index) => ({
+      ...entry,
+      cwd: index === 0 ? workspace : alias,
+      modified: new Date(Date.UTC(2026, 0, 2, 0, 0, 2 - index)),
+    }));
+    const commands: string[] = [];
+    const loader = createSessionStatsLoader({
+      runGit: async (args) => {
+        commands.push(args[0]!);
+        return "";
+      },
+    });
+
+    await loader.reconcile(
+      [newest!, older!],
+      [newest!, older!],
+      () => undefined,
+    );
+
+    assert.equal(commands.filter((command) => command === "log").length, 2);
+    assert.equal(commands.filter((command) => command === "diff").length, 1);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("canonical workspace discovery is bounded and reused for one universe", async () => {
+  const sessions = makeSessions(1_000);
+  let calls = 0;
+  let active = 0;
+  let maxActive = 0;
+  const loader = createSessionStatsLoader({
+    canonicalizeConcurrency: 8,
+    canonicalizeCwd: async (cwd) => {
       calls++;
       active++;
       maxActive = Math.max(maxActive, active);
       await new Promise<void>((resolve) => setImmediate(resolve));
       active--;
-      return "3\t1\tfile.ts\n";
+      return cwd;
     },
-  });
-  const sessions = makeSessions(120);
-
-  await loader.load(sessions, new AbortController().signal, () => undefined);
-
-  assert.equal(calls, 240);
-  assert.equal(maxActive, 4);
-  assert.equal(loader.cache.size, 120);
-  assert.deepEqual(loader.cache.get(sessions[0]!.path), {
-    add: 4,
-    mod: 2,
-    del: 0,
+    runGit: async () => "",
   });
 
-  await loader.load(sessions, new AbortController().signal, () => undefined);
-  assert.equal(calls, 240, "cached sessions must not spawn Git again");
+  await loader.reconcile(sessions.slice(0, 12), sessions, () => undefined);
+  await loader.reconcile(sessions.slice(12, 24), sessions, () => undefined);
+
+  assert.equal(calls, 1_000);
+  assert.equal(maxActive, 8);
 });
 
-test("cancelling a stale list stops queued work and prevents stale cache updates", async () => {
+test("cancelling canonical discovery stops scheduling undiscovered workspaces", async () => {
+  const sessions = makeSessions(1_000);
+  const releases: Array<() => void> = [];
   let started = 0;
-  let completeImmediately = false;
   let resolveStarted!: () => void;
   const enoughStarted = new Promise<void>((resolve) => {
     resolveStarted = resolve;
   });
   const loader = createSessionStatsLoader({
-    maxConcurrency: 3,
-    runGit: (_args, _cwd, signal) => {
+    canonicalizeConcurrency: 4,
+    canonicalizeCwd: (cwd) => {
       started++;
-      if (started === 3) resolveStarted();
-      if (completeImmediately) return Promise.resolve("2\t0\tfile.ts\n");
+      if (started === 4) resolveStarted();
       return new Promise<string>((resolve) => {
-        signal.addEventListener("abort", () => resolve("9\t0\tstale.ts\n"), {
-          once: true,
-        });
+        releases.push(() => resolve(cwd));
       });
     },
-  });
-  const sessions = makeSessions(100);
-  const stale = new AbortController();
-  let updates = 0;
-  const loading = loader.load(sessions, stale.signal, () => {
-    updates++;
+    runGit: async () => "",
   });
 
-  await enoughStarted;
-  stale.abort();
-  await loading;
-
-  assert.equal(started, 3);
-  assert.equal(updates, 0);
-  assert.equal(loader.cache.size, 0);
-
-  completeImmediately = true;
-  await loader.load(
-    [sessions[0]!],
-    new AbortController().signal,
+  const loading = loader.reconcile(
+    sessions.slice(0, 12),
+    sessions,
     () => undefined,
   );
-  assert.deepEqual(loader.cache.get(sessions[0]!.path), {
-    add: 4,
-    mod: 0,
-    del: 0,
+  await enoughStarted;
+  loader.cancel();
+  for (const release of releases) release();
+  await loading;
+
+  assert.equal(started, 4);
+  assert.equal(loader.cache.size, 0);
+});
+
+test("stats cache is a per-query first observation and a new loader refreshes it", async () => {
+  const session = makeSessions(1)[0]!;
+  let added = 1;
+  let calls = 0;
+  const create = () =>
+    createSessionStatsLoader({
+      canonicalizeCwd: async (cwd) => cwd,
+      runGit: async () => {
+        calls++;
+        return `${added}\t0\tfile.ts\n`;
+      },
+    });
+  const firstPicker = create();
+
+  await firstPicker.reconcile([session], [session], () => undefined);
+  added = 5;
+  await firstPicker.reconcile([session], [session], () => undefined);
+  assert.deepEqual(firstPicker.get(session), {
+    status: "ready",
+    stats: { add: 2, mod: 0, del: 0 },
   });
+  assert.equal(calls, 2);
+
+  const reopenedPicker = create();
+  await reopenedPicker.reconcile([session], [session], () => undefined);
+  assert.deepEqual(reopenedPicker.get(session), {
+    status: "ready",
+    stats: { add: 10, mod: 0, del: 0 },
+  });
+  assert.equal(calls, 4);
 });

--- a/tests/extensions/sessions/sessions.test.ts
+++ b/tests/extensions/sessions/sessions.test.ts
@@ -6,6 +6,7 @@ import {
   buildSessionPreview,
   filterSessionEntries,
   parseLimit,
+  selectSessionStatsWindow,
   type SessionInfoLike,
 } from "../../../extensions/sessions/sessions.ts";
 
@@ -33,6 +34,37 @@ test("session search matches normalized metadata", () => {
   ];
   assert.equal(filterSessionEntries(entries, "oauth").length, 1);
   assert.equal(filterSessionEntries(entries, "billing").length, 0);
+});
+
+test("session stats window follows the SelectList centered viewport", () => {
+  const sessions = Array.from({ length: 20 }, (_, index) => ({
+    ...session,
+    id: `session-${index}`,
+    path: `/tmp/session-${index}.jsonl`,
+  }));
+
+  assert.deepEqual(
+    selectSessionStatsWindow(sessions, sessions[0]!.path, 5).map(
+      (entry) => entry.path,
+    ),
+    sessions.slice(0, 5).map((entry) => entry.path),
+  );
+  assert.deepEqual(
+    selectSessionStatsWindow(sessions, sessions[10]!.path, 5).map(
+      (entry) => entry.path,
+    ),
+    sessions.slice(8, 13).map((entry) => entry.path),
+  );
+  assert.deepEqual(
+    selectSessionStatsWindow(sessions, sessions[19]!.path, 5).map(
+      (entry) => entry.path,
+    ),
+    sessions.slice(15).map((entry) => entry.path),
+  );
+  assert.equal(
+    selectSessionStatsWindow(sessions, "/missing.jsonl", 5)[0]?.path,
+    sessions[0]!.path,
+  );
 });
 
 test("persisted session labels and preview content are terminal-safe", () => {


### PR DESCRIPTION
## Summary

- load Session Git statistics only for the rows the picker can actually render, while using the full Session universe to identify the true latest Session per canonical workspace
- reconcile viewport changes incrementally, share identical queries, cancel work that leaves the viewport, and keep the cache bounded to one picker
- distinguish pending and unavailable statistics from a verified clean result instead of caching Git failures as zero
- canonicalize workspace aliases with bounded, reusable discovery and stop scheduling both Git and canonicalization work when the picker closes
- add deterministic 10/120/1,000-Session coverage plus a real-Git benchmark

## Compatibility impact

- User-visible: statistics now appear progressively as rows enter the viewport; pending rows show `…`, and unavailable Git evidence shows `?`
- Existing calculated values and Session selection/preview behavior are unchanged
- Cache semantics are picker-scoped and per-query first observation; reopening the picker refreshes repository state without background polling
- Tool schemas, configuration, persisted Session data, Provider behavior, permissions, and Session lifecycle are unchanged

## Benchmark

`bun benchmarks/session-git-stats.ts`

- 1,000 Sessions, multi-workspace: 24 cold Git calls, 0 warm calls
- 1,000 Sessions, one workspace: 13 cold Git calls, 0 warm calls
- Git cancellation: 4 calls started, about 0.9 ms to settle, no cached result
- 1,000 canonical workspaces: maximum canonicalization concurrency 8, 0 repeated-universe calls
- canonicalization cancellation: 4 operations started, about 0.3 ms to settle, no cached result

## Validation

- `node --test --experimental-strip-types tests/extensions/sessions/*.test.ts` — 35 passed
- `bun run check` — passed; only the existing file-search Effect diagnostics remain warnings
- `bun run test` — 915 Node tests and 30 Vitest tests passed
- `git diff --check`
- three independent review rounds across repository design and adversarial performance/lifecycle analysis; final round: no findings

Manual Pi TUI smoke was not counted because `pi list` currently loads `/Users/tushaokun/work/openpi-main-runtime`, not this worktree. No installed package source was changed.

Closes #187
