### PR TITLE
fix(file-search): define BinaryDownloadError and consolidate Effect layer provides (#170)

### DIFF
--- a/extensions/file-search/src/binaries.ts
+++ b/extensions/file-search/src/binaries.ts
@@ -20,7 +20,15 @@ import { execFile } from "node:child_process";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
-import { Crypto, Data, Effect, Encoding, FileSystem, Stream } from "effect";
+import {
+  Crypto,
+  Data,
+  Effect,
+  Encoding,
+  FileSystem,
+  Layer,
+  Stream,
+} from "effect";
 import { FetchHttpClient, HttpClient } from "effect/unstable/http";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
@@ -161,6 +169,12 @@ export class InstallError extends Data.TaggedError("InstallError")<{
   readonly cause?: unknown;
 }> {}
 
+export class BinaryDownloadError extends Data.TaggedError(
+  "BinaryDownloadError",
+)<{
+  readonly message: string;
+}> {}
+
 export interface BinaryEnv {
   /** True when the executable runs and supports the flags this tool requires. */
   readonly probe: (command: string, tool: ToolName) => Effect.Effect<boolean>;
@@ -237,9 +251,9 @@ export function readBoundedResponse<E, R>(
   return Effect.gen(function* () {
     const declaredLength = Number(response.headers["content-length"]);
     if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
-      return yield* Effect.fail(
-        new Error(`download exceeds the ${maxBytes}-byte size limit`),
-      );
+      return yield* new BinaryDownloadError({
+        message: `download exceeds the ${maxBytes}-byte size limit`,
+      });
     }
 
     const result = yield* Stream.runFoldEffect(
@@ -249,7 +263,9 @@ export function readBoundedResponse<E, R>(
         const totalBytes = accumulator.totalBytes + chunk.byteLength;
         if (totalBytes > maxBytes) {
           return Effect.fail(
-            new Error(`download exceeds the ${maxBytes}-byte size limit`),
+            new BinaryDownloadError({
+              message: `download exceeds the ${maxBytes}-byte size limit`,
+            }),
           );
         }
         return Effect.sync(() => {
@@ -272,9 +288,9 @@ function downloadAsset(client: HttpClient.HttpClient, initialUrl: URL) {
 
     for (let redirects = 0; redirects <= MAX_DOWNLOAD_REDIRECTS; redirects++) {
       if (url.protocol !== "https:") {
-        return yield* Effect.fail(
-          new Error(`refusing non-HTTPS download URL: ${url.href}`),
-        );
+        return yield* new BinaryDownloadError({
+          message: `refusing non-HTTPS download URL: ${url.href}`,
+        });
       }
 
       const result = yield* Effect.scoped(
@@ -283,31 +299,27 @@ function downloadAsset(client: HttpClient.HttpClient, initialUrl: URL) {
           if ([301, 302, 303, 307, 308].includes(response.status)) {
             const location = response.headers.location;
             if (!location) {
-              return yield* Effect.fail(
-                new Error(`redirect from ${url.href} had no location header`),
-              );
+              return yield* new BinaryDownloadError({
+                message: `redirect from ${url.href} had no location header`,
+              });
             }
             if (redirects === MAX_DOWNLOAD_REDIRECTS) {
-              return yield* Effect.fail(
-                new Error(
-                  `download exceeded ${MAX_DOWNLOAD_REDIRECTS} redirects`,
-                ),
-              );
+              return yield* new BinaryDownloadError({
+                message: `download exceeded ${MAX_DOWNLOAD_REDIRECTS} redirects`,
+              });
             }
             if (!URL.canParse(location, url)) {
-              return yield* Effect.fail(
-                new Error(
-                  `download returned an invalid redirect URL: ${location}`,
-                ),
-              );
+              return yield* new BinaryDownloadError({
+                message: `download returned an invalid redirect URL: ${location}`,
+              });
             }
             return { _tag: "Redirect" as const, url: new URL(location, url) };
           }
 
           if (response.status < 200 || response.status >= 300) {
-            return yield* Effect.fail(
-              new Error(`download failed with HTTP ${response.status}`),
-            );
+            return yield* new BinaryDownloadError({
+              message: `download failed with HTTP ${response.status}`,
+            });
           }
           return {
             _tag: "Complete" as const,
@@ -320,7 +332,9 @@ function downloadAsset(client: HttpClient.HttpClient, initialUrl: URL) {
       url = result.url;
     }
 
-    return yield* Effect.fail(new Error("download redirect handling failed"));
+    return yield* new BinaryDownloadError({
+      message: "download redirect handling failed",
+    });
   });
 }
 
@@ -344,9 +358,9 @@ export const liveBinaryEnv: BinaryEnv = {
   install: (asset, destination) => {
     const install = Effect.gen(function* () {
       if (!URL.canParse(asset.url)) {
-        return yield* Effect.fail(
-          new Error(`invalid download URL: ${asset.url}`),
-        );
+        return yield* new BinaryDownloadError({
+          message: `invalid download URL: ${asset.url}`,
+        });
       }
 
       const url = new URL(asset.url);
@@ -360,11 +374,9 @@ export const liveBinaryEnv: BinaryEnv = {
       const digestBytes = yield* crypto.digest("SHA-256", bytes);
       const digest = Encoding.encodeHex(digestBytes);
       if (digest !== asset.sha256) {
-        return yield* Effect.fail(
-          new Error(
-            `SHA-256 mismatch for ${asset.fileName}: expected ${asset.sha256}, received ${digest}`,
-          ),
-        );
+        return yield* new BinaryDownloadError({
+          message: `SHA-256 mismatch for ${asset.fileName}: expected ${asset.sha256}, received ${digest}`,
+        });
       }
 
       const workDir = yield* fs.makeTempDirectoryScoped({
@@ -384,9 +396,9 @@ export const liveBinaryEnv: BinaryEnv = {
         }),
       ).pipe(Effect.timeout(60_000));
       if (tarExitCode !== ChildProcessSpawner.ExitCode(0)) {
-        return yield* Effect.fail(
-          new Error(`tar failed with exit code ${tarExitCode}`),
-        );
+        return yield* new BinaryDownloadError({
+          message: `tar failed with exit code ${tarExitCode}`,
+        });
       }
 
       const extracted = join(workDir, asset.archiveDir, asset.binaryName);
@@ -401,13 +413,17 @@ export const liveBinaryEnv: BinaryEnv = {
       yield* fs.rename(stagedDestination, destination);
     });
 
-    return install.pipe(
-      Effect.scoped,
-      Effect.provide(NodeServices.layer),
-      Effect.provide(NodeHttpClient.layerFetch),
-      Effect.provideService(FetchHttpClient.RequestInit, {
+    const InstallLayer = Layer.mergeAll(
+      NodeServices.layer,
+      NodeHttpClient.layerFetch,
+      Layer.succeed(FetchHttpClient.RequestInit, {
         redirect: "manual",
       }),
+    );
+
+    return install.pipe(
+      Effect.scoped,
+      Effect.provide(InstallLayer),
       Effect.mapError(
         (cause) =>
           new InstallError({


### PR DESCRIPTION
## Problem

`extensions/file-search/src/binaries.ts` emitted 12 Effect language service diagnostics (11 × `effect(globalErrorInEffectFailure)` / TS377023 and 1 × `effect(multipleEffectProvide)` / TS377033). Using bare `new Error(...)` in Effect failure channels deprived errors of a stable discriminant, while chaining separate `Effect.provide` calls risked fragmented layer construction (Fixes #170).

## Value

Eliminating TS377023 and TS377033 diagnostics improves Effect type safety, provides an explicit tagged error (`BinaryDownloadError`) for failure channel discrimination, and ensures deterministic single-layer dependency wiring without breaking the existing public `InstallError` contract.

## Approach

1. Defined `BinaryDownloadError extends Data.TaggedError("BinaryDownloadError")<{ readonly message: string }>` in `extensions/file-search/src/binaries.ts`.
2. Replaced 11 bare `new Error(...)` instances in failure channels with `new BinaryDownloadError({ message: ... })`, using direct `yield*` in generators.
3. Consolidated the three chained `Effect.provide` / `Effect.provideService` calls into a single composed `Layer` using `Layer.mergeAll` + `Layer.succeed`.
4. Retained the existing `mapError` to convert internal errors to `InstallError`, preserving the public API contract.

## Validation

- `bun run typecheck` - passed (0 errors, TS377023 and TS377033 resolved)
- `bun run check` - passed (format, lint, typecheck)
- `bun run test` - 964 tests passed (934 Node + 30 Vitest), 0 failures
- `git diff --check` - passed

## Impact

- User-visible behavior: None.
- Model-visible context/tools: None.
- Runtime/lifecycle: Single combined layer provide for binary download dependencies.
- Persisted config/data: None.
- Compatibility or risk: None; public `InstallError` and `BinaryEnv.install` API contracts remain unchanged.