### PR TITLE
fix(workflows): persist late worktree cleanup provenance

### DIFF
--- a/extensions/workflows/index.ts
+++ b/extensions/workflows/index.ts
@@ -665,6 +665,20 @@ export interface ActiveWorkflowRunLifecycle {
   forceSettle(error: string): void;
 }
 
+interface WorkflowLifecycleTestHooks {
+  readonly reclaimWorktree?: typeof reclaimWorktree;
+  readonly onRunStarted?: (run: ActiveWorkflowRunLifecycle) => void;
+}
+
+let workflowLifecycleTestHooks: WorkflowLifecycleTestHooks | undefined;
+
+/** Test-only control for deterministic lifecycle race coverage. */
+export function __setWorkflowTestLifecycleHooks(
+  hooks: WorkflowLifecycleTestHooks | undefined,
+) {
+  workflowLifecycleTestHooks = hooks;
+}
+
 /** Abort every live child and bound the whole session-shutdown barrier once. */
 export async function shutdownActiveWorkflowRuns(
   runs: readonly ActiveWorkflowRunLifecycle[],
@@ -2040,7 +2054,10 @@ export default function workflows(pi: ExtensionAPI) {
                     detached: false,
                   };
                 } else {
-                  cleanup = await reclaimWorktree(ctx.cwd, worktree).catch(
+                  const reclaimer =
+                    workflowLifecycleTestHooks?.reclaimWorktree ??
+                    reclaimWorktree;
+                  cleanup = await reclaimer(ctx.cwd, worktree).catch(
                     (error): WorktreeCleanup => ({
                       removed: false,
                       branchDeleted: false,
@@ -2062,13 +2079,14 @@ export default function workflows(pi: ExtensionAPI) {
                     };
                   }
                 }
-                if (!runSettled) {
-                  record.worktreeCleanup = cleanup;
-                  if (cleanup.branchDeleted) delete record.worktreeBranch;
-                  else record.worktreeBranch = cleanup.branch;
-                  if (!cleanup.removed) record.worktreePath = worktree.path;
-                  emit();
-                }
+                record.worktreeCleanup = cleanup;
+                if (cleanup.branchDeleted) delete record.worktreeBranch;
+                else record.worktreeBranch = cleanup.branch;
+                if (!cleanup.removed) record.worktreePath = worktree.path;
+                // Forced settlement fixes the execution verdict, but cleanup
+                // provenance discovered afterward still belongs in the run.
+                if (runSettled) persistence.checkpoint({ immediate: true });
+                else emit();
               }
             }
           }, invocationSignal)
@@ -2140,6 +2158,7 @@ export default function workflows(pi: ExtensionAPI) {
       activeRuns.set(runId, activeRun);
       const completion = runScript();
       activeRun.completion = completion;
+      workflowLifecycleTestHooks?.onRunStarted?.(activeRun);
       if (ctx.hasUI) lastContext = ctx;
       updateIndicator();
 

--- a/extensions/workflows/index.ts
+++ b/extensions/workflows/index.ts
@@ -666,6 +666,7 @@ export interface ActiveWorkflowRunLifecycle {
 }
 
 interface WorkflowLifecycleTestHooks {
+  readonly persistWorkflow?: typeof persistWorkflowJson;
   readonly reclaimWorktree?: typeof reclaimWorktree;
   readonly onRunStarted?: (run: ActiveWorkflowRunLifecycle) => void;
 }
@@ -1227,6 +1228,9 @@ export default function workflows(pi: ExtensionAPI) {
       persistWorkflowJson(runDir, details);
       const persistence = createWorkflowPersistence(runDir, details, {
         journal: () => journalEntries,
+        ...(workflowLifecycleTestHooks?.persistWorkflow
+          ? { persist: workflowLifecycleTestHooks.persistWorkflow }
+          : {}),
       });
 
       // A caller wait never owns the run. All runs survive an interrupted
@@ -2085,8 +2089,15 @@ export default function workflows(pi: ExtensionAPI) {
                 if (!cleanup.removed) record.worktreePath = worktree.path;
                 // Forced settlement fixes the execution verdict, but cleanup
                 // provenance discovered afterward still belongs in the run.
-                if (runSettled) persistence.checkpoint({ immediate: true });
-                else emit();
+                // No later final flush remains, so failures must be observable.
+                if (runSettled) {
+                  try {
+                    persistence.flush();
+                  } catch (error) {
+                    appendArtifactPersistenceFailure(details, error);
+                    persistTerminalRecovery();
+                  }
+                } else emit();
               }
             }
           }, invocationSignal)

--- a/tests/extensions/workflows/execute.e2e.test.ts
+++ b/tests/extensions/workflows/execute.e2e.test.ts
@@ -28,6 +28,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import { SPINNER_INTERVAL_MS } from "../../../extensions/shared/spinner.ts";
 import { reclaimWorktree } from "../../../extensions/shared/worktree.ts";
+import { persistWorkflowJson } from "../../../extensions/workflows/artifacts.ts";
 import type { WorkflowDetails } from "../../../extensions/workflows/model.ts";
 import type { WorkflowAgentSessionFactory } from "../../../extensions/workflows/runner.ts";
 
@@ -996,6 +997,11 @@ test("an oversized legacy replay is rejected without a success record", async ()
 });
 
 test("forced settlement persists worktree cleanup that finishes later", async () => {
+  modelIdle = true;
+  for (const handler of handlers.get("agent_settled") ?? []) {
+    await handler({}, ctx);
+  }
+  sentMessages.length = 0;
   let activeRun:
     | Parameters<typeof shutdownActiveWorkflowRuns>[0][number]
     | undefined;
@@ -1008,11 +1014,23 @@ test("forced settlement persists worktree cleanup that finishes later", async ()
     releaseCleanup = resolve;
   });
   let actualCleanup: Awaited<ReturnType<typeof reclaimWorktree>> | undefined;
+  let latePersistenceFailures = 0;
 
   __setWorkflowTestAgentSessionFactory(async () => ({
     session: fakeAgentSession("isolated agent output"),
   }));
   __setWorkflowTestLifecycleHooks({
+    persistWorkflow(runDir, details, journal) {
+      if (
+        latePersistenceFailures === 0 &&
+        details.status === "failed" &&
+        details.agents.some((agent) => agent.worktreeCleanup !== undefined)
+      ) {
+        latePersistenceFailures++;
+        throw new Error("injected late cleanup persistence failure");
+      }
+      persistWorkflowJson(runDir, details, journal);
+    },
     onRunStarted(run) {
       activeRun = run;
     },
@@ -1051,8 +1069,26 @@ test("forced settlement persists worktree cleanup that finishes later", async ()
     releaseCleanup();
     await activeRun.completion;
     assert.ok(actualCleanup);
+    assert.equal(latePersistenceFailures, 1);
+
+    const deliveriesForRun = () =>
+      sentMessages.filter((sent) =>
+        String(sent.message.content).includes(
+          `(${String(launch.details.runId)})`,
+        ),
+      );
+    await waitFor(
+      () => deliveriesForRun().length === 1,
+      "forced settlement completion delivery",
+    );
 
     const persisted = readWorkflowJson(launch.details.runId);
+    assert.equal(persisted.status, "failed");
+    assert.match(String(persisted.error), /Session shutdown deadline exceeded/);
+    assert.match(
+      String(persisted.error),
+      /Artifact persistence failed: injected late cleanup persistence failure/,
+    );
     const agent = (persisted.agents as Array<Record<string, unknown>>)[0];
     assert.deepEqual(agent?.worktreeCleanup, actualCleanup);
     assert.equal(
@@ -1061,6 +1097,28 @@ test("forced settlement persists worktree cleanup that finishes later", async ()
     );
     if (actualCleanup.removed) assert.equal(agent?.worktreePath, undefined);
     assert.equal(typeof agent?.worktreeHandoffArtifact, "string");
+    const delivery = persisted.delivery as Record<string, unknown>;
+    assert.equal(
+      delivery.id,
+      `workflow:${String(launch.details.runId)}:terminal`,
+    );
+    assert.equal(delivery.state, "delivered");
+    assert.equal(delivery.attempts, 1);
+    assert.equal(typeof delivery.updatedAt, "number");
+    assert.equal(typeof delivery.deliveredAt, "number");
+
+    const delivered = deliveriesForRun()[0];
+    assert.ok(delivered);
+    assert.match(String(delivered.message.content), /failed/);
+    assert.match(
+      String(delivered.message.content),
+      /Session shutdown deadline exceeded/,
+    );
+
+    for (const handler of handlers.get("agent_settled") ?? []) {
+      await handler({}, ctx);
+    }
+    assert.equal(deliveriesForRun().length, 1);
   } finally {
     releaseCleanup();
     if (activeRun?.completion) await activeRun.completion.catch(() => {});

--- a/tests/extensions/workflows/execute.e2e.test.ts
+++ b/tests/extensions/workflows/execute.e2e.test.ts
@@ -27,6 +27,7 @@ import type {
   ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import { SPINNER_INTERVAL_MS } from "../../../extensions/shared/spinner.ts";
+import { reclaimWorktree } from "../../../extensions/shared/worktree.ts";
 import type { WorkflowDetails } from "../../../extensions/workflows/model.ts";
 import type { WorkflowAgentSessionFactory } from "../../../extensions/workflows/runner.ts";
 
@@ -50,8 +51,12 @@ writeFileSync(join(repoDir, "fixture.txt"), "fixture\n");
 git(["add", "."]);
 git(["commit", "-q", "-m", "fixture"]);
 
-const { default: workflows, __setWorkflowTestAgentSessionFactory } =
-  await import("../../../extensions/workflows/index.ts");
+const {
+  default: workflows,
+  __setWorkflowTestAgentSessionFactory,
+  __setWorkflowTestLifecycleHooks,
+  shutdownActiveWorkflowRuns,
+} = await import("../../../extensions/workflows/index.ts");
 
 type CapturedTool = {
   name: string;
@@ -986,6 +991,80 @@ test("an oversized legacy replay is rejected without a success record", async ()
     );
     assert.equal(existsSync(join(resumedDir, "journal.json")), false);
   } finally {
+    __setWorkflowTestAgentSessionFactory(undefined);
+  }
+});
+
+test("forced settlement persists worktree cleanup that finishes later", async () => {
+  let activeRun:
+    | Parameters<typeof shutdownActiveWorkflowRuns>[0][number]
+    | undefined;
+  let markCleanupStarted = () => {};
+  let releaseCleanup = () => {};
+  const cleanupStarted = new Promise<void>((resolve) => {
+    markCleanupStarted = resolve;
+  });
+  const cleanupGate = new Promise<void>((resolve) => {
+    releaseCleanup = resolve;
+  });
+  let actualCleanup: Awaited<ReturnType<typeof reclaimWorktree>> | undefined;
+
+  __setWorkflowTestAgentSessionFactory(async () => ({
+    session: fakeAgentSession("isolated agent output"),
+  }));
+  __setWorkflowTestLifecycleHooks({
+    onRunStarted(run) {
+      activeRun = run;
+    },
+    async reclaimWorktree(repoCwd, worktree) {
+      markCleanupStarted();
+      await cleanupGate;
+      actualCleanup = await reclaimWorktree(repoCwd, worktree);
+      return actualCleanup;
+    },
+  });
+
+  try {
+    const launch = (await workflow.execute(
+      "e2e-forced-worktree-cleanup",
+      {
+        script:
+          'export const meta = { name: "forced-worktree-cleanup" };\n' +
+          'await agent("finish in isolation", { agent_type: "reviewer", isolation: "worktree" });\n' +
+          "return true;",
+        background: true,
+      },
+      undefined,
+      undefined,
+      ctx,
+    )) as { details: { runId?: unknown } };
+
+    await cleanupStarted;
+    assert.ok(activeRun);
+    assert.equal(await shutdownActiveWorkflowRuns([activeRun], 10), false);
+
+    const forced = readWorkflowJson(launch.details.runId);
+    assert.equal(forced.status, "failed");
+    const forcedAgent = (forced.agents as Array<Record<string, unknown>>)[0];
+    assert.equal(forcedAgent?.worktreeCleanup, undefined);
+
+    releaseCleanup();
+    await activeRun.completion;
+    assert.ok(actualCleanup);
+
+    const persisted = readWorkflowJson(launch.details.runId);
+    const agent = (persisted.agents as Array<Record<string, unknown>>)[0];
+    assert.deepEqual(agent?.worktreeCleanup, actualCleanup);
+    assert.equal(
+      agent?.worktreeBranch,
+      actualCleanup.branchDeleted ? undefined : actualCleanup.branch,
+    );
+    if (actualCleanup.removed) assert.equal(agent?.worktreePath, undefined);
+    assert.equal(typeof agent?.worktreeHandoffArtifact, "string");
+  } finally {
+    releaseCleanup();
+    if (activeRun?.completion) await activeRun.completion.catch(() => {});
+    __setWorkflowTestLifecycleHooks(undefined);
     __setWorkflowTestAgentSessionFactory(undefined);
   }
 });


### PR DESCRIPTION
## Problem

During forced workflow settlement, an isolated agent may still be awaiting asynchronous worktree reclamation. The existing `runSettled` guard then skips persisting the final cleanup metadata, which can leave stale branch information or omit the path of a preserved checkout.

Fixes #114.

## Value

Persisting the final cleanup evidence keeps workflow provenance accurate and makes manual recovery information reliable after shutdown timeouts.

## Approach

- Persist worktree cleanup, branch, and checkout-path metadata independently of the workflow's settled state.
- Use an immediate checkpoint when cleanup finishes after forced settlement.
- Preserve the existing terminal verdict and result-delivery behavior.
- Add a deterministic regression test that pauses reclamation while forced settlement occurs.

## Validation

- `node --test --experimental-strip-types --test-name-pattern="forced settlement persists worktree cleanup that finishes later" tests/extensions/workflows/execute.e2e.test.ts` — passed.
- Relevant controller and worktree-handoff tests — 8/8 passed.
- `bun run typecheck` — completed successfully, with existing Effect diagnostics in `extensions/file-search/src/binaries.ts`.
- Full Windows validation still encounters pre-existing platform-specific failures: the complete execute E2E file has 8 passing and 2 existing replay/path failures; `bun run check` encounters existing CRLF formatting differences; `bun run test` was interrupted after an existing git-info test hung.

## Impact

- User-visible behavior: none.
- Model-visible context or tools: none.
- Runtime/lifecycle: late worktree cleanup provenance is checkpointed after forced settlement.
- Persisted data: `workflow.json` now records the final cleanup outcome accurately.
- Compatibility/risk: low; terminal status and cleanup behavior are unchanged.