### PR TITLE
fix(setup): query Windows process start times

### DIFF
--- a/extensions/shared/setup-config.ts
+++ b/extensions/shared/setup-config.ts
@@ -639,24 +639,55 @@ const sameOwner = (left: LockOwner, right: LockOwner) =>
 const sameFile = (left: Stats, right: Stats) =>
   left.dev === right.dev && left.ino === right.ino;
 
+const parsePowerShellProcessStartedAt = (stdout: string) => {
+  const startedAt = Number(stdout.trim());
+  return isPositiveInteger(startedAt) ? startedAt : undefined;
+};
+
+const parsePsProcessStartedAt = (stdout: string) => {
+  const startedAt = Date.parse(stdout.trim());
+  return Number.isFinite(startedAt) ? startedAt : undefined;
+};
+
+export function processStartedAtQuery(
+  pid: number,
+  platform = process.platform,
+) {
+  if (platform === "win32") {
+    const script = [
+      "$ErrorActionPreference='Stop'",
+      `$p=Get-Process -Id ${pid}`,
+      "[Console]::Out.Write(([DateTimeOffset]$p.StartTime).ToUnixTimeMilliseconds())",
+    ].join("; ");
+    return {
+      command: "powershell.exe",
+      args: ["-NoProfile", "-NonInteractive", "-Command", script],
+      env: undefined,
+      parseOutput: parsePowerShellProcessStartedAt,
+    };
+  }
+  return {
+    command: "ps",
+    args: ["-o", "lstart=", "-p", String(pid)],
+    env: { LC_ALL: "C" },
+    parseOutput: parsePsProcessStartedAt,
+  };
+}
+
 const queryProcessStartedAt = (pid: number) =>
   new Promise<number | undefined>((resolve) => {
-    if (process.platform === "win32") {
-      resolve(undefined);
-      return;
-    }
+    const query = processStartedAtQuery(pid);
     try {
       execFile(
-        "ps",
-        ["-o", "lstart=", "-p", String(pid)],
+        query.command,
+        query.args,
         {
           encoding: "utf8",
-          env: { ...process.env, LC_ALL: "C" },
+          env: query.env ? { ...process.env, ...query.env } : process.env,
           timeout: 1_000,
         },
         (error, stdout) => {
-          const startedAt = error ? Number.NaN : Date.parse(stdout.trim());
-          resolve(Number.isFinite(startedAt) ? startedAt : undefined);
+          resolve(error ? undefined : query.parseOutput(stdout));
         },
       );
     } catch {

--- a/tests/extensions/capabilities/index.test.ts
+++ b/tests/extensions/capabilities/index.test.ts
@@ -11,6 +11,9 @@ import {
 } from "../../../extensions/shared/tool-surface.ts";
 import { createCapabilitiesExtension } from "../../../extensions/capabilities/index.ts";
 
+const SUBAGENT_SKILL_PATH_PATTERN =
+  /skills(?:\\\\|[\\/])subagents(?:\\\\|[\\/])SKILL\.md/;
+
 interface CapturedTool {
   name: string;
   description: string;
@@ -238,7 +241,7 @@ test("an explicit subagent request loads delegation directly", () => {
     "subagent_check",
     "subagent_list",
   ]);
-  assert.match(JSON.stringify(results), /skills\/subagents\/SKILL\.md/);
+  assert.match(JSON.stringify(results), SUBAGENT_SKILL_PATH_PATTERN);
 });
 
 test("reserved capability words load their groups without action verbs", () => {
@@ -310,7 +313,7 @@ test("the gateway returns progressive skill guidance for a loaded group", async 
     groups: ["delegate"],
   });
 
-  assert.match(result.content[0]!.text, /skills\/subagents\/SKILL\.md/);
+  assert.match(result.content[0]!.text, SUBAGENT_SKILL_PATH_PATTERN);
 });
 
 test("conditional or negated capability boilerplate does not widen the tool surface", () => {

--- a/tests/extensions/shared/setup-config.test.ts
+++ b/tests/extensions/shared/setup-config.test.ts
@@ -23,11 +23,12 @@ const {
   DEFAULT_SETUP_CONFIG,
   FOOTER_PRESET_DEFINITIONS,
   formatSetupConfig,
-  POST_EDIT_COMMAND_MAX_CHARS,
-  SETUP_CONFIG_PATH,
   loadSetupConfig,
   parseSetupConfig,
+  POST_EDIT_COMMAND_MAX_CHARS,
+  processStartedAtQuery,
   saveSetupConfig,
+  SETUP_CONFIG_PATH,
   updateSetupConfig,
 } = await import("../../../extensions/shared/setup-config.ts");
 
@@ -46,6 +47,64 @@ const removeLockArtifacts = () => {
   }
 };
 
+async function runSetupConfigChildScenario({
+  source,
+  tempPrefix,
+  env = {},
+  failureLabel,
+}: {
+  source: string;
+  tempPrefix: string;
+  env?: NodeJS.ProcessEnv;
+  failureLabel: string;
+}) {
+  const scenarioAgentDir = mkdtempSync(join(tmpdir(), tempPrefix));
+  const child = spawn(
+    process.execPath,
+    ["--experimental-strip-types", "--input-type=module", "--eval", source],
+    {
+      env: {
+        ...process.env,
+        PI_CODING_AGENT_DIR: scenarioAgentDir,
+        SETUP_CONFIG_MODULE_URL: setupConfigModuleUrl,
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const finish = (error?: unknown) => {
+      if (settled) return;
+      settled = true;
+      rmSync(scenarioAgentDir, { recursive: true, force: true });
+      if (error) reject(error);
+      else resolve();
+    };
+    child.once("error", (error) => {
+      finish(new Error(`${failureLabel} failed to spawn`, { cause: error }));
+    });
+    child.once("exit", (code) => {
+      if (code === 0 && stdout === "preserved\n") finish();
+      else
+        finish(
+          new Error(`${failureLabel} exited ${code}: ${stderr || stdout}`),
+        );
+    });
+  });
+}
+
 test("capability discovery defaults to explicit and accepts adaptive opt-in", () => {
   assert.equal(DEFAULT_SETUP_CONFIG.capabilities.discovery, "explicit");
   assert.equal(
@@ -62,6 +121,29 @@ test("capability discovery defaults to explicit and accepts adaptive opt-in", ()
     formatSetupConfig(DEFAULT_SETUP_CONFIG),
     /Capability discovery: explicit/,
   );
+});
+
+test("process start-time queries are platform-specific and conservative", () => {
+  const windowsQuery = processStartedAtQuery(123, "win32");
+  assert.equal(windowsQuery.command, "powershell.exe");
+  assert.deepEqual(windowsQuery.args.slice(0, 3), [
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+  ]);
+  assert.match(windowsQuery.args.at(-1) ?? "", /Get-Process -Id 123/);
+  assert.equal(windowsQuery.parseOutput("1700000000000"), 1_700_000_000_000);
+  assert.equal(windowsQuery.parseOutput("not a timestamp"), undefined);
+
+  const posixQuery = processStartedAtQuery(123, "linux");
+  assert.equal(posixQuery.command, "ps");
+  assert.deepEqual(posixQuery.args, ["-o", "lstart=", "-p", "123"]);
+  assert.deepEqual(posixQuery.env, { LC_ALL: "C" });
+  assert.equal(
+    posixQuery.parseOutput("Mon Jan  1 00:00:00 2024\n"),
+    Date.parse("Mon Jan  1 00:00:00 2024"),
+  );
+  assert.equal(posixQuery.parseOutput("not a timestamp"), undefined);
 });
 
 test("every one-line footer preset keeps model context left and cwd right", () => {
@@ -374,6 +456,67 @@ test("a reused PID does not impersonate the dead lock owner", async () => {
   }
 });
 
+test("process start-time query failures do not authorize lock recovery", async () => {
+  const source = `
+const childProcess = await import("node:child_process");
+const { syncBuiltinESMExports } = await import("node:module");
+childProcess.default.execFile = (...args) => {
+  const callback = args.at(-1);
+  if (typeof callback !== "function") {
+    throw new Error("expected execFile callback");
+  }
+  queueMicrotask(() => callback(new Error("mock process start query failure"), ""));
+};
+syncBuiltinESMExports();
+
+const { existsSync, linkSync, readFileSync, rmSync, writeFileSync } = await import("node:fs");
+const {
+  DEFAULT_SETUP_CONFIG,
+  SETUP_CONFIG_PATH,
+  saveSetupConfig,
+  updateSetupConfig,
+} = await import(process.env.SETUP_CONFIG_MODULE_URL);
+
+await saveSetupConfig(DEFAULT_SETUP_CONFIG);
+const lockPath = SETUP_CONFIG_PATH + ".lock";
+const owner = {
+  version: 1,
+  pid: process.pid,
+  processStartedAt: 1,
+  processStartedAtVerified: true,
+  createdAt: Date.now(),
+  token: "44444444-4444-4444-8444-444444444444",
+};
+const metadata = JSON.stringify(owner) + "\\n";
+const claimPath = lockPath + ".owner." + owner.pid + "." + owner.processStartedAt + "." + owner.token;
+writeFileSync(claimPath, metadata);
+linkSync(claimPath, lockPath);
+
+let mutated = false;
+try {
+  await updateSetupConfig((current) => {
+    mutated = true;
+    return { ...current, ui: { ...current.ui, showHeader: true } };
+  });
+  throw new Error("lock was recovered after an unknown process start-time query");
+} catch (error) {
+  if (!(error instanceof Error) || !error.message.includes("Timed out waiting")) throw error;
+}
+if (mutated) throw new Error("mutator ran under unknown lock ownership");
+if (!existsSync(lockPath) || readFileSync(lockPath, "utf8") !== metadata) {
+  throw new Error("unknown lock ownership was modified");
+}
+rmSync(process.env.PI_CODING_AGENT_DIR, { recursive: true, force: true });
+process.stdout.write("preserved\\n");
+`;
+
+  await runSetupConfigChildScenario({
+    source,
+    tempPrefix: "my-pi-setup-query-failure-lock-",
+    failureLabel: "query failure owner check",
+  });
+});
+
 test("live and uncertain lock owners are never stolen", async () => {
   const source = `
 const { spawn } = await import("node:child_process");
@@ -435,44 +578,11 @@ process.stdout.write("preserved\\n");
 `;
 
   const runs = ["live", "unknown", "mismatched"].map((scenario) => {
-    const scenarioAgentDir = mkdtempSync(
-      join(tmpdir(), `my-pi-setup-${scenario}-lock-`),
-    );
-    const child = spawn(
-      process.execPath,
-      ["--experimental-strip-types", "--input-type=module", "--eval", source],
-      {
-        env: {
-          ...process.env,
-          PI_CODING_AGENT_DIR: scenarioAgentDir,
-          SETUP_CONFIG_MODULE_URL: setupConfigModuleUrl,
-          SETUP_LOCK_SCENARIO: scenario,
-        },
-        stdio: ["ignore", "pipe", "pipe"],
-      },
-    );
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
-    return new Promise<void>((resolve, reject) => {
-      child.once("error", reject);
-      child.once("exit", (code) => {
-        rmSync(scenarioAgentDir, { recursive: true, force: true });
-        if (code === 0 && stdout === "preserved\n") resolve();
-        else
-          reject(
-            new Error(
-              `${scenario} owner check exited ${code}: ${stderr || stdout}`,
-            ),
-          );
-      });
+    return runSetupConfigChildScenario({
+      source,
+      tempPrefix: `my-pi-setup-${scenario}-lock-`,
+      env: { SETUP_LOCK_SCENARIO: scenario },
+      failureLabel: `${scenario} owner check`,
     });
   });
 


### PR DESCRIPTION
## Problem

  Fixes #211.

  Windows test runs exposed two platform assumptions:

  - setup config lock liveness could not distinguish a reused PID from the original lock owner on `win32`, because
  process start-time lookup always returned `undefined`;
  - capability guidance tests assumed POSIX `/` path separators, while Windows paths use `\` and JSON stringification
  escapes them as `\\`.

  As a result, the Windows reproduction commands failed even though `package.json` declares Node support without an OS
  restriction.

  ## Value

  Windows contributors can trust the targeted setup/capabilities tests instead of being blocked by unrelated platform
  failures.

  More importantly, setup config lock recovery now exercises the same PID + process-start-time safety check on Windows
  as on POSIX. A stale lock left by a crashed writer can be recovered when the owner identity is provably dead, while
  uncertain ownership still fails closed.

  ## Approach

  Implemented a platform-specific process start-time query helper:

  - Windows uses `powershell.exe -NoProfile -NonInteractive -Command` with `Get-Process -Id <pid>` and emits Unix
  milliseconds from `StartTime`;
  - POSIX keeps the existing `ps -o lstart= -p <pid>` path with `LC_ALL=C`;
  - command failures, unavailable platform tools, timeouts, or unparsable output still return `undefined`, preserving
  the existing conservative `unknown` liveness fallback.

  The lock protocol itself is unchanged.

  For capabilities tests, replaced the hardcoded POSIX path regex with one that accepts `/`, `\`, and JSON-escaped `\\`.

  ## Validation

  Run on Windows with Bun `1.3.14`:

  - `bun install --frozen-lockfile` — pass
  - `node --test --experimental-strip-types tests/extensions/shared/setup-config.test.ts` — pass, 17/17
  - `node --test --experimental-strip-types tests/extensions/capabilities/index.test.ts` — pass, 15/15
  - `bun run lint` — pass
  - `bun run typecheck` — pass, with existing Effect language-service warnings

  Not fully green locally:

  - `bun run check` is still blocked by the existing CRLF formatting issue mentioned in #211.
  - `bun run test` reaches the fixed setup/capabilities tests successfully, but still hits unrelated Windows failures/
  hangs outside this PR scope.

  ## Impact

  User-visible behavior: None.

  Model-visible context/tools: None.

  Runtime/lifecycle: Windows setup config lock recovery can now prove a lock owner with a reused PID is dead by
  comparing process start time, matching the existing POSIX safety invariant.

  Persisted config/data: None. Lock file format and setup config format are unchanged.

  Compatibility or risk: Adds a Windows dependency on `powershell.exe` for the stronger liveness check. If PowerShell is
  unavailable, restricted, times out, or returns unparsable output, behavior falls back to the existing conservative
  `unknown` result.