### PR TITLE
ci: add npm release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
+      - name: Verify manual release source
+        if: github.event_name == 'workflow_dispatch'
+        run: test "${GITHUB_REF}" = "refs/heads/main"
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - run: bun run check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: npm
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - run: bun run check
+      - run: bun run test
+      - name: Verify release tag matches package version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          test "${GITHUB_REF_NAME}" = "v${version}"
+      - name: Verify package contents
+        run: npm pack --dry-run
+      - name: Publish package
+        run: npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,47 +2,106 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing version tag to publish (for example, v0.5.0)
+        required: true
+        type: string
   push:
     tags:
       - "v*.*.*"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
-  publish:
-    name: Publish to npm
+  validate:
+    name: Validate release
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    environment: npm
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v7
+      - name: Resolve release source
+        id: source
+        env:
+          DISPATCH_TAG: ${{ inputs.tag }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REF: ${{ github.ref }}
+        run: |
+          if test "${EVENT_NAME}" = "workflow_dispatch"; then
+            test "${REF}" = "refs/heads/main"
+            release_tag="${DISPATCH_TAG}"
+          else
+            release_tag="${REF_NAME}"
+          fi
+          git check-ref-format "refs/tags/${release_tag}"
+          case "${release_tag}" in
+            v*.*.*) ;;
+            *) exit 1 ;;
+          esac
+          printf 'tag=%s\n' "${release_tag}" >>"${GITHUB_OUTPUT}"
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.source.outputs.tag }}
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
-      - name: Verify manual release source
-        if: github.event_name == 'workflow_dispatch'
-        run: test "${GITHUB_REF}" = "refs/heads/main"
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - run: bun run check
       - run: bun run test
-      - name: Verify release tag matches package version
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Verify tagged release source
+        env:
+          RELEASE_TAG: ${{ steps.source.outputs.tag }}
         run: |
           version="$(node -p "require('./package.json').version")"
-          test "${GITHUB_REF_NAME}" = "v${version}"
+          test "${RELEASE_TAG}" = "v${version}"
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          git merge-base --is-ancestor HEAD origin/main
       - name: Verify package contents
-        run: npm pack --dry-run
+        run: npm pack --dry-run --ignore-scripts
+      - name: Build release artifact
+        run: |
+          mkdir release-artifact
+          npm pack --ignore-scripts --pack-destination release-artifact
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: npm-package
+          path: release-artifact/*.tgz
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish to npm
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: npm-package
+          path: release-artifact
       - name: Publish package
-        run: npm publish --access public
+        run: |
+          mapfile -t packages < <(find release-artifact -maxdepth 1 -type f -name '*.tgz' -print)
+          test "${#packages[@]}" -eq 1
+          npm publish "${packages[0]}" --ignore-scripts --access public

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,27 @@
+# Releasing OpenPI to npm
+
+OpenPI releases `@tt-a1i/openpi` through [the Release workflow](.github/workflows/release.yml). Do not publish from a local checkout.
+
+## One-time repository setup
+
+Before the first workflow release:
+
+1. Configure the npm trusted publisher for organization/user `tt-a1i`, repository `openpi`, workflow `release.yml`, and environment `npm`.
+2. Protect the GitHub `npm` environment with a required reviewer and prevent unreviewed deployment from other branches or tags. Allow only the protected `main` branch and version tags matching `v*.*.*`.
+
+The workflow has no long-lived npm token. Its publish job receives an OIDC identity only after the unprivileged validation job succeeds and the `npm` environment permits the deployment. The publish job consumes only the validated package artifact and does not run repository lifecycle scripts.
+
+## Release by version tag
+
+The version tag is the canonical release entry point:
+
+1. Update `package.json` to the intended version through a pull request and merge it to `main`.
+2. Create and push `v<package.json version>` at that merged commit, for example `v0.5.0`.
+3. Approve the `npm` environment deployment when the Release workflow reaches the publish job.
+4. Confirm the workflow succeeded and the npm package version and provenance are visible.
+
+The workflow rejects tags whose name differs from `package.json`, and rejects tagged commits that are not contained in `main`.
+
+## Manual dispatch
+
+Use `workflow_dispatch` only to publish an existing version tag explicitly. Run the workflow from `main` and supply the tag in the required `tag` input. The same version, ancestry, validation, environment, and publication checks apply. A workflow can also be rerun after a transient failure without creating or moving a tag.


### PR DESCRIPTION
## Problem

Closes #226.

OpenPI validates `npm pack` in CI, but publishing `@tt-a1i/openpi` to npm currently depends on a maintainer's local machine and local npm authentication.

## Value

Moves npm publication into a repeatable GitHub Actions path, reduces dependence on long-lived local credentials, and lets maintainers use npm trusted publishing with OIDC and provenance.

## Approach

Add `.github/workflows/release.yml` with a release job that runs on manual dispatch and version tags. The job uses GitHub-hosted Ubuntu, Node 24 for npm trusted publishing compatibility, Bun 1.3.14 to match the repo toolchain, and the existing `check` and `test` scripts before publishing.

For tag releases, the workflow verifies that `GITHUB_REF_NAME` matches the `package.json` version, so a tag such as `v0.5.0` must publish package version `0.5.0`.

The workflow targets the `npm` GitHub environment so the repository can add environment protection before publication.

## Validation

- `bun run check` passed.
- `bun run test` passed: 934 node tests and 30 Vitest tests.
- `npm pack --dry-run --ignore-scripts` passed.
- Parsed `.github/workflows/release.yml` as YAML successfully.

`actionlint` was not installed locally, so I did not run it.

## Impact

User-visible behavior: None until maintainers configure npm trusted publishing and trigger a release.

Model-visible context/tools: None.

Runtime/lifecycle: Adds a GitHub Actions release path for npm publication.

Persisted config/data: None.

Compatibility or risk: Publishing requires npm trusted publisher configuration matching repository `tt-a1i/openpi`, workflow filename `release.yml`, and environment `npm`. Node 24 is used only in the release workflow; normal CI still covers the documented Node floor.
