### PR TITLE
fix(workflows): bound settled run retention

### DIFF
--- a/extensions/workflows/index.ts
+++ b/extensions/workflows/index.ts
@@ -125,6 +125,7 @@ import {
   countStates,
   createUsageReader,
   emptyUsage,
+  evictOldestSettledRuns,
   formatElapsed,
   formatUsage,
   isWorkflowRunId,
@@ -790,7 +791,10 @@ export default function workflows(pi: ExtensionAPI) {
     new Map(
       [...activeRuns].map(([runId, run]) => [runId, run.details] as const),
     );
+  // This is an ephemeral UI projection. Persistence and result delivery own
+  // the durable history and pending completion independently.
   const settledRuns = new Map<string, WorkflowDetails>();
+  let settledRunsEvicted = 0;
   /** Keep current-session settled records live for their ephemeral UI renderer. */
   const dashboardDetails = () =>
     new Map<string, WorkflowDetails>([...settledRuns, ...activeDetails()]);
@@ -942,6 +946,7 @@ export default function workflows(pi: ExtensionAPI) {
 
   const recordSettledRun = (details: WorkflowDetails) => {
     settledRuns.set(details.runId, details);
+    settledRunsEvicted += evictOldestSettledRuns(settledRuns).length;
     if (details.status === "completed") completedRuns += 1;
     else failedRuns += 1;
   };
@@ -1011,6 +1016,7 @@ export default function workflows(pi: ExtensionAPI) {
     turnStartedAt = 0;
     completedRuns = 0;
     failedRuns = 0;
+    settledRunsEvicted = 0;
     settledRuns.clear();
     installWorkflowNavigation(ctx);
     updateIndicator();
@@ -2427,9 +2433,13 @@ export default function workflows(pi: ExtensionAPI) {
           content: [
             { type: "text", text: buildWorkflowStatusSummary(details, runDir) },
           ],
-          details: { runs: [summarize(details)] },
+          details: { runs: [summarize(details)], settledRunsEvicted },
         });
       }
+      const retentionNote =
+        settledRunsEvicted > 0
+          ? `\n${settledRunsEvicted} settled workflow detail${settledRunsEvicted === 1 ? "" : "s"} evicted from memory; persisted artifacts retained.`
+          : "";
       const runs = [
         ...[...activeRuns.values()].map((run) => run.details),
         ...settledRuns.values(),
@@ -2437,9 +2447,12 @@ export default function workflows(pi: ExtensionAPI) {
       if (runs.length === 0) {
         return Promise.resolve({
           content: [
-            { type: "text", text: "No active or recently finished workflows." },
+            {
+              type: "text",
+              text: `No active or recently finished workflows.${retentionNote}`,
+            },
           ],
-          details: { runs: [] },
+          details: { runs: [], settledRunsEvicted },
         });
       }
       const lines = runs.map((d) => {
@@ -2447,8 +2460,8 @@ export default function workflows(pi: ExtensionAPI) {
         return `${d.runId}${d.name ? ` "${d.name}"` : ""} — ${statusWord(d.status)} · ${done + failed}/${d.agents.length} agents${failed ? `, ${failed} failed` : ""}${uncertain ? `, ${uncertain} uncertain` : ""}`;
       });
       return Promise.resolve({
-        content: [{ type: "text", text: lines.join("\n") }],
-        details: { runs: runs.map(summarize) },
+        content: [{ type: "text", text: lines.join("\n") + retentionNote }],
+        details: { runs: runs.map(summarize), settledRunsEvicted },
       });
     },
   });

--- a/extensions/workflows/model.ts
+++ b/extensions/workflows/model.ts
@@ -174,6 +174,35 @@ export interface WorkflowDetails {
   error?: string;
 }
 
+/**
+ * Bound only the current-session terminal projection. Persisted workflow
+ * records and side artifacts remain the canonical history.
+ */
+export const MAX_SETTLED_RUNS = 32;
+
+/** Evict the oldest terminal projections without touching active-run state. */
+export function evictOldestSettledRuns(
+  settledRuns: Map<string, WorkflowDetails>,
+  maxRuns = MAX_SETTLED_RUNS,
+): string[] {
+  const limit = Number.isFinite(maxRuns)
+    ? Math.max(0, Math.floor(maxRuns))
+    : MAX_SETTLED_RUNS;
+  const evicted: string[] = [];
+  while (settledRuns.size > limit) {
+    let oldest: { runId: string; at: number } | undefined;
+    for (const [runId, details] of settledRuns) {
+      if (details.status === "running") continue;
+      const at = details.finishedAt ?? details.startedAt;
+      if (!oldest || at < oldest.at) oldest = { runId, at };
+    }
+    if (!oldest) break;
+    settledRuns.delete(oldest.runId);
+    evicted.push(oldest.runId);
+  }
+  return evicted;
+}
+
 export function workflowGraphRecords(
   agents: readonly AgentRecord[],
 ): WorkflowGraphRecord[] {

--- a/tests/extensions/workflows/execute.e2e.test.ts
+++ b/tests/extensions/workflows/execute.e2e.test.ts
@@ -29,7 +29,10 @@ import type {
 import { SPINNER_INTERVAL_MS } from "../../../extensions/shared/spinner.ts";
 import { reclaimWorktree } from "../../../extensions/shared/worktree.ts";
 import { persistWorkflowJson } from "../../../extensions/workflows/artifacts.ts";
-import type { WorkflowDetails } from "../../../extensions/workflows/model.ts";
+import {
+  MAX_SETTLED_RUNS,
+  type WorkflowDetails,
+} from "../../../extensions/workflows/model.ts";
 import type { WorkflowAgentSessionFactory } from "../../../extensions/workflows/runner.ts";
 
 const agentDir = mkdtempSync(join(tmpdir(), "my-pi-setup-wf-e2e-"));
@@ -757,6 +760,52 @@ test("a failing script reports the error and records the run as failed", async (
   const persisted = readWorkflowJson(failed.runId);
   assert.equal(persisted.status, "failed");
   assert.match(String(persisted.error), /kaboom/);
+});
+
+test("settled retention is bounded while status and artifacts remain observable", async () => {
+  const before = (await status.execute("e2e-retention-before", {})) as {
+    details: { settledRunsEvicted: number };
+  };
+  const runIds: string[] = [];
+
+  for (let index = 0; index < MAX_SETTLED_RUNS + 1; index++) {
+    const result = (await workflow.execute(
+      `e2e-retention-${index}`,
+      {
+        script: `export const meta = { name: "retention-${index}" };\nreturn ${index};`,
+        wait: true,
+      },
+      undefined,
+      undefined,
+      ctx,
+    )) as { details: { runId?: unknown } };
+    assert.equal(typeof result.details.runId, "string");
+    runIds.push(result.details.runId as string);
+  }
+
+  const after = (await status.execute("e2e-retention-after", {})) as {
+    content: Array<{ text?: string }>;
+    details: {
+      runs: Array<{ runId: unknown }>;
+      settledRunsEvicted: number;
+    };
+  };
+  assert.ok(after.details.runs.length <= MAX_SETTLED_RUNS);
+  assert.ok(after.details.settledRunsEvicted >= before.details.settledRunsEvicted + 1);
+  assert.match(
+    after.content[0]?.text ?? "",
+    /settled workflow details? evicted from memory; persisted artifacts retained\./,
+  );
+
+  const oldestRunId = runIds[0]!;
+  assert.equal(existsSync(join(runDirFor(oldestRunId), "workflow.json")), true);
+  const lookup = (await status.execute("e2e-retention-lookup", {
+    runId: oldestRunId,
+  })) as {
+    details: { runs: Array<{ runId: unknown; status: unknown }> };
+  };
+  assert.equal(lookup.details.runs[0]?.runId, oldestRunId);
+  assert.equal(lookup.details.runs[0]?.status, "completed");
 });
 
 test("agent calls run through the injected session factory and resume replays the journal", async () => {

--- a/tests/extensions/workflows/execute.e2e.test.ts
+++ b/tests/extensions/workflows/execute.e2e.test.ts
@@ -791,7 +791,9 @@ test("settled retention is bounded while status and artifacts remain observable"
     };
   };
   assert.ok(after.details.runs.length <= MAX_SETTLED_RUNS);
-  assert.ok(after.details.settledRunsEvicted >= before.details.settledRunsEvicted + 1);
+  assert.ok(
+    after.details.settledRunsEvicted >= before.details.settledRunsEvicted + 1,
+  );
   assert.match(
     after.content[0]?.text ?? "",
     /settled workflow details? evicted from memory; persisted artifacts retained\./,

--- a/tests/extensions/workflows/model.test.ts
+++ b/tests/extensions/workflows/model.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  evictOldestSettledRuns,
+  MAX_SETTLED_RUNS,
+  type WorkflowDetails,
+} from "../../../extensions/workflows/model.ts";
+
+function details(
+  runId: string,
+  startedAt: number,
+  finishedAt: number,
+  status: WorkflowDetails["status"] = "completed",
+): WorkflowDetails {
+  return {
+    runId,
+    background: true,
+    status,
+    startedAt,
+    finishedAt,
+    phases: [],
+    agents: [],
+  };
+}
+
+test("settled retention evicts the oldest terminal projection only", () => {
+  const active = new Map([
+    ["wf_active", details("wf_active", 1, 2, "running")],
+  ]);
+  const settled = new Map([
+    ["wf_active", active.get("wf_active")!],
+    ["wf_new", details("wf_new", 10, 30)],
+    ["wf_old", details("wf_old", 20, 20)],
+    ["wf_middle", details("wf_middle", 30, 25)],
+  ]);
+
+  const evicted = evictOldestSettledRuns(settled, 3);
+
+  assert.deepEqual(evicted, ["wf_old"]);
+  assert.deepEqual([...settled.keys()], ["wf_active", "wf_new", "wf_middle"]);
+  assert.deepEqual([...active.keys()], ["wf_active"]);
+  assert.equal(active.get("wf_active")?.status, "running");
+});
+
+test("settled retention enforces its default hard count bound", () => {
+  const settled = new Map<string, WorkflowDetails>();
+  for (let index = 0; index < MAX_SETTLED_RUNS + 3; index++) {
+    const runId = `wf_${index.toString(16).padStart(2, "0")}`;
+    settled.set(runId, details(runId, index, index));
+  }
+
+  const evicted = evictOldestSettledRuns(settled);
+
+  assert.equal(settled.size, MAX_SETTLED_RUNS);
+  assert.equal(evicted.length, 3);
+  assert.deepEqual(evicted, ["wf_00", "wf_01", "wf_02"]);
+});


### PR DESCRIPTION
## Problem

Issue #178 identifies unbounded growth of settled workflow details in the current-session memory projection, even though completed run artifacts are already persisted separately.

## Value

A long-running session now has a hard count bound for its ephemeral settled-run projection, while operators can see how many entries were evicted and can still query persisted runs by ID.

## Approach

- Keep at most 32 settled workflow projections in memory.
- Evict the oldest terminal projection first and never evict a running run.
- Keep persistence and result delivery independent; eviction does not delete workflow.json or side artifacts.
- Report the cumulative evicted count in workflow_status output and structured details.
- Add model-level and execute-level tests covering the bound, oldest-first eviction, active-run preservation, artifact retention, and lookup after eviction.

## Validation

- bun run lint — passed.
- bun run typecheck — passed; the repository still reports its pre-existing file-search Effect warnings on this base branch.
- Settled-retention focused tests — 3/3 passed.
- git diff --check — passed.
- The broader workflow e2e file had 10/12 passing tests on Windows; the two failures are existing injected-session/replay fixture failures outside this retention change.

## Impact

This PR intentionally implements the count-bound portion of #178. It does not add byte/age or disk cleanup policy. Persisted artifacts, pending completion delivery, resume data, and active runs remain outside the eviction path.

Related to #178