### PR TITLE
fix(workflows): honor acceptance verdicts during replay

### DIFF
--- a/extensions/workflows/artifacts.ts
+++ b/extensions/workflows/artifacts.ts
@@ -127,10 +127,7 @@ export function persistWorkflowAgentResult(
   index: number,
   result: { output: string; structured?: unknown },
 ) {
-  const artifact = path.join(
-    "agent-results",
-    `agent-${String(index).padStart(4, "0")}.json`,
-  );
+  const artifact = `agent-results/agent-${String(index).padStart(4, "0")}.json`;
   const encoded = encodeCompleteJson(
     {
       output: result.output,

--- a/extensions/workflows/index.ts
+++ b/extensions/workflows/index.ts
@@ -78,7 +78,6 @@ import {
   acceptanceInstruction,
   acceptanceSchema,
   applyAcceptance,
-  evaluateAcceptance,
   parseAcceptanceContract,
 } from "./acceptance.ts";
 import {
@@ -1700,11 +1699,33 @@ export default function workflows(pi: ExtensionAPI) {
             cached.output,
             PREVIEW_LENGTH,
           );
-          if (acceptanceContract) {
-            record.acceptance = evaluateAcceptance(
-              acceptanceContract,
-              cached.structured,
+          const judged = applyAcceptance({
+            contract: acceptanceContract,
+            structured: cached.structured,
+            agentOk: true,
+          });
+          const acceptance = judged.ledger;
+          if (acceptance) record.acceptance = acceptance;
+          if (!judged.ok) {
+            record.invocation = transitionInvocation(record.invocation!, {
+              status: "rejected",
+              at: finishedAt,
+            });
+            record.state = "error";
+            record.error = sanitizeWorkflowDisplayLine(
+              judged.error ?? "Agent failed",
             );
+            emit();
+            replayLease.end();
+            return {
+              ok: false,
+              output: cached.output,
+              ...(cached.structured !== undefined
+                ? { structured: cached.structured }
+                : {}),
+              ...(acceptance ? { acceptance } : {}),
+              error: record.error,
+            };
           }
           const persisted = persistAgentResult({
             output: cached.output,
@@ -1727,7 +1748,7 @@ export default function workflows(pi: ExtensionAPI) {
               ...(cached.structured !== undefined
                 ? { structured: cached.structured }
                 : {}),
-              ...(record.acceptance ? { acceptance: record.acceptance } : {}),
+              ...(acceptance ? { acceptance } : {}),
               error: persisted.error,
             };
           }
@@ -1761,7 +1782,7 @@ export default function workflows(pi: ExtensionAPI) {
               ? { structured: cached.structured }
               : {}),
             ...(ref ? { ref } : {}),
-            ...(record.acceptance ? { acceptance: record.acceptance } : {}),
+            ...(acceptance ? { acceptance } : {}),
           };
         }
 

--- a/tests/extensions/workflows/execute.e2e.test.ts
+++ b/tests/extensions/workflows/execute.e2e.test.ts
@@ -839,6 +839,196 @@ test("agent calls run through the injected session factory and resume replays th
   }
 });
 
+test("replayed acceptance preserves success and rejects non-accepted verdicts", async () => {
+  let sessionCreations = 0;
+  const acceptedStructured = {
+    acceptance: {
+      criteria: [{ id: "tests", status: "accepted", evidence: [] }],
+    },
+  };
+  const factory: WorkflowAgentSessionFactory = async (options) => {
+    sessionCreations++;
+    const structuredTool = options?.customTools?.find(
+      (tool) => tool.name === "structured_output",
+    );
+    assert.ok(structuredTool);
+    const session = fakeAgentSession("acceptance replay output");
+    const originalPrompt = session.prompt.bind(session);
+    const existingTools = session.getAllTools();
+    session.getAllTools = () => [
+      ...existingTools,
+      {
+        name: structuredTool.name,
+        description: structuredTool.description,
+        parameters: structuredTool.parameters,
+        promptGuidelines: structuredTool.promptGuidelines,
+        sourceInfo: {
+          path: "<custom:structured_output>",
+          source: "custom",
+          scope: "temporary",
+          origin: "top-level",
+        },
+      },
+    ];
+    session.getActiveToolNames = () => [
+      ...existingTools.map((tool) => tool.name),
+      structuredTool.name,
+    ];
+    session.getToolDefinition = (name) =>
+      name === structuredTool.name ? structuredTool : undefined;
+    session.prompt = async () => {
+      await structuredTool.execute(
+        "acceptance-replay-structured-output",
+        acceptedStructured,
+        new AbortController().signal,
+        () => {},
+        ctx,
+      );
+      await originalPrompt("");
+    };
+    return { session };
+  };
+  __setWorkflowTestAgentSessionFactory(factory);
+
+  const acceptance = {
+    criteria: [{ id: "tests", description: "Focused tests pass" }],
+  };
+  const script =
+    'export const meta = { name: "acceptance-replay" };\n' +
+    `const r = await agent("acceptance replay fixture", { agent_type: "reviewer", acceptance: ${JSON.stringify(acceptance)} });\n` +
+    "return { ok: r.ok, acceptance: r.acceptance, ref: r.ref, error: r.error };";
+
+  try {
+    const first = (await workflow.execute(
+      "e2e-acceptance-replay-source",
+      { script, wait: true },
+      undefined,
+      undefined,
+      ctx,
+    )) as { details: { runId?: unknown } };
+    const sourceDir = runDirFor(first.details.runId);
+    const sourceJournalPath = join(sourceDir, "journal.json");
+    const sourceJournal = JSON.parse(
+      readFileSync(sourceJournalPath, "utf8"),
+    ) as { entries: Array<Record<string, unknown>> };
+    assert.equal(sourceJournal.entries.length, 1);
+
+    const acceptedReplay = (await workflow.execute(
+      "e2e-acceptance-replay-accepted",
+      {
+        script,
+        resume_from_run_id: String(first.details.runId),
+        wait: true,
+      },
+      undefined,
+      undefined,
+      ctx,
+    )) as { details: { runId?: unknown; result?: Record<string, unknown> } };
+    const acceptedAgent = (
+      readWorkflowJson(acceptedReplay.details.runId).agents as Array<
+        Record<string, unknown>
+      >
+    )[0]!;
+    assert.equal(acceptedReplay.details.result?.ok, true);
+    assert.equal(
+      (acceptedReplay.details.result?.acceptance as { status?: unknown })
+        ?.status,
+      "accepted",
+    );
+    assert.equal(acceptedAgent.state, "done");
+    assert.equal(acceptedAgent.replayed, true);
+    assert.equal(acceptedAgent.acceptance
+      ? (acceptedAgent.acceptance as { status?: unknown }).status
+      : undefined, "accepted");
+    assert.equal(acceptedAgent.resultRef !== undefined, true);
+    assert.equal(acceptedAgent.resultArtifact, "agent-results/agent-0001.json");
+    assert.ok(
+      existsSync(
+        join(
+          runDirFor(acceptedReplay.details.runId),
+          String(acceptedAgent.resultArtifact),
+        ),
+      ),
+    );
+    assert.equal(
+      JSON.parse(
+        readFileSync(
+          join(runDirFor(acceptedReplay.details.runId), "journal.json"),
+          "utf8",
+        ),
+      ).entries.length,
+      1,
+    );
+
+    const nonAccepted = [
+      {
+        status: "rejected",
+        structured: {
+          acceptance: {
+            criteria: [{ id: "tests", status: "rejected", evidence: [] }],
+          },
+        },
+      },
+      { status: "missing", structured: {} },
+      {
+        status: "malformed",
+        structured: {
+          acceptance: {
+            criteria: [{ id: "unexpected", status: "accepted", evidence: [] }],
+          },
+        },
+      },
+    ] as const;
+    for (const verdict of nonAccepted) {
+      const journal = JSON.parse(
+        readFileSync(sourceJournalPath, "utf8"),
+      ) as { entries: Array<Record<string, unknown>> };
+      journal.entries[0]!.structured = verdict.structured;
+      writeFileSync(sourceJournalPath, JSON.stringify(journal));
+
+      const resumed = (await workflow.execute(
+        `e2e-acceptance-replay-${verdict.status}`,
+        {
+          script,
+          resume_from_run_id: String(first.details.runId),
+          wait: true,
+        },
+        undefined,
+        undefined,
+        ctx,
+      )) as { details: { runId?: unknown; result?: Record<string, unknown> } };
+      const persisted = readWorkflowJson(resumed.details.runId);
+      const agent = (persisted.agents as Array<Record<string, unknown>>)[0]!;
+      const resultAcceptance = resumed.details.result?.acceptance as
+        | { status?: unknown }
+        | undefined;
+      const agentAcceptance = agent.acceptance as
+        | { status?: unknown }
+        | undefined;
+
+      assert.equal(resumed.details.result?.ok, false);
+      assert.equal(resultAcceptance?.status, verdict.status);
+      assert.match(String(resumed.details.result?.error), /Acceptance/);
+      assert.equal(agent.state, "error");
+      assert.equal(agentAcceptance?.status, verdict.status);
+      assert.match(String(agent.error), new RegExp(`Acceptance ${verdict.status}`));
+      assert.equal(agent.resultArtifact, undefined);
+      assert.equal(agent.resultRef, undefined);
+      assert.equal(
+        existsSync(join(runDirFor(resumed.details.runId), "agent-results/agent-0001.json")),
+        false,
+      );
+      assert.equal(
+        existsSync(join(runDirFor(resumed.details.runId), "journal.json")),
+        false,
+      );
+    }
+    assert.equal(sessionCreations, 1);
+  } finally {
+    __setWorkflowTestAgentSessionFactory(undefined);
+  }
+});
+
 test("oversized authoritative agent results fail without a success record", async () => {
   const factory: WorkflowAgentSessionFactory = async (options) => {
     const structuredTool = options?.customTools?.find(


### PR DESCRIPTION
## Problem

The replay path evaluated an acceptance contract only for display, then marked a cached agent result as done and returned `ok: true` even when the replayed acceptance verdict was rejected, missing, or malformed. Related to #112.

## Value

Corrupted or manually edited journals now fail closed instead of silently presenting an unaccepted replay as a successful agent result.

## Approach

- Route replayed cached results through the same `applyAcceptance` decision used by live execution.
- Persist the acceptance ledger and return an error state without creating an artifact, handoff reference, or replay journal entry when the verdict is not accepted.
- Keep successful replay behavior unchanged, including artifact persistence and re-journaling.
- Use stable run-relative forward-slash artifact references so replay handoffs remain valid on Windows.
- Add end-to-end coverage for accepted, rejected, missing, and malformed replay verdicts.

## Validation

- `node --test --experimental-strip-types tests/extensions/workflows/execute.e2e.test.ts` — 12 passed.
- `node --test --experimental-strip-types tests/extensions/workflows/acceptance.test.ts` — passed.
- `bun run lint` — passed.
- `bun run typecheck` — passed with the repository's existing warnings in `extensions/file-search`.
- `git diff --check` — passed.
- The workflow artifact test retains an existing Windows-only expectation mismatch: directory replacement reports `EPERM` rather than `EISDIR`.

## Impact

- User-visible behavior: replayed non-accepted results are reported as failures instead of successes.
- Runtime/lifecycle: rejected replays end in the error state and do not register successful handoffs.
- Persisted data: accepted replay artifacts and journal chaining are preserved; rejected replays do not create success artifacts.
- Compatibility/risk: no acceptance contract or live-execution semantics changed; malformed journal payloads now fail closed.