### PR TITLE
fix(context-pivot): clarify native no-history failures

### DIFF
--- a/extensions/context-pivot/index.ts
+++ b/extensions/context-pivot/index.ts
@@ -186,8 +186,11 @@ export default function contextPivot(pi: ExtensionAPI) {
           onError: (error) => {
             if (pivotGeneration === generation) pending = undefined;
             clear();
+            const message = formatContextPivotError(error);
             if (ctx.hasUI) {
-              ctx.ui.notify(formatContextPivotError(error), "error");
+              ctx.ui.notify(message, "error");
+            } else {
+              console.error(message);
             }
           },
         });

--- a/extensions/context-pivot/index.ts
+++ b/extensions/context-pivot/index.ts
@@ -11,6 +11,9 @@ import {
 
 export const MIN_CONTEXT_PIVOT_TOKENS = 30_000;
 const STATUS_KEY = "context-pivot";
+const NOTHING_TO_COMPACT_ERROR = "Nothing to compact (session too small)";
+const NO_DISCARDABLE_HISTORY_MESSAGE =
+  "Context pivot could not run: this session has no discardable history to compact. Continue in the current session, or use /sessions to choose another session; to begin cleanly, start a new Session in Pi.";
 
 interface PendingPivot {
   brief: string;
@@ -55,6 +58,13 @@ export function buildPivotSummary(brief: string): string {
     "",
     brief.trim(),
   ].join("\n");
+}
+
+function formatContextPivotError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message === NOTHING_TO_COMPACT_ERROR
+    ? NO_DISCARDABLE_HISTORY_MESSAGE
+    : `Context pivot failed: ${message}`;
 }
 
 function impossibleKeptId(entries: readonly SessionEntry[]) {
@@ -177,10 +187,7 @@ export default function contextPivot(pi: ExtensionAPI) {
             if (pivotGeneration === generation) pending = undefined;
             clear();
             if (ctx.hasUI) {
-              ctx.ui.notify(
-                `Context pivot failed: ${error instanceof Error ? error.message : String(error)}`,
-                "error",
-              );
+              ctx.ui.notify(formatContextPivotError(error), "error");
             }
           },
         });

--- a/tests/extensions/context-pivot/index.test.ts
+++ b/tests/extensions/context-pivot/index.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type {
+  CompactOptions,
   ExtensionAPI,
   ExtensionContext,
+  ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import contextPivot, {
   buildPivotSummary,
@@ -76,4 +78,84 @@ test("builds a clean pivot summary without notebook or handoff coupling", () => 
   assert.doesNotMatch(summary, /notebook/i);
   assert.doesNotMatch(summary, /handoff/i);
   assert.equal(MIN_CONTEXT_PIVOT_TOKENS, 30_000);
+});
+
+test("translates native no-history failures and clears the pivot state", async () => {
+  let tool: ToolDefinition | undefined;
+  let compactOptions: CompactOptions | undefined;
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  const notifications: Array<{ message: string; level: string }> = [];
+  const statuses: Array<string | undefined> = [];
+  const sentMessages: string[] = [];
+  const pi = {
+    registerTool(candidate: ToolDefinition) {
+      tool = candidate;
+    },
+    getActiveTools: () => [],
+    setActiveTools() {},
+    on(event: string, handler: (...args: unknown[]) => unknown) {
+      handlers.set(event, handler);
+    },
+    registerCommand() {},
+    sendUserMessage(message: string) {
+      sentMessages.push(message);
+    },
+  } as unknown as ExtensionAPI;
+
+  contextPivot(pi);
+  assert.ok(tool);
+
+  const ctx = {
+    hasUI: true,
+    getContextUsage: () => ({
+      tokens: MIN_CONTEXT_PIVOT_TOKENS,
+      contextWindow: 200_000,
+      percent: 15,
+    }),
+    compact(options: CompactOptions) {
+      compactOptions = options;
+    },
+    ui: {
+      notify(message: string, level: string) {
+        notifications.push({ message, level });
+      },
+      setStatus(_key: string, value: string | undefined) {
+        statuses.push(value);
+      },
+      theme: { fg: (_color: string, text: string) => text },
+    },
+  } as unknown as ExtensionContext;
+
+  await tool.execute(
+    "context-pivot-test",
+    { brief: "Continue with the next phase." },
+    undefined,
+    undefined,
+    ctx,
+  );
+  assert.ok(compactOptions?.onError);
+  compactOptions.onError(new Error("Nothing to compact (session too small)"));
+
+  assert.equal(
+    notifications.at(-1)?.message,
+    "Context pivot could not run: this session has no discardable history to compact. Continue in the current session, or use /sessions to choose another session; to begin cleanly, start a new Session in Pi.",
+  );
+  assert.equal(notifications.at(-1)?.level, "error");
+  assert.equal(statuses.at(-1), undefined);
+  assert.deepEqual(sentMessages, []);
+  assert.equal(handlers.get("session_before_compact")?.({}), undefined);
+
+  await tool.execute(
+    "context-pivot-test-2",
+    { brief: "Continue with the next phase." },
+    undefined,
+    undefined,
+    ctx,
+  );
+  assert.ok(compactOptions?.onError);
+  compactOptions.onError(new Error("provider unavailable"));
+  assert.equal(
+    notifications.at(-1)?.message,
+    "Context pivot failed: provider unavailable",
+  );
 });

--- a/tests/extensions/context-pivot/index.test.ts
+++ b/tests/extensions/context-pivot/index.test.ts
@@ -159,3 +159,53 @@ test("translates native no-history failures and clears the pivot state", async (
     "Context pivot failed: provider unavailable",
   );
 });
+
+test("reports native no-history failures without a UI", async () => {
+  let tool: ToolDefinition | undefined;
+  let compactOptions: CompactOptions | undefined;
+  const pi = {
+    registerTool(candidate: ToolDefinition) {
+      tool = candidate;
+    },
+    getActiveTools: () => [],
+    setActiveTools() {},
+    on() {},
+    registerCommand() {},
+  } as unknown as ExtensionAPI;
+
+  contextPivot(pi);
+  assert.ok(tool);
+
+  const errors: string[] = [];
+  const originalError = console.error;
+  console.error = (message: unknown) => errors.push(String(message));
+  try {
+    const ctx = {
+      hasUI: false,
+      getContextUsage: () => ({
+        tokens: MIN_CONTEXT_PIVOT_TOKENS,
+        contextWindow: 200_000,
+        percent: 15,
+      }),
+      compact(options: CompactOptions) {
+        compactOptions = options;
+      },
+    } as unknown as ExtensionContext;
+
+    await tool.execute(
+      "context-pivot-headless-test",
+      { brief: "Continue with the next phase." },
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.ok(compactOptions?.onError);
+    compactOptions.onError(new Error("Nothing to compact (session too small)"));
+  } finally {
+    console.error = originalError;
+  }
+
+  assert.deepEqual(errors, [
+    "Context pivot could not run: this session has no discardable history to compact. Continue in the current session, or use /sessions to choose another session; to begin cleanly, start a new Session in Pi.",
+  ]);
+});


### PR DESCRIPTION
## Problem

`context_pivot` can pass its minimum context threshold while native compaction still rejects the session with `Nothing to compact (session too small)`. The current error is technically accurate but does not tell the user what to do next.

## Value

Turn this native no-history failure into a clear, actionable message while preserving the existing behavior and messages for all other failures.

## Approach

- Translate only the exact native `Nothing to compact (session too small)` error.
- Tell the user to continue in the current session or use `/sessions` to choose another session or start a new one.
- Keep cleanup of pending pivot state and compaction state unchanged.
- Add a focused regression test covering the translated error and the unchanged generic-error path.

Related to #24

## Validation

- `node --test --experimental-strip-types tests/extensions/context-pivot/index.test.ts` — 4/4 passed
- `bun run lint` — passed
- `bun run typecheck` — passed; existing file-search Effect warnings remain outside this change
- `git diff upstream/main...HEAD --check` — passed

## Impact

No persisted data, native compaction semantics, or unrelated extension behavior changes.

## Compatibility

Existing successful pivots and other errors retain their current behavior.