### PR TITLE
perf(workflows): incrementally project child progress

### DIFF
--- a/benchmarks/workflow-progress.ts
+++ b/benchmarks/workflow-progress.ts
@@ -1,0 +1,131 @@
+import { performance } from "node:perf_hooks";
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import { AgentProgressProjection } from "../extensions/workflows/progress-projection.ts";
+
+type AgentMessage = AgentSession["messages"][number];
+
+function readOption(name: string) {
+  const index = process.argv.indexOf(name);
+  if (index >= 0) return process.argv[index + 1];
+  return process.argv
+    .find((argument) => argument.startsWith(`${name}=`))
+    ?.slice(name.length + 1);
+}
+
+function parseSizes(raw: string | undefined) {
+  const sizes = (raw ?? "100,1000,10000")
+    .split(",")
+    .map((value) => Number.parseInt(value, 10));
+  if (
+    sizes.some(
+      (value) => !Number.isSafeInteger(value) || value <= 0 || value % 2 !== 0,
+    )
+  ) {
+    throw new Error("--sizes must contain positive even message counts");
+  }
+  return sizes;
+}
+
+const zeroUsage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 0,
+  },
+};
+
+for (const messageCount of parseSizes(readOption("--sizes"))) {
+  let sourceMessageVisits = 0;
+  const store: AgentMessage[] = [];
+  const messages = new Proxy(store, {
+    get(target, property, receiver) {
+      if (typeof property === "string" && /^\d+$/.test(property)) {
+        sourceMessageVisits++;
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  });
+  const projection = new AgentProgressProjection();
+  const toolCycles = messageCount / 2;
+  let lifecycleEvents = 0;
+  let progressWrites = 0;
+
+  const started = performance.now();
+  for (let index = 0; index < toolCycles; index++) {
+    const toolCallId = `call-${index}`;
+    const assistant = {
+      role: "assistant" as const,
+      content: [
+        { type: "text" as const, text: `cycle ${index}` },
+        {
+          type: "toolCall" as const,
+          id: toolCallId,
+          name: "read",
+          arguments: { path: `fixture-${index}.txt` },
+        },
+      ],
+      api: "openai-responses",
+      provider: "benchmark",
+      model: "benchmark",
+      usage: zeroUsage,
+      stopReason: "toolUse" as const,
+      timestamp: index * 2,
+    } satisfies AgentMessage;
+    const result = {
+      role: "toolResult" as const,
+      toolCallId,
+      toolName: "read",
+      content: [{ type: "text" as const, text: `result ${index}` }],
+      isError: false,
+      timestamp: index * 2 + 1,
+    } satisfies AgentMessage;
+
+    messages.push(assistant);
+    projection.append(assistant);
+    lifecycleEvents++;
+    projection.snapshot();
+    progressWrites++;
+
+    for (let lifecycle = 0; lifecycle < 2; lifecycle++) {
+      lifecycleEvents++;
+      projection.snapshot();
+      progressWrites++;
+    }
+
+    messages.push(result);
+    projection.append(result);
+    lifecycleEvents++;
+    projection.snapshot();
+    progressWrites++;
+  }
+
+  // runAgent performs one authoritative terminal reconciliation.
+  projection.replace(messages);
+  const terminal = projection.snapshot();
+  const wallMs = performance.now() - started;
+  const oneScanPerProgressLowerBoundVisits =
+    messageCount ** 2 + messageCount / 2;
+
+  console.log(
+    JSON.stringify({
+      messages: messageCount,
+      toolCycles,
+      lifecycleEvents,
+      progressWrites,
+      sourceMessageVisits,
+      oneScanPerProgressLowerBoundVisits,
+      reductionVsOneScanLowerBound: Number(
+        (oneScanPerProgressLowerBoundVisits / sourceMessageVisits).toFixed(1),
+      ),
+      transcriptEntries: terminal.transcript.length,
+      wallMs: Number(wallMs.toFixed(1)),
+    }),
+  );
+}

--- a/extensions/workflows/progress-projection.ts
+++ b/extensions/workflows/progress-projection.ts
@@ -1,0 +1,306 @@
+import {
+  calculateContextTokens,
+  type AgentSession,
+  estimateTokens,
+} from "@earendil-works/pi-coding-agent";
+import { type AgentUsage, emptyUsage, type TranscriptEntry } from "./model.ts";
+import { safeStringify, truncateUtf8 } from "./serialization.ts";
+
+const TRANSCRIPT_ENTRY_MAX_BYTES = 16 * 1024;
+const TRANSCRIPT_TOTAL_MAX_BYTES = 256 * 1024;
+const TRANSCRIPT_MAX_ENTRIES = 200;
+
+type AgentMessage = AgentSession["messages"][number];
+export type ProgressAssistantMessage = Extract<
+  AgentMessage,
+  { role: "assistant" }
+>;
+
+export interface ProgressToolTiming {
+  startedAt?: number;
+  finishedAt?: number;
+  durationMs?: number;
+}
+
+type ContextTokens = number | null | undefined;
+
+interface ProjectedTranscriptEntry {
+  role: TranscriptEntry["role"];
+  text: string;
+  sourceTextTruncated: boolean;
+  name?: string;
+  sourceToolCallId?: string;
+  isError?: boolean;
+  timestamp?: number;
+}
+
+export interface AgentProgressProjectionSnapshot {
+  preview: string;
+  usage: AgentUsage;
+  latestAssistant?: ProgressAssistantMessage;
+  transcript: TranscriptEntry[];
+}
+
+function validAssistantContextTokens(message: ProgressAssistantMessage) {
+  if (
+    message.stopReason === "aborted" ||
+    message.stopReason === "error" ||
+    !message.usage
+  ) {
+    return undefined;
+  }
+  const tokens = calculateContextTokens(message.usage);
+  return tokens > 0 ? tokens : undefined;
+}
+
+function boundedSourceText(text: string) {
+  const bounded = truncateUtf8(text, TRANSCRIPT_ENTRY_MAX_BYTES);
+  return { text: bounded, sourceTextTruncated: bounded !== text };
+}
+
+function safeJson(value: unknown) {
+  return safeStringify(value, {
+    maxBytes: TRANSCRIPT_ENTRY_MAX_BYTES,
+    maxDepth: 12,
+    maxNodes: 2_000,
+  });
+}
+
+function messageEntries(message: AgentMessage): ProjectedTranscriptEntry[] {
+  if (message.role === "user") {
+    const source =
+      typeof message.content === "string"
+        ? message.content
+        : message.content
+            .map((part) =>
+              part.type === "text" ? part.text : `[image: ${part.mimeType}]`,
+            )
+            .join("\n");
+    if (!source.trim()) return [];
+    return [
+      {
+        role: "user",
+        ...boundedSourceText(source),
+        timestamp: message.timestamp,
+      },
+    ];
+  }
+
+  if (message.role === "assistant") {
+    const entries: ProjectedTranscriptEntry[] = [];
+    for (const part of message.content) {
+      if (part.type === "text" && part.text.trim()) {
+        entries.push({
+          role: "assistant",
+          ...boundedSourceText(part.text),
+          timestamp: message.timestamp,
+        });
+        continue;
+      }
+      if (part.type === "thinking" && part.thinking.trim()) {
+        entries.push({
+          role: "thinking",
+          ...boundedSourceText(part.thinking),
+          timestamp: message.timestamp,
+        });
+        continue;
+      }
+      if (part.type === "toolCall") {
+        entries.push({
+          role: "tool",
+          ...boundedSourceText(safeJson(part.arguments)),
+          name: part.name,
+          sourceToolCallId: part.id,
+          timestamp: message.timestamp,
+        });
+      }
+    }
+    return entries;
+  }
+
+  if (message.role !== "toolResult") return [];
+  const source = message.content
+    .map((part) =>
+      part.type === "text" ? part.text : `[image: ${part.mimeType}]`,
+    )
+    .join("\n");
+  return [
+    {
+      role: "toolResult",
+      ...boundedSourceText(source),
+      name: message.toolName,
+      sourceToolCallId: message.toolCallId,
+      isError: message.isError,
+      timestamp: message.timestamp,
+    },
+  ];
+}
+
+function assistantText(message: ProgressAssistantMessage) {
+  return message.content
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("\n")
+    .trim();
+}
+
+function addAssistantUsage(
+  usage: AgentUsage,
+  message: ProgressAssistantMessage,
+) {
+  usage.turns++;
+  const current = message.usage;
+  if (!current) return;
+  usage.input += current.input || 0;
+  usage.output += current.output || 0;
+  usage.cacheRead += current.cacheRead || 0;
+  usage.cacheWrite += current.cacheWrite || 0;
+  usage.cost += current.cost?.total || 0;
+}
+
+function toolMetadata(
+  toolCallId: string,
+  timings: ReadonlyMap<string, ProgressToolTiming>,
+) {
+  const timing = timings.get(toolCallId);
+  return {
+    toolCallId: truncateUtf8(toolCallId, 1024),
+    ...(timing?.startedAt === undefined ? {} : { startedAt: timing.startedAt }),
+    ...(timing?.finishedAt === undefined
+      ? {}
+      : { finishedAt: timing.finishedAt }),
+    ...(timing?.durationMs === undefined
+      ? {}
+      : { durationMs: timing.durationMs }),
+  };
+}
+
+/**
+ * Bounded, ephemeral projection of Pi's active child messages.
+ *
+ * Pi remains canonical. Normal finalized messages are folded once; startup,
+ * compaction, and terminal settlement replace this state from Pi's messages.
+ */
+export class AgentProgressProjection {
+  private usage = emptyUsage();
+  private preview = "";
+  private latestAssistant?: ProgressAssistantMessage;
+  private firstEntry?: ProjectedTranscriptEntry;
+  private tailEntries: ProjectedTranscriptEntry[] = [];
+  private totalEntries = 0;
+  private contextTokens: ContextTokens;
+
+  constructor(
+    messages: readonly AgentMessage[] = [],
+    contextTokens?: ContextTokens,
+  ) {
+    this.replace(messages, contextTokens);
+  }
+
+  replace(messages: readonly AgentMessage[], contextTokens?: ContextTokens) {
+    this.usage = emptyUsage();
+    this.preview = "";
+    this.latestAssistant = undefined;
+    this.firstEntry = undefined;
+    this.tailEntries = [];
+    this.totalEntries = 0;
+    this.contextTokens = contextTokens;
+    for (const message of messages) this.ingest(message, false);
+  }
+
+  append(message: AgentMessage) {
+    this.ingest(message, true);
+  }
+
+  private ingest(message: AgentMessage, updateContext: boolean) {
+    if (message.role === "assistant") {
+      addAssistantUsage(this.usage, message);
+      this.latestAssistant = message;
+      const text = assistantText(message);
+      if (text) this.preview = text;
+    }
+
+    if (updateContext && this.contextTokens !== undefined) {
+      const assistantTokens =
+        message.role === "assistant"
+          ? validAssistantContextTokens(message)
+          : undefined;
+      if (assistantTokens !== undefined) {
+        this.contextTokens = assistantTokens;
+      } else if (this.contextTokens !== null) {
+        this.contextTokens += estimateTokens(message);
+      }
+    }
+
+    for (const entry of messageEntries(message)) this.pushEntry(entry);
+  }
+
+  private pushEntry(entry: ProjectedTranscriptEntry) {
+    this.totalEntries++;
+    if (!this.firstEntry) {
+      this.firstEntry = entry;
+      return;
+    }
+    this.tailEntries.push(entry);
+    if (this.tailEntries.length >= TRANSCRIPT_MAX_ENTRIES) {
+      this.tailEntries.shift();
+    }
+  }
+
+  snapshot(
+    toolTimings: ReadonlyMap<string, ProgressToolTiming> = new Map(),
+  ): AgentProgressProjectionSnapshot {
+    const selected = this.firstEntry
+      ? [this.firstEntry, ...this.tailEntries]
+      : [];
+    const transcript: TranscriptEntry[] = [];
+    let totalBytes = 0;
+    for (const entry of selected) {
+      const remaining = TRANSCRIPT_TOTAL_MAX_BYTES - totalBytes;
+      if (remaining <= 0) break;
+      const text = truncateUtf8(
+        entry.text,
+        Math.min(TRANSCRIPT_ENTRY_MAX_BYTES, remaining),
+      );
+      totalBytes += Buffer.byteLength(text, "utf8");
+      const truncated = entry.sourceTextTruncated || text !== entry.text;
+      transcript.push({
+        role: entry.role,
+        text: truncated ? `${text}\n[transcript entry truncated]` : text,
+        ...(entry.name === undefined ? {} : { name: entry.name }),
+        ...(entry.sourceToolCallId === undefined
+          ? {}
+          : toolMetadata(entry.sourceToolCallId, toolTimings)),
+        ...(entry.isError === undefined ? {} : { isError: entry.isError }),
+        ...(entry.timestamp === undefined
+          ? {}
+          : { timestamp: entry.timestamp }),
+      });
+    }
+    if (transcript.length < this.totalEntries) {
+      transcript.push({
+        role: "toolResult",
+        name: "transcript",
+        text: `[transcript truncated: retained ${transcript.length} of ${this.totalEntries} entries]`,
+      });
+    }
+    return {
+      preview: this.preview,
+      usage: {
+        ...this.usage,
+        ...(typeof this.contextTokens === "number"
+          ? { contextTokens: this.contextTokens }
+          : {}),
+      },
+      latestAssistant: this.latestAssistant,
+      transcript,
+    };
+  }
+}
+
+export function transcriptFromMessages(
+  messages: AgentMessage[],
+  toolTimings: ReadonlyMap<string, ProgressToolTiming> = new Map(),
+) {
+  return new AgentProgressProjection(messages).snapshot(toolTimings).transcript;
+}

--- a/extensions/workflows/runner.ts
+++ b/extensions/workflows/runner.ts
@@ -39,17 +39,19 @@ import {
   STRUCTURED_OUTPUT_TOOL_DESCRIPTION,
 } from "./prompt.ts";
 import {
+  AgentProgressProjection,
+  type ProgressAssistantMessage,
+  transcriptFromMessages,
+} from "./progress-projection.ts";
+import {
   createReplayFilesystemBoundary,
   type ReplayFilesystemBoundaryOptions,
 } from "./replay-safety.ts";
-import { safeStringify, truncateUtf8 } from "./serialization.ts";
+import { truncateUtf8 } from "./serialization.ts";
 import { bindWorkflowToolRenderer } from "./tool-renderer.ts";
 
 const AGENT_OUTPUT_MAX_BYTES = 64 * 1024;
 export const MODEL_PROGRESS_TIMEOUT_MS = 45_000;
-const TRANSCRIPT_ENTRY_MAX_BYTES = 16 * 1024;
-const TRANSCRIPT_TOTAL_MAX_BYTES = 256 * 1024;
-const TRANSCRIPT_MAX_ENTRIES = 200;
 
 export type WorkflowModel = NonNullable<ExtensionContext["model"]>;
 export type ThinkingLevel = ReturnType<ExtensionAPI["getThinkingLevel"]>;
@@ -239,7 +241,9 @@ function makeStructuredOutputTool(
   });
 }
 
-type AssistantMessage = Extract<AgentMessage, { role: "assistant" }>;
+type AssistantMessage = ProgressAssistantMessage;
+
+export { transcriptFromMessages };
 
 export interface AssistantSettlement {
   stopReason: AssistantMessage["stopReason"];
@@ -275,28 +279,6 @@ export function agentFailureMessage(
   return settlement?.errorMessage ?? promptErrorMessage ?? "Agent failed";
 }
 
-function finalOutput(messages: AgentMessage[]): string {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (msg.role !== "assistant") continue;
-    const text = msg.content
-      .filter((part) => part.type === "text")
-      .map((part) => part.text)
-      .join("\n")
-      .trim();
-    if (text) return text;
-  }
-  return "";
-}
-
-function safeJson(value: unknown): string {
-  return safeStringify(value, {
-    maxBytes: TRANSCRIPT_ENTRY_MAX_BYTES,
-    maxDepth: 12,
-    maxNodes: 2_000,
-  });
-}
-
 /** Record lifecycle timings without inferring completion from message timestamps. */
 export function recordToolExecutionTiming(
   timings: Map<string, ToolExecutionTiming>,
@@ -319,133 +301,6 @@ export function recordToolExecutionTiming(
     finishedAt: observedAt,
     ...(durationMs === undefined ? {} : { durationMs }),
   });
-}
-
-function toolMetadata(
-  toolCallId: string,
-  timings: ReadonlyMap<string, ToolExecutionTiming>,
-) {
-  const timing = timings.get(toolCallId);
-  return {
-    toolCallId: truncateUtf8(toolCallId, 1024),
-    ...(timing?.startedAt === undefined ? {} : { startedAt: timing.startedAt }),
-    ...(timing?.finishedAt === undefined
-      ? {}
-      : { finishedAt: timing.finishedAt }),
-    ...(timing?.durationMs === undefined
-      ? {}
-      : { durationMs: timing.durationMs }),
-  };
-}
-
-/** Convert pi messages into a compact, serializable transcript for the UI. */
-export function transcriptFromMessages(
-  messages: AgentMessage[],
-  toolTimings: ReadonlyMap<string, ToolExecutionTiming> = new Map(),
-): TranscriptEntry[] {
-  const entries: TranscriptEntry[] = [];
-  for (const message of messages) {
-    if (message.role === "user") {
-      const text =
-        typeof message.content === "string"
-          ? message.content
-          : message.content
-              .map((part) =>
-                part.type === "text" ? part.text : `[image: ${part.mimeType}]`,
-              )
-              .join("\n");
-      if (text.trim()) {
-        entries.push({ role: "user", text, timestamp: message.timestamp });
-      }
-      continue;
-    }
-
-    if (message.role === "assistant") {
-      for (const part of message.content) {
-        if (part.type === "text" && part.text.trim()) {
-          entries.push({
-            role: "assistant",
-            text: part.text,
-            timestamp: message.timestamp,
-          });
-        } else if (part.type === "thinking" && part.thinking.trim()) {
-          entries.push({
-            role: "thinking",
-            text: part.thinking,
-            timestamp: message.timestamp,
-          });
-        } else if (part.type === "toolCall") {
-          entries.push({
-            role: "tool",
-            name: part.name,
-            text: safeJson(part.arguments),
-            timestamp: message.timestamp,
-            ...toolMetadata(part.id, toolTimings),
-          });
-        }
-      }
-      continue;
-    }
-
-    if (message.role !== "toolResult") continue;
-    const text = message.content
-      .map((part) =>
-        part.type === "text" ? part.text : `[image: ${part.mimeType}]`,
-      )
-      .join("\n");
-    entries.push({
-      role: "toolResult",
-      name: message.toolName,
-      text,
-      isError: message.isError,
-      timestamp: message.timestamp,
-      ...toolMetadata(message.toolCallId, toolTimings),
-    });
-  }
-  const selected =
-    entries.length <= TRANSCRIPT_MAX_ENTRIES
-      ? entries
-      : [entries[0], ...entries.slice(-(TRANSCRIPT_MAX_ENTRIES - 1))];
-  const bounded: TranscriptEntry[] = [];
-  let totalBytes = 0;
-  for (const entry of selected) {
-    const remaining = TRANSCRIPT_TOTAL_MAX_BYTES - totalBytes;
-    if (remaining <= 0) break;
-    const text = truncateUtf8(
-      entry.text,
-      Math.min(TRANSCRIPT_ENTRY_MAX_BYTES, remaining),
-    );
-    totalBytes += Buffer.byteLength(text, "utf8");
-    bounded.push({
-      ...entry,
-      text:
-        text === entry.text ? text : `${text}\n[transcript entry truncated]`,
-    });
-  }
-  if (bounded.length < entries.length) {
-    bounded.push({
-      role: "toolResult",
-      name: "transcript",
-      text: `[transcript truncated: retained ${bounded.length} of ${entries.length} entries]`,
-    });
-  }
-  return bounded;
-}
-
-function computeUsage(messages: AgentMessage[]): AgentUsage {
-  const usage = emptyUsage();
-  for (const msg of messages) {
-    if (msg.role !== "assistant") continue;
-    usage.turns++;
-    const u = msg.usage;
-    if (!u) continue;
-    usage.input += u.input || 0;
-    usage.output += u.output || 0;
-    usage.cacheRead += u.cacheRead || 0;
-    usage.cacheWrite += u.cacheWrite || 0;
-    usage.cost += u.cost?.total || 0;
-  }
-  return usage;
 }
 
 function errorText(error: unknown): string {
@@ -581,12 +436,17 @@ export async function runAgent(
   let modelProgressTimeoutMessage: string | undefined;
   let abortOperation: Promise<unknown> | undefined;
   let rejectForAbort: ((error: Error) => void) | undefined;
+  let rejectForProjectionFailure: ((error: Error) => void) | undefined;
   const abortRace = new Promise<never>((_resolve, reject) => {
     rejectForAbort = reject;
+  });
+  const projectionFailureRace = new Promise<never>((_resolve, reject) => {
+    rejectForProjectionFailure = reject;
   });
   // The same promise covers startup and prompting. Keep it observed even when
   // a pre-aborted run returns before either race is installed.
   void abortRace.catch(() => {});
+  void projectionFailureRace.catch(() => {});
   const abortError = () =>
     options.signal?.reason instanceof Error
       ? options.signal.reason
@@ -711,8 +571,8 @@ export async function runAgent(
   let promptErrorMessage: string | undefined;
   const toolTimings = new Map<string, ToolExecutionTiming>();
 
-  const captureToolRenderData = () => {
-    for (const message of childSession.messages) {
+  const captureToolRenderData = (messages: readonly AgentMessage[]) => {
+    for (const message of messages) {
       if (message.role === "assistant") {
         for (const part of message.content) {
           if (part.type !== "toolCall") continue;
@@ -734,24 +594,27 @@ export async function runAgent(
     }
   };
 
-  const sync = () => {
-    // Operator reuse can restore earlier messages before this activation's
-    // event subscription starts. Rehydrate their native UI projection here.
-    captureToolRenderData();
-    const messages = childSession.messages;
-    usage = computeUsage(messages);
-
+  const refreshModel = (latestAssistant?: AssistantMessage) => {
     const sessionModel = childSession.model;
     modelId = sessionModel?.id ?? modelId;
     contextWindow = sessionModel?.contextWindow ?? contextWindow;
-    const context = childSession.getContextUsage();
-    if (
-      typeof context?.tokens === "number" &&
-      Number.isFinite(context.tokens) &&
-      context.tokens >= 0
-    ) {
-      usage.contextTokens = context.tokens;
+    if (!latestAssistant) return;
+    const responseMatchesSession =
+      !sessionModel ||
+      (latestAssistant.provider === sessionModel.provider &&
+        latestAssistant.model === sessionModel.id);
+    const reportedId = latestAssistant.responseModel ?? latestAssistant.model;
+    const reportedModel = responseMatchesSession
+      ? options.modelRegistry.find(latestAssistant.provider, reportedId)
+      : undefined;
+    if (reportedModel) {
+      modelId = reportedModel.id;
+      contextWindow = reportedModel.contextWindow;
     }
+  };
+
+  const sampleContextTokens = () => {
+    const context = childSession.getContextUsage();
     if (
       typeof context?.contextWindow === "number" &&
       Number.isFinite(context.contextWindow) &&
@@ -759,33 +622,72 @@ export async function runAgent(
     ) {
       contextWindow = context.contextWindow;
     }
-
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i];
-      if (msg.role !== "assistant") continue;
-      // Some gateways report a concrete fallback model. Prefer its registry
-      // metadata when available so capacity tracks the model that served the
-      // latest response rather than a hardcoded/configured guess.
-      const responseMatchesSession =
-        !sessionModel ||
-        (msg.provider === sessionModel.provider &&
-          msg.model === sessionModel.id);
-      const reportedId = msg.responseModel ?? msg.model;
-      const reportedModel = responseMatchesSession
-        ? options.modelRegistry.find(msg.provider, reportedId)
-        : undefined;
-      if (reportedModel) {
-        modelId = reportedModel.id;
-        contextWindow = reportedModel.contextWindow;
-      }
-      break;
+    if (
+      typeof context?.tokens === "number" &&
+      Number.isFinite(context.tokens) &&
+      context.tokens >= 0
+    ) {
+      return context.tokens;
     }
+    return context?.tokens === null ? null : undefined;
+  };
+
+  const projection = new AgentProgressProjection();
+  let lastProjection = projection.snapshot(toolTimings);
+
+  const snapshotProjection = () => {
+    const snapshot = projection.snapshot(toolTimings);
+    usage = snapshot.usage;
+    refreshModel(snapshot.latestAssistant);
+    lastProjection = snapshot;
+    return snapshot;
+  };
+
+  const reconcileProjection = () => {
+    projection.replace(childSession.messages, sampleContextTokens());
+    return snapshotProjection();
+  };
+
+  const emitProgress = () => {
+    const snapshot = snapshotProjection();
+    options.onProgress?.({
+      preview: snapshot.preview,
+      usage,
+      model: modelId,
+      contextWindow,
+      transcript: bindWorkflowToolRenderer(snapshot.transcript, toolRenderer),
+    });
   };
 
   let armModelProgress = () => {};
   let markModelProgress = () => {};
   let completeModelTurn = () => {};
   let cancelModelProgressWatchdog = () => {};
+  let compactionReconcileQueued = false;
+  const queueCompactionReconcile = () => {
+    if (compactionReconcileQueued) return;
+    compactionReconcileQueued = true;
+    queueMicrotask(() => {
+      compactionReconcileQueued = false;
+      if (settled) return;
+      // Pi may synchronously remove a restored overflow assistant immediately
+      // after compaction_end. Read canonical state after that mutation.
+      try {
+        reconcileProjection();
+        emitProgress();
+      } catch (error) {
+        promptErrorMessage ??= `Failed to reconcile agent progress after compaction: ${errorText(error)}`;
+        rejectForProjectionFailure?.(new Error(promptErrorMessage));
+        try {
+          abortOperation ??= childSession.abort();
+          void abortOperation.catch(() => {});
+        } catch {
+          // The projection failure remains authoritative; bounded cleanup gets
+          // another chance to abort and dispose the child below.
+        }
+      }
+    });
+  };
   const unsubscribe = childSession.subscribe((event) => {
     if (settled) return;
     if (event.type === "turn_start") armModelProgress();
@@ -820,36 +722,34 @@ export async function runAgent(
         assistantSettlement,
         event.message,
       );
+      // Pi publishes the finalized message before tool lifecycle delivery.
+      // Hydrate native rendering from this one message without reading history.
+      captureToolRenderData([event.message]);
+      projection.append(event.message);
     }
     if (
       event.type === "tool_execution_start" ||
       event.type === "tool_execution_end"
     ) {
       recordToolExecutionTiming(toolTimings, event);
-    } else if (
-      event.type !== "message_end" &&
-      event.type !== "compaction_end"
-    ) {
+    } else if (event.type === "compaction_end") {
+      queueCompactionReconcile();
+      return;
+    } else if (event.type !== "message_end") {
       return;
     }
-    sync();
-    const progressTranscript = bindWorkflowToolRenderer(
-      transcriptFromMessages(childSession.messages, toolTimings),
-      toolRenderer,
-    );
-    options.onProgress?.({
-      preview: finalOutput(childSession.messages),
-      usage,
-      model: modelId,
-      contextWindow,
-      transcript: progressTranscript,
-    });
+    emitProgress();
   });
 
   let output = "";
   let transcript: TranscriptEntry[] = [];
   let cleanupErrors: string[] = [];
   try {
+    // Operator reuse may restore messages before this activation subscribes.
+    // Hydrate both bounded projections once; ordinary progress never rescans it.
+    projection.replace(childSession.messages, sampleContextTokens());
+    captureToolRenderData(childSession.messages);
+    snapshotProjection();
     if (!aborted) {
       const watchdog = createModelProgressWatchdog(
         (error) => {
@@ -878,25 +778,38 @@ export async function runAgent(
           childSession.prompt(buildWorkflowAgentPrompt(options.prompt)),
         ),
         abortRace,
+        projectionFailureRace,
       ]);
     }
   } catch (error) {
-    promptErrorMessage = errorText(error);
+    promptErrorMessage ??= errorText(error);
   } finally {
     cancelModelProgressWatchdog();
     options.signal?.removeEventListener("abort", onAbort);
     settled = true;
     unsubscribe();
     unsubscribeToolGuards?.();
-    sync();
-    output = truncateUtf8(
-      finalOutput(childSession.messages),
-      AGENT_OUTPUT_MAX_BYTES,
-    );
-    transcript = bindWorkflowToolRenderer(
-      transcriptFromMessages(childSession.messages, toolTimings),
-      toolRenderer,
-    );
+    try {
+      const finalProjection = reconcileProjection();
+      output = truncateUtf8(finalProjection.preview, AGENT_OUTPUT_MAX_BYTES);
+      transcript = bindWorkflowToolRenderer(
+        finalProjection.transcript,
+        toolRenderer,
+      );
+    } catch (error) {
+      promptErrorMessage ??= `Failed to reconcile final agent progress: ${errorText(error)}`;
+      // A broken canonical accessor must not prevent owned-session cleanup.
+      // Preserve the last projection that was fully observed instead.
+      try {
+        output = truncateUtf8(lastProjection.preview, AGENT_OUTPUT_MAX_BYTES);
+        transcript = bindWorkflowToolRenderer(
+          lastProjection.transcript,
+          toolRenderer,
+        );
+      } catch (fallbackError) {
+        promptErrorMessage += `; failed to render last progress: ${errorText(fallbackError)}`;
+      }
+    }
     const cleanup = await shutdownAndDisposeChildSession(childSession, {
       abort: aborted || promptErrorMessage !== undefined,
       abortOperation,

--- a/tests/extensions/workflows/progress-projection.test.ts
+++ b/tests/extensions/workflows/progress-projection.test.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import { AgentProgressProjection } from "../../../extensions/workflows/progress-projection.ts";
+
+type AgentMessage = AgentSession["messages"][number];
+
+const usage = (totalTokens: number) => ({
+  input: totalTokens,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens,
+  cost: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 0,
+  },
+});
+
+function assistant(text: string, totalTokens: number, timestamp = 1_000) {
+  return {
+    role: "assistant",
+    content: [{ type: "text" as const, text }],
+    api: "openai-responses",
+    provider: "fixture",
+    model: "fixture",
+    usage: usage(totalTokens),
+    stopReason: "stop" as const,
+    timestamp,
+  } satisfies AgentMessage;
+}
+
+test("incremental projection preserves occurrences and is compaction-aware", () => {
+  const first = assistant("first", 100);
+  const projection = new AgentProgressProjection([first], 100);
+  const second = assistant("second", 200, 2_000);
+  const result = {
+    role: "toolResult" as const,
+    toolCallId: "call-2",
+    toolName: "read",
+    content: [{ type: "text" as const, text: "result" }],
+    isError: false,
+    timestamp: 2_100,
+  } satisfies AgentMessage;
+
+  projection.append(second);
+  projection.append(second);
+  projection.append(result);
+  const incremental = projection.snapshot();
+  assert.equal(incremental.preview, "second");
+  assert.equal(incremental.usage.turns, 3);
+  assert.equal(
+    incremental.transcript.filter((entry) => entry.text === "second").length,
+    2,
+  );
+  assert.ok((incremental.usage.contextTokens ?? 0) > 200);
+
+  const retained = assistant("retained", 50, 3_000);
+  projection.replace([retained], null);
+  const compacted = projection.snapshot();
+  assert.equal(compacted.preview, "retained");
+  assert.equal(compacted.usage.turns, 1);
+  assert.equal(compacted.usage.contextTokens, undefined);
+  assert.equal(
+    compacted.transcript.some((entry) => entry.text === "first"),
+    false,
+  );
+
+  const recovered = assistant("recovered", 80, 4_000);
+  projection.append(recovered);
+  assert.equal(projection.snapshot().usage.contextTokens, 80);
+});
+
+test("bounded transcript preserves the first and newest entries", () => {
+  const messages: AgentMessage[] = Array.from({ length: 205 }, (_, index) => ({
+    role: "user" as const,
+    content: `message ${index}`,
+    timestamp: index,
+  }));
+  const transcript = new AgentProgressProjection(messages).snapshot()
+    .transcript;
+
+  assert.equal(transcript.length, 201);
+  assert.equal(transcript[0]?.text, "message 0");
+  assert.equal(
+    transcript.some((entry) => entry.text === "message 1"),
+    false,
+  );
+  assert.equal(transcript.at(-2)?.text, "message 204");
+  assert.match(transcript.at(-1)?.text ?? "", /retained 200 of 205 entries/);
+});
+
+test("tool timings remain keyed by call identity after incremental ingestion", () => {
+  const call = {
+    ...assistant("", 10),
+    content: [
+      {
+        type: "toolCall" as const,
+        id: "call-a",
+        name: "read",
+        arguments: { path: "fixture" },
+      },
+    ],
+    stopReason: "toolUse" as const,
+  } satisfies AgentMessage;
+  const projection = new AgentProgressProjection();
+  projection.append(call);
+
+  const transcript = projection.snapshot(
+    new Map([["call-a", { startedAt: 10, finishedAt: 25, durationMs: 15 }]]),
+  ).transcript;
+
+  assert.deepEqual(
+    transcript.map(({ toolCallId, startedAt, finishedAt, durationMs }) => ({
+      toolCallId,
+      startedAt,
+      finishedAt,
+      durationMs,
+    })),
+    [
+      {
+        toolCallId: "call-a",
+        startedAt: 10,
+        finishedAt: 25,
+        durationMs: 15,
+      },
+    ],
+  );
+});
+
+test("transcript byte limits preserve UTF-8 boundaries and explicit markers", () => {
+  const oversized = new AgentProgressProjection([
+    { role: "user", content: "界".repeat(10_000), timestamp: 1 },
+  ]).snapshot().transcript;
+  const [prefix = "", marker] = (oversized[0]?.text ?? "").split(
+    "\n[transcript entry truncated]",
+  );
+  assert.equal(marker, "");
+  assert.ok(Buffer.byteLength(prefix, "utf8") <= 16 * 1024);
+  assert.equal(prefix.endsWith("界"), true);
+
+  const manyLargeMessages: AgentMessage[] = Array.from(
+    { length: 20 },
+    (_, index) => ({
+      role: "user" as const,
+      content: String(index % 10).repeat(16 * 1024),
+      timestamp: index,
+    }),
+  );
+  const bounded = new AgentProgressProjection(manyLargeMessages).snapshot()
+    .transcript;
+  const retained = bounded.filter((entry) => entry.name !== "transcript");
+  assert.equal(retained.length, 16);
+  assert.ok(
+    retained.reduce(
+      (bytes, entry) => bytes + Buffer.byteLength(entry.text, "utf8"),
+      0,
+    ) <=
+      256 * 1024,
+  );
+  assert.match(bounded.at(-1)?.text ?? "", /retained 16 of 20 entries/);
+});

--- a/tests/extensions/workflows/runner.test.ts
+++ b/tests/extensions/workflows/runner.test.ts
@@ -67,16 +67,29 @@ function runnerHarness(options: {
   prompt?: () => Promise<void>;
   abort?: () => Promise<void>;
   shutdown?: () => Promise<void>;
+  onMessageRead?: () => void;
+  onContextUsage?: () => void;
 }) {
   const listeners = new Set<AgentSessionEventListener>();
-  const messages: AgentSession["messages"] = [];
+  const observedMessages = (value: AgentSession["messages"]) =>
+    new Proxy(value, {
+      get(target, property, receiver) {
+        if (typeof property === "string" && /^\d+$/.test(property)) {
+          options.onMessageRead?.();
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+  let messages = observedMessages([]);
   const firstDisposal = deferred<void>();
   let bindings = 0;
   let prompts = 0;
   let aborts = 0;
   let disposals = 0;
   const session = {
-    messages,
+    get messages() {
+      return messages;
+    },
     model: undefined,
     extensionRunner: {
       hasHandlers: () => options.shutdown !== undefined,
@@ -102,7 +115,10 @@ function runnerHarness(options: {
       disposals++;
       firstDisposal.resolve();
     },
-    getContextUsage: () => undefined,
+    getContextUsage: () => {
+      options.onContextUsage?.();
+      return undefined;
+    },
     getAllTools: () => [],
     getToolDefinition: () => undefined,
   } as unknown as AgentSession;
@@ -110,7 +126,12 @@ function runnerHarness(options: {
   return {
     factory,
     session,
-    messages,
+    get messages() {
+      return messages;
+    },
+    replaceMessages: (next: AgentSession["messages"]) => {
+      messages = observedMessages(next);
+    },
     emit: (event: AgentSessionEvent) => {
       for (const listener of listeners) listener(event);
     },
@@ -422,6 +443,240 @@ test("schema-less agents accept an empty assistant message_end", async () => {
   assert.equal(outcome.aborted, false);
   assert.equal(outcome.output, "");
   assert.equal(outcome.error, undefined);
+  assert.equal(harness.disposals(), 1);
+});
+
+test("runAgent projects a long tool loop without rescanning canonical history", async () => {
+  let messageReads = 0;
+  let contextUsageReads = 0;
+  let respond = () => {};
+  const harness = runnerHarness({
+    onMessageRead: () => messageReads++,
+    onContextUsage: () => contextUsageReads++,
+    prompt: async () => respond(),
+  });
+  respond = () => {
+    for (let index = 0; index < 50; index++) {
+      const toolCallId = `call-${index}`;
+      const assistant = {
+        ...assistantTextMessage(`cycle ${index}`),
+        content: [
+          { type: "text" as const, text: `cycle ${index}` },
+          {
+            type: "toolCall" as const,
+            id: toolCallId,
+            name: "read",
+            arguments: { path: `fixture-${index}.txt` },
+          },
+        ],
+        stopReason: "toolUse" as const,
+        timestamp: 1_000 + index * 2,
+      };
+      const result = {
+        role: "toolResult" as const,
+        toolCallId,
+        toolName: "read",
+        content: [{ type: "text" as const, text: `result ${index}` }],
+        isError: false,
+        timestamp: 1_001 + index * 2,
+      };
+      harness.messages.push(assistant);
+      harness.emit({ type: "message_end", message: assistant });
+      harness.emit({
+        type: "tool_execution_start",
+        toolCallId,
+        toolName: "read",
+        args: { path: `fixture-${index}.txt` },
+      });
+      harness.emit({
+        type: "tool_execution_end",
+        toolCallId,
+        toolName: "read",
+        result,
+        isError: false,
+      });
+      harness.messages.push(result);
+      harness.emit({ type: "message_end", message: result });
+    }
+    // Pi state is canonical even if a final projection event is missed.
+    harness.messages.push(assistantTextMessage("unannounced final state"));
+  };
+
+  const outcome = await runHarnessAgent(harness);
+
+  assert.equal(outcome.ok, true);
+  assert.equal(outcome.output, "unannounced final state");
+  assert.equal(outcome.usage.turns, 51);
+  assert.equal(
+    outcome.transcript.some(
+      (entry) => entry.role === "toolResult" && entry.text === "result 49",
+    ),
+    true,
+  );
+  assert.ok(
+    messageReads <= harness.messages.length * 4,
+    `${harness.messages.length} messages caused ${messageReads} canonical history reads`,
+  );
+  assert.ok(
+    messageReads >= harness.messages.length,
+    "terminal reconciliation must read every canonical message",
+  );
+  assert.equal(
+    contextUsageReads,
+    2,
+    "context occupancy should be sampled only at hydrate and final reconcile",
+  );
+});
+
+test("compaction rebuilds progress after Pi finishes mutating active messages", async () => {
+  let contextUsageReads = 0;
+  let respond = async () => {};
+  const progress: Array<
+    Parameters<NonNullable<Parameters<typeof runAgent>[0]["onProgress"]>>[0]
+  > = [];
+  const harness = runnerHarness({
+    onContextUsage: () => contextUsageReads++,
+    prompt: () => respond(),
+  });
+  respond = async () => {
+    const discarded = assistantTextMessage("discarded before compaction");
+    harness.messages.push(discarded);
+    harness.emit({ type: "message_end", message: discarded });
+
+    harness.emit({
+      type: "compaction_end",
+      reason: "threshold",
+      result: {
+        summary: "fixture summary",
+        firstKeptEntryId: "fixture-entry",
+        tokensBefore: 1_000,
+        estimatedTokensAfter: 100,
+      },
+      aborted: false,
+      willRetry: false,
+    });
+    // Pi emits first, then can synchronously finish mutating active state.
+    const retained = assistantTextMessage("retained summary context");
+    harness.replaceMessages([retained]);
+    await Promise.resolve();
+
+    const compacted = progress.at(-1);
+    assert.equal(compacted?.preview, "retained summary context");
+    assert.equal(
+      compacted?.transcript.some((entry) =>
+        entry.text.includes("discarded before compaction"),
+      ),
+      false,
+    );
+
+    const completed = assistantTextMessage("completed after compaction");
+    harness.messages.push(completed);
+    harness.emit({ type: "message_end", message: completed });
+  };
+
+  const outcome = await runHarnessAgent(harness, {
+    onProgress: (update) => progress.push(update),
+  });
+
+  assert.equal(outcome.ok, true);
+  assert.equal(outcome.output, "completed after compaction");
+  assert.equal(outcome.usage.turns, 2);
+  assert.equal(
+    outcome.transcript.some((entry) =>
+      entry.text.includes("discarded before compaction"),
+    ),
+    false,
+  );
+  assert.equal(contextUsageReads, 3);
+});
+
+test("a deferred compaction projection failure stays inside the child outcome", async () => {
+  let respond = () => Promise.resolve();
+  const harness = runnerHarness({ prompt: () => respond() });
+  respond = () => {
+    harness.emit({
+      type: "compaction_end",
+      reason: "threshold",
+      result: {
+        summary: "fixture summary",
+        firstKeptEntryId: "fixture-entry",
+        tokensBefore: 1_000,
+        estimatedTokensAfter: 100,
+      },
+      aborted: false,
+      willRetry: false,
+    });
+    harness.replaceMessages([assistantTextMessage("compacted")]);
+    return new Promise<void>(() => {});
+  };
+
+  const outcome = await settleWithin(
+    runHarnessAgent(harness, {
+      onProgress: () => {
+        throw new Error("progress writer failed");
+      },
+    }),
+  );
+
+  assert.equal(outcome.ok, false);
+  assert.match(
+    outcome.error ?? "",
+    /failed to reconcile agent progress.*progress writer failed/i,
+  );
+  assert.equal(harness.aborts(), 1);
+  assert.equal(harness.disposals(), 1);
+});
+
+test("a persistent reconciliation failure cannot bypass child cleanup", async () => {
+  let contextUsageReads = 0;
+  let respond = () => Promise.resolve();
+  const harness = runnerHarness({
+    prompt: () => respond(),
+    onContextUsage: () => {
+      contextUsageReads++;
+      if (contextUsageReads > 1) throw new Error("context accessor failed");
+    },
+  });
+  respond = () => {
+    harness.emit({
+      type: "compaction_end",
+      reason: "threshold",
+      result: {
+        summary: "fixture summary",
+        firstKeptEntryId: "fixture-entry",
+        tokensBefore: 1_000,
+        estimatedTokensAfter: 100,
+      },
+      aborted: false,
+      willRetry: false,
+    });
+    return new Promise<void>(() => {});
+  };
+
+  const outcome = await settleWithin(runHarnessAgent(harness));
+
+  assert.equal(outcome.ok, false);
+  assert.match(
+    outcome.error ?? "",
+    /failed to reconcile agent progress.*context accessor failed/i,
+  );
+  assert.equal(harness.aborts(), 1);
+  assert.equal(harness.disposals(), 1);
+});
+
+test("a startup projection hydration failure cannot leak the child session", async () => {
+  const harness = runnerHarness({
+    onContextUsage: () => {
+      throw new Error("startup context accessor failed");
+    },
+  });
+
+  const outcome = await settleWithin(runHarnessAgent(harness));
+
+  assert.equal(outcome.ok, false);
+  assert.match(outcome.error ?? "", /startup context accessor failed/i);
+  assert.equal(harness.prompts(), 0);
+  assert.equal(harness.aborts(), 1);
   assert.equal(harness.disposals(), 1);
 });
 


### PR DESCRIPTION
## Problem

Workflow child progress currently rebuilds usage, preview, transcript, tool renderer state, and context occupancy from the complete Pi message history on every finalized message and tool lifecycle event. A long tool loop therefore repeatedly traverses an ever-growing history and becomes quadratic. This closes #179.

## Value

Long-running Workflow agents keep responsive progress reporting without spending progressively more CPU on derived UI state. The improvement grows with the run: a 10,000-message benchmark visits canonical source messages 10,000 times instead of the 100,005,000 visits required by a conservative one-full-scan-per-progress lower bound.

## Approach

- Add an ephemeral, bounded `AgentProgressProjection` that folds each finalized Pi message once and produces the existing full progress snapshot shape.
- Keep Pi messages canonical: rebuild from them at activation startup, after compaction, and at terminal settlement.
- Sample context occupancy only at those reconciliation boundaries and estimate it incrementally between them.
- Preserve the first and newest transcript entries, per-entry and aggregate byte limits, tool-call timing identities, native tool rendering, and final canonical reconciliation for missed events.
- Defer compaction reconciliation by one microtask so Pi can finish its synchronous message mutation first.
- Keep projection failures inside the child outcome and make abort/dispose unconditional, including persistent and startup hydration failures.

This intentionally does not add a persisted cross-activation checkpoint. Reusing an operator still performs one linear startup hydration per activation.

## Validation

- RED on the base revision: the 100-message tool-loop regression observed 30,704 canonical history reads (limit: 400).
- `node --test --experimental-strip-types tests/extensions/workflows/progress-projection.test.ts tests/extensions/workflows/runner.test.ts` — 33/33 passed.
- `node --test --experimental-strip-types tests/extensions/workflows/*.test.ts` — 246/246 passed.
- `bun run check` — passed. The 12 existing Effect diagnostics remain tracked by #170.
- `bun run test` — Node 926/926 and Vitest 30/30 passed.
- `bun benchmarks/workflow-progress.ts`:
  - 100 messages: 100 source visits vs 10,050 one-scan lower bound (100.5x reduction).
  - 1,000 messages: 1,000 vs 1,000,500 (1,000.5x reduction).
  - 10,000 messages: 10,000 vs 100,005,000 (10,000.5x reduction).
- Three independent review agents examined the current diff; all returned no findings after lifecycle, test, benchmark, compaction, and cleanup concerns were addressed.
- Manual Pi/TUI smoke was not run; the change is covered through deterministic runner/projection tests and the repository-wide suite.

## Impact

- User-visible behavior: progress content and update cadence remain compatible; long Workflow child loops should remain responsive.
- Model-visible context/tools: no schema, tool, prompt, or capability changes.
- Runtime/lifecycle: adds per-run ephemeral derived state, bounded to 200 transcript entries, 16 KiB per entry, and 256 KiB aggregate text; canonical state is reconciled at lifecycle boundaries.
- Persisted config/data: none.
- Compatibility/risk: compaction and terminal facts still come from Pi's canonical messages. New failure paths fail closed and still clean up the owned child session.
