### PR TITLE
perf(subagents): stop retained child Git polling

### DIFF
--- a/extensions/shared/child-session.ts
+++ b/extensions/shared/child-session.ts
@@ -1,10 +1,12 @@
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   type AgentSession,
   DefaultPackageManager,
   DefaultResourceLoader,
   getAgentDir,
+  type LoadExtensionsResult,
   type PackageSource,
   ProjectTrustStore,
   type ResolvedPaths,
@@ -165,6 +167,158 @@ function packageSourceValue(source: PackageSource) {
   return typeof source === "string" ? source : source.source;
 }
 
+const CHILD_DISABLED_OPENPI_EXTENSION =
+  "-extensions/git-info/index.ts" as const;
+const OPENPI_GIT_INFO_EXTENSION_PATH = realpathSync.native(
+  fileURLToPath(new URL("../git-info/index.ts", import.meta.url)),
+);
+
+function canonicalExistingPath(value: string) {
+  try {
+    return realpathSync.native(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function excludeOpenPiGitInfoExtension(
+  resources: LoadExtensionsResult,
+): LoadExtensionsResult {
+  return {
+    ...resources,
+    extensions: resources.extensions.filter(
+      (extension) =>
+        canonicalExistingPath(extension.resolvedPath) !==
+        OPENPI_GIT_INFO_EXTENSION_PATH,
+    ),
+  };
+}
+
+function installedPathNamesOpenPi(installedPath: string) {
+  try {
+    const stats = statSync(installedPath);
+    if (stats.isDirectory()) {
+      const manifestPath = path.join(installedPath, "package.json");
+      if (!existsSync(manifestPath)) return false;
+      const manifest = JSON.parse(
+        readFileSync(manifestPath, "utf8"),
+      ) as unknown;
+      return (
+        typeof manifest === "object" &&
+        manifest !== null &&
+        !Array.isArray(manifest) &&
+        (manifest as Record<string, unknown>).name === "@tt-a1i/openpi"
+      );
+    }
+    let current = stats.isFile() ? path.dirname(installedPath) : undefined;
+    while (current) {
+      const manifestPath = path.join(current, "package.json");
+      if (existsSync(manifestPath)) {
+        const manifest = JSON.parse(
+          readFileSync(manifestPath, "utf8"),
+        ) as unknown;
+        return (
+          typeof manifest === "object" &&
+          manifest !== null &&
+          !Array.isArray(manifest) &&
+          (manifest as Record<string, unknown>).name === "@tt-a1i/openpi"
+        );
+      }
+      const parent = path.dirname(current);
+      if (parent === current) return false;
+      current = parent;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function piMatchesPublishedOpenPiSource(options: {
+  source: string;
+  cwd: string;
+  agentDir: string;
+}) {
+  const settingsManager = SettingsManager.inMemory({
+    packages: [options.source],
+  });
+  const packageManager = new DefaultPackageManager({
+    cwd: options.cwd,
+    agentDir: options.agentDir,
+    settingsManager,
+  });
+  return (
+    packageManager.removeSourceFromSettings("npm:@tt-a1i/openpi") ||
+    packageManager.removeSourceFromSettings(
+      "git:https://github.com/tt-a1i/openpi",
+    )
+  );
+}
+
+function createOpenPiPackageMatcher(options: {
+  cwd: string;
+  agentDir: string;
+}) {
+  const sourceMatches = new Map<string, boolean>();
+  const installedPathMatches = new Map<string, boolean>();
+  return (source: string, installedPath?: string) => {
+    let sourceMatch = sourceMatches.get(source);
+    if (sourceMatch === undefined) {
+      sourceMatch = piMatchesPublishedOpenPiSource({ source, ...options });
+      sourceMatches.set(source, sourceMatch);
+    }
+    if (sourceMatch || installedPath === undefined) return sourceMatch;
+
+    const resolvedPath = path.resolve(installedPath);
+    let installedPathMatch = installedPathMatches.get(resolvedPath);
+    if (installedPathMatch === undefined) {
+      installedPathMatch = installedPathNamesOpenPi(resolvedPath);
+      installedPathMatches.set(resolvedPath, installedPathMatch);
+    }
+    return installedPathMatch;
+  };
+}
+
+function openPiPackageSources(
+  packageManager: DefaultPackageManager,
+  options: { cwd: string; agentDir: string },
+) {
+  const isOpenPiPackage = createOpenPiPackageMatcher(options);
+  const sources = {
+    user: new Set<string>(),
+    project: new Set<string>(),
+  };
+  for (const configured of packageManager.listConfiguredPackages()) {
+    if (isOpenPiPackage(configured.source, configured.installedPath)) {
+      sources[configured.scope].add(configured.source);
+    }
+  }
+  return sources;
+}
+
+function disablesOpenPiGitInfo(pattern: string) {
+  return (
+    pattern.startsWith("-") &&
+    pattern.slice(1).replace(/^\.\//, "") ===
+      CHILD_DISABLED_OPENPI_EXTENSION.slice(1)
+  );
+}
+
+function disableOpenPiGitInfo(source: PackageSource): PackageSource {
+  if (typeof source !== "string") {
+    if (source.extensions?.length === 0) return source;
+    if (source.autoload === false && source.extensions === undefined) {
+      return source;
+    }
+  }
+  const configured = typeof source === "string" ? { source } : source;
+  const extensions = [...(configured.extensions ?? [])];
+  if (!extensions.some(disablesOpenPiGitInfo)) {
+    extensions.push(CHILD_DISABLED_OPENPI_EXTENSION);
+  }
+  return { ...configured, extensions };
+}
+
 function blockedPackageSources(
   packageManager: DefaultPackageManager,
   resolvedPaths: ResolvedPaths,
@@ -204,6 +358,7 @@ function blockedPackageSources(
 function createEphemeralChildSettings(
   sourceSettings: SettingsManager,
   blockedSources: { user: Set<string>; project: Set<string> },
+  openPiSources: { user: Set<string>; project: Set<string> },
   projectTrusted: boolean,
 ) {
   const globalSettings = sourceSettings.getGlobalSettings();
@@ -213,9 +368,15 @@ function createEphemeralChildSettings(
     scope: "user" | "project",
   ) => ({
     ...settings,
-    packages: settings.packages?.filter(
-      (source) => !blockedSources[scope].has(packageSourceValue(source)),
-    ),
+    packages: settings.packages
+      ?.filter(
+        (source) => !blockedSources[scope].has(packageSourceValue(source)),
+      )
+      .map((source) =>
+        openPiSources[scope].has(packageSourceValue(source))
+          ? disableOpenPiGitInfo(source)
+          : source,
+      ),
   });
   const contents = {
     global: JSON.stringify(settingsForScope(globalSettings, "user")),
@@ -248,10 +409,15 @@ async function createChildSettingsManager(options: {
     cwd: options.cwd,
     agentDir: options.agentDir,
   });
+  const openPiSources = openPiPackageSources(packageManager, {
+    cwd: options.cwd,
+    agentDir: options.agentDir,
+  });
 
   return createEphemeralChildSettings(
     sourceSettings,
     blockedSources,
+    openPiSources,
     options.projectTrusted,
   );
 }
@@ -348,6 +514,7 @@ export async function createChildResources(options: ChildResourceOptions) {
     cwd: options.cwd,
     agentDir,
     settingsManager,
+    extensionsOverride: excludeOpenPiGitInfoExtension,
     ...(options.appendSystemPrompt
       ? { appendSystemPrompt: options.appendSystemPrompt }
       : {}),

--- a/tests/extensions/shared/child-session.test.ts
+++ b/tests/extensions/shared/child-session.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {
   mkdir,
   mkdtemp,
+  realpath,
   readdir,
   readFile,
   rm,
@@ -13,6 +14,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   createAgentSession,
+  DefaultPackageManager,
   DefaultResourceLoader,
   defineTool,
   ProjectTrustStore,
@@ -649,6 +651,210 @@ test("child resources exclude pi-intercom npm, Git, and local packages without m
     for (const marker of executionMarkers) {
       assert.equal(await readFile(marker, "utf8"), "executed");
     }
+  });
+});
+
+test("headless child resources exclude OpenPI git polling at 1/8/64 retained sessions", async () => {
+  await withTempDir(async (directory) => {
+    const cwd = path.join(directory, "project");
+    const agentDir = path.join(directory, "agent");
+    const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+    const gitInfoPath = await realpath(
+      fileURLToPath(
+        new URL("../../../extensions/git-info/index.ts", import.meta.url),
+      ),
+    );
+    const gitReadPath = await realpath(
+      fileURLToPath(
+        new URL("../../../extensions/git-read/index.ts", import.meta.url),
+      ),
+    );
+    await mkdir(cwd, { recursive: true });
+    await mkdir(agentDir, { recursive: true });
+    await writeFile(
+      path.join(agentDir, "settings.json"),
+      JSON.stringify({
+        packages: [
+          {
+            source: repoRoot,
+            extensions: [`+${gitInfoPath}`, "extensions/git-read/index.ts"],
+          },
+        ],
+      }),
+    );
+
+    const topLevelSettings = SettingsManager.create(cwd, agentDir, {
+      projectTrusted: true,
+    });
+    const topLevelLoader = new DefaultResourceLoader({
+      cwd,
+      agentDir,
+      settingsManager: topLevelSettings,
+    });
+    await topLevelLoader.reload();
+    const topLevelPaths = await Promise.all(
+      topLevelLoader
+        .getExtensions()
+        .extensions.map((extension) => realpath(extension.resolvedPath)),
+    );
+    const topLevelPollers = topLevelPaths.filter(
+      (extensionPath) => extensionPath === gitInfoPath,
+    ).length;
+    assert.equal(topLevelPollers, 1, "the parent loader must keep git-info");
+
+    const child = await createChildResources({
+      cwd,
+      agentDir,
+      projectTrusted: true,
+    });
+    const childPaths = await Promise.all(
+      child.loader
+        .getExtensions()
+        .extensions.map((extension) => realpath(extension.resolvedPath)),
+    );
+    const childPollers = childPaths.filter(
+      (extensionPath) => extensionPath === gitInfoPath,
+    ).length;
+    const childPackageManager = new DefaultPackageManager({
+      cwd,
+      agentDir,
+      settingsManager: child.settingsManager,
+    });
+    const childPackagePaths = await childPackageManager.resolve(
+      async () => "skip",
+    );
+    const childGitInfoResource = await Promise.all(
+      childPackagePaths.extensions.map(async (resource) => ({
+        ...resource,
+        canonicalPath: await realpath(resource.path),
+      })),
+    ).then((resources) =>
+      resources.find((resource) => resource.canonicalPath === gitInfoPath),
+    );
+    assert.equal(
+      childGitInfoResource?.enabled,
+      false,
+      "the child package filter must disable git-info before import",
+    );
+    assert.equal(
+      childPaths.includes(gitReadPath),
+      true,
+      "ordinary child-safe OpenPI extensions must remain loaded",
+    );
+
+    for (const retained of [1, 8, 64]) {
+      assert.equal(
+        retained * childPollers,
+        0,
+        `${retained} retained children must create no git-info pollers`,
+      );
+      assert.equal(
+        retained * topLevelPollers,
+        retained,
+        "the parent-loader control must remain valid",
+      );
+    }
+
+    for (const source of [gitInfoPath, path.dirname(gitInfoPath)]) {
+      await writeFile(
+        path.join(agentDir, "settings.json"),
+        JSON.stringify({ extensions: [source] }),
+      );
+      const directSettings = SettingsManager.create(cwd, agentDir, {
+        projectTrusted: true,
+      });
+      const directLoader = new DefaultResourceLoader({
+        cwd,
+        agentDir,
+        settingsManager: directSettings,
+      });
+      await directLoader.reload();
+      assert.deepEqual(directLoader.getExtensions().errors, []);
+      const parentDirectPaths = await Promise.all(
+        directLoader
+          .getExtensions()
+          .extensions.map((extension) => realpath(extension.resolvedPath)),
+      );
+      assert.equal(
+        parentDirectPaths.includes(gitInfoPath),
+        true,
+        `parent source ${source} must load git-info as the control`,
+      );
+      const directChild = await createChildResources({
+        cwd,
+        agentDir,
+        projectTrusted: true,
+      });
+      const directPaths = await Promise.all(
+        directChild.loader
+          .getExtensions()
+          .extensions.map((extension) => realpath(extension.resolvedPath)),
+      );
+      assert.equal(
+        directPaths.includes(gitInfoPath),
+        false,
+        `child source ${source} must not restore git-info`,
+      );
+    }
+
+    await writeFile(
+      path.join(agentDir, "settings.json"),
+      JSON.stringify({ packages: [{ source: repoRoot, extensions: [] }] }),
+    );
+    const disabledExtensionsChild = await createChildResources({
+      cwd,
+      agentDir,
+      projectTrusted: true,
+    });
+    assert.deepEqual(
+      disabledExtensionsChild.loader.getExtensions().extensions,
+      [],
+      "an empty package extension filter must remain fully disabled",
+    );
+  });
+});
+
+test("nested manifestless packages are not mistaken for OpenPI", async () => {
+  await withTempDir(async (directory) => {
+    const cwd = path.join(directory, "project");
+    const agentDir = path.join(directory, "agent");
+    const openPiCheckout = path.join(directory, "openpi-checkout");
+    const ordinaryPackage = path.join(openPiCheckout, "ordinary-package");
+    const ordinaryGitInfo = path.join(
+      ordinaryPackage,
+      "extensions",
+      "git-info",
+      "index.ts",
+    );
+    await mkdir(cwd, { recursive: true });
+    await mkdir(agentDir, { recursive: true });
+    await mkdir(path.dirname(ordinaryGitInfo), { recursive: true });
+    await writeFile(
+      path.join(openPiCheckout, "package.json"),
+      JSON.stringify({ name: "@tt-a1i/openpi" }),
+    );
+    await writeFile(
+      ordinaryGitInfo,
+      `export default function (pi) {
+        pi.registerCommand("ordinary-lg", { handler() {} });
+      }`,
+    );
+    await writeFile(
+      path.join(agentDir, "settings.json"),
+      JSON.stringify({ packages: [ordinaryPackage] }),
+    );
+
+    const child = await createChildResources({
+      cwd,
+      agentDir,
+      projectTrusted: true,
+    });
+    const childPaths = await Promise.all(
+      child.loader
+        .getExtensions()
+        .extensions.map((extension) => realpath(extension.resolvedPath)),
+    );
+    assert.equal(childPaths.includes(await realpath(ordinaryGitInfo)), true);
   });
 });
 


### PR DESCRIPTION
## Problem

Retained Direct and Workflow child sessions load OpenPI's interactive `git-info` extension even though headless children cannot use its dashboard or slash commands. Each loaded instance refreshes every five seconds and starts four Git subprocesses (one repository probe plus branch, head, and status reads), so idle work scales the polling load with the retained child count.

Closes #182.

## Value

Headless children no longer create recurring Git work while they are retained. The structural subprocess count per refresh interval changes from 4/32/256 for 1/8/64 retained children to 0/0/0, without removing child model tools, skills, or ordinary OpenPI extensions. Parent sessions keep the interactive Git dashboard unchanged.

## Approach

- Apply a child-only package filter that force-excludes OpenPI's built-in `extensions/git-info/index.ts` before extension import for npm, Git, and local OpenPI package sources.
- Add an exact canonical-path fallback at the child resource boundary for Pi's direct extension file and directory settings, which do not use package filters.
- Preserve package settings that already disable all extensions, and avoid matching unrelated manifestless packages nested under an OpenPI checkout.
- Keep this at `createChildResources`, the shared Pi-native resource seam used by both Direct and Workflow children.

## Validation

- Regression-first check: the new retained-child test failed on the base revision because one child still created one `git-info` poller.
- `node --test --experimental-strip-types tests/extensions/shared/child-session.test.ts tests/extensions/git-info/index.test.ts tests/extensions/subagents/pi-backend.test.ts` — 20 passed.
- `bun run check` — passed; the 12 reported Effect diagnostics are pre-existing and tracked by #170.
- `bun run test` — 917 Node tests and 30 Vitest tests passed.
- Independent design, adversarial, and test reviews completed with no remaining findings. Review fixes included making force-exclusion override absolute `+` includes, covering direct extension sources, preventing nested-package false positives, and adding non-vacuous parent/pre-load controls.
- No manual Pi/TUI smoke was run; this change affects only headless child resource loading and has deterministic loader coverage.

## Impact

- User-visible behavior: retained headless children stop idle Git polling; parent-session Git UI remains available.
- Model-visible context/tools: unchanged. `git-info` provides commands and UI handlers, not child model tools.
- Runtime/lifecycle: Direct and Workflow child resources omit the built-in OpenPI `git-info` extension; all other child resources retain existing behavior.
- Persisted config/data: unchanged. Filtering is applied only to ephemeral child settings and resources.
- Compatibility/risk: child-local `/lg`, `/pr`, and Git dashboard handlers are absent, but these interactive surfaces are not usable in print-mode headless children. Exact package identity and canonical-path checks preserve unrelated extensions, including same-relative-path nested packages.
