### PR TITLE
fix(background-terminals): sanitize model-facing output

### DIFF
--- a/extensions/background-terminals/src/prompt.ts
+++ b/extensions/background-terminals/src/prompt.ts
@@ -13,6 +13,7 @@ import {
   type TerminalSnapshot,
 } from "./domain.ts";
 import { MAX_RUNNING, type KillResult } from "./manager.ts";
+import { sanitizeTerminalText } from "../../shared/terminal-text.ts";
 
 /** bg_status stdout tail. */
 export const STATUS_STDOUT_MAX = 16 * 1024;
@@ -139,7 +140,7 @@ function outputSection(
   maxLines: number,
 ) {
   if (view.totalBytes === 0) return `${label}: (empty)`;
-  const truncation = truncateTail(view.text, {
+  const truncation = truncateTail(sanitizeTerminalText(view.text), {
     maxBytes: Math.min(maxBytes, DEFAULT_MAX_BYTES),
     maxLines: Math.min(maxLines, DEFAULT_MAX_LINES),
   });

--- a/tests/extensions/background-terminals/prompt.test.ts
+++ b/tests/extensions/background-terminals/prompt.test.ts
@@ -161,3 +161,25 @@ test("completion output is a shorter tail than the detailed status view", () => 
   assert.match(completion, /stdout truncated/);
   assert.match(status, /line-1\n/);
 });
+
+test("model-facing output sanitizes terminal text before tail truncation", () => {
+  const rawOutput =
+    "\u001b[31mreadable-start\u001b[0m" +
+    `\u001b]8;;https://example.com;${"osc-payload-".repeat(1_600)}\u0007` +
+    "\u001b]8;;\u0007\u202Espoof\u0000\u0001readable-end";
+  const terminal = snap({
+    stdout: view({
+      text: rawOutput,
+      totalBytes: Buffer.byteLength(rawOutput),
+    }),
+  });
+
+  for (const rendered of [
+    buildStatusResult(terminal),
+    buildTerminalResultMessage(terminal),
+  ]) {
+    assert.match(rendered, /readable-startspoof.*readable-end/);
+    assert.doesNotMatch(rendered, /osc-payload-/);
+    assert.doesNotMatch(rendered, /[\u001b\u202e\u0000\u0001]/u);
+  }
+});


### PR DESCRIPTION
## Problem

The model-facing `bg_status` and background-terminal completion messages passed retained stdout/stderr directly to `truncateTail`. The TUI and watch paths already sanitize terminal text, but these prompt paths could expose ANSI/OSC, bidirectional, and other control characters. Truncating first could also leave an unmatched control sequence fragment in the model-visible tail.

## Value

Keep model-facing terminal output readable and safe by removing terminal control text before applying the existing output-size and line limits.

## Approach

- Reuse the existing shared `sanitizeTerminalText` helper.
- Sanitize once in the shared output-section path used by both `bg_status` and completion follow-ups.
- Keep raw captured output and spill files unchanged for evidence and `/ps` viewing.
- Add regression coverage for ANSI, OSC, bidi, and control characters, including a payload larger than the display cap to prove sanitization happens before truncation.

Related to #72

## Validation

- `node --test --experimental-strip-types tests/extensions/background-terminals/prompt.test.ts` — 7/7 passed
- `bun run lint` — passed
- `bun run typecheck` — passed; existing file-search Effect warnings remain outside this change
- `git diff upstream/main...HEAD --check` — passed

## Impact

Only model-facing stdout/stderr previews change. Raw logs, spill files, TUI rendering, process lifecycle, session disk budgeting, and Windows termination behavior are unchanged.