### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Problem
+
+<!-- What concrete problem does this PR solve? Who or what is affected? Link the Issue when one exists. -->
+
+## Value
+
+<!-- Why is solving this worthwhile? Describe the user, product, reliability, performance, or maintenance value. -->
+
+## Approach
+
+<!-- How does the change solve the problem? Call out important design choices or trade-offs. -->
+
+## Validation
+
+<!-- List commands run and their results. Include benchmarks or manual evidence when relevant, and state anything not run. -->
+
+## Impact
+
+<!-- Note relevant changes, or say "None", for: user-visible behavior, model-visible context/tools, runtime/lifecycle, persisted config/data, and compatibility or risk. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ If those answers are unclear, investigate before adding surface area.
 - Preserve unrelated and uncommitted user work. Make the smallest scoped change that satisfies the request.
 - Follow existing patterns and tests before inventing a new abstraction.
 - Run `bun run check` and `bun run test` after making a change. If a relevant validation command does not exist, call that out and propose one.
+- When opening or updating a pull request, follow `.github/PULL_REQUEST_TEMPLATE.md` and complete its Problem, Value, Approach, Validation, and Impact sections.
 - Avoid explicit return types unless they are necessary. Prefer inference over repeatedly declaring types.
 - Treat `as any` as an absolute last resort; use real type safety.
 - Keep user-visible behavior, model-visible context, and persisted/runtime state tests separate when the distinction matters.


### PR DESCRIPTION
## Problem

Pull requests currently have no shared structure, so authors can describe implementation details without clearly stating the problem being solved, why the change is valuable, or what evidence supports it.

## Value

A short common structure makes PR intent easier to understand, review, and compare. It also makes missing validation and compatibility impact visible before merge.

## Approach

Add a concise default pull request template with five sections: Problem, Value, Approach, Validation, and Impact. Guidance stays in HTML comments so empty prompts do not add noise to submitted descriptions. Add one instruction to `AGENTS.md` requiring agents to follow and complete the template when opening or updating a PR.

## Validation

- `bun run check` — passed with the 12 existing Effect diagnostics tracked by #170.
- `bun run test` — 915 tests passed.
- `git diff --check` — passed.
- Manual: confirmed the template is located at GitHub's default `.github/PULL_REQUEST_TEMPLATE.md` path.

## Impact

- User-visible behavior: new PRs start with the shared description structure.
- Model-visible context/tools: repository agents are explicitly required to complete the template; tool schemas are unchanged.
- Runtime/lifecycle: none.
- Persisted config/data: none.
- Compatibility or risk: existing PRs are unchanged; authors can still edit or remove any section.
