### PR TITLE
feat(ci): notify Feishu for new pull requests

### DIFF
--- a/.github/actions/feishu-pr-notification/index.cjs
+++ b/.github/actions/feishu-pr-notification/index.cjs
@@ -1,0 +1,151 @@
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+
+const FIELD_LIMIT = 256;
+const REVIEWER_LIMIT = 128;
+const REVIEWERS_LIMIT = 512;
+const URL_LIMIT = 512;
+const CONTROL_OR_LINE_SEPARATOR = /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/u;
+const BIDI_CONTROL = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/u;
+
+function truncateCodePoints(value, maxCodePoints) {
+  const points = Array.from(value);
+  if (points.length <= maxCodePoints) return value;
+  if (maxCodePoints <= 1) return "…";
+  return `${points.slice(0, maxCodePoints - 1).join("")}…`;
+}
+
+function isEncodedAngleBracket(value) {
+  return /^&(?:lt;?|gt;?|#0*(?:60|62)(?:;|(?![0-9]))|#x0*(?:3c|3e)(?:;|(?![0-9a-f])))/iu.test(
+    value,
+  );
+}
+
+/** Project untrusted PR metadata into one bounded Feishu plain-text field. */
+function sanitizeFeishuField(value, maxCodePoints = FIELD_LIMIT) {
+  const points = Array.from(String(value ?? ""))
+    .filter((point) => !BIDI_CONTROL.test(point))
+    .map((point) => (CONTROL_OR_LINE_SEPARATOR.test(point) ? " " : point));
+  // Keep benign Unicode and ordinary ampersands byte-for-byte. The parallel
+  // NFKC projection is used only to identify compatibility characters that a
+  // downstream renderer could turn into Feishu <at> markup or an angle-bracket
+  // entity. Replacement characters remain non-ASCII under NFKC/NFKD.
+  const compatibility = points.map((point) => point.normalize("NFKC"));
+  const safe = points.map((point, index) => {
+    if (compatibility[index] === "<") return "‹";
+    if (compatibility[index] === ">") return "›";
+    if (
+      compatibility[index] === "&" &&
+      isEncodedAngleBracket(compatibility.slice(index).join(""))
+    ) {
+      return "⅋";
+    }
+    return point;
+  });
+  return truncateCodePoints(
+    safe.join("").replace(/\s+/gu, " ").trim(),
+    maxCodePoints,
+  );
+}
+
+function formatNotificationText(event, repository) {
+  const pr = event.pull_request;
+  const author = sanitizeFeishuField(pr.user?.login ?? "unknown");
+  const reviewers = [
+    ...(pr.requested_reviewers ?? []).map((reviewer) =>
+      sanitizeFeishuField(reviewer.login, REVIEWER_LIMIT),
+    ),
+    ...(pr.requested_teams ?? []).map(
+      (team) => `team/${sanitizeFeishuField(team.slug, REVIEWER_LIMIT)}`,
+    ),
+  ].filter(Boolean);
+  const reviewerText =
+    reviewers.length > 0
+      ? sanitizeFeishuField(reviewers.join(", "), REVIEWERS_LIMIT)
+      : "未指定";
+  const lines = [
+    `${sanitizeFeishuField(repository)} 有新的 PR`,
+    `#${pr.number} ${sanitizeFeishuField(pr.title)}`,
+    `作者：${author}`,
+    `审阅人：${reviewerText}`,
+    `分支：${sanitizeFeishuField(pr.head.label)} -> ${sanitizeFeishuField(pr.base.ref)}`,
+    `PR 链接：${sanitizeFeishuField(pr.html_url, URL_LIMIT)}`,
+  ];
+  return lines.join("\n");
+}
+
+function isSuccessfulResponse(payload) {
+  return (
+    payload !== null &&
+    typeof payload === "object" &&
+    (payload.code === 0 || payload.StatusCode === 0)
+  );
+}
+
+async function sendNotification({
+  event,
+  repository,
+  webhook,
+  secret,
+  now = Date.now,
+}) {
+  const timestamp = String(Math.floor(now() / 1_000));
+  const stringToSign = `${timestamp}\n${secret}`;
+  const sign = crypto
+    .createHmac("sha256", stringToSign)
+    .update("")
+    .digest("base64");
+  const response = await fetch(webhook, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      timestamp,
+      sign,
+      msg_type: "text",
+      content: { text: formatNotificationText(event, repository) },
+    }),
+  });
+  const text = await response.text();
+
+  if (!response.ok) {
+    throw new Error(`Feishu webhook returned ${response.status}: ${text}`);
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw new Error(
+      `Feishu webhook returned an invalid JSON response: ${text}`,
+    );
+  }
+
+  if (!isSuccessfulResponse(payload)) {
+    throw new Error(`Feishu webhook failed: ${text}`);
+  }
+}
+
+async function main() {
+  const event = JSON.parse(fs.readFileSync(process.env.EVENT_PATH, "utf8"));
+  await sendNotification({
+    event,
+    repository: process.env.REPOSITORY,
+    webhook: process.env.FEISHU_PR_BOT_WEBHOOK,
+    secret: process.env.FEISHU_PR_BOT_SECRET,
+  });
+  console.log("Feishu PR notification sent.");
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  formatNotificationText,
+  isSuccessfulResponse,
+  sanitizeFeishuField,
+  sendNotification,
+};

--- a/.github/workflows/feishu-pr-notification.yml
+++ b/.github/workflows/feishu-pr-notification.yml
@@ -1,0 +1,94 @@
+name: Feishu PR Notification
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  notify:
+    name: Notify Feishu
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ !github.event.pull_request.draft }}
+    steps:
+      - name: Send PR notification
+        env:
+          FEISHU_PR_BOT_WEBHOOK: ${{ secrets.FEISHU_PR_BOT_WEBHOOK }}
+          FEISHU_PR_BOT_SECRET: ${{ secrets.FEISHU_PR_BOT_SECRET }}
+          REPOSITORY: ${{ github.repository }}
+          EVENT_PATH: ${{ github.event_path }}
+        run: |
+          if test -z "${FEISHU_PR_BOT_WEBHOOK}" && test -z "${FEISHU_PR_BOT_SECRET}"; then
+            echo "Feishu bot secrets are not configured; skipping notification."
+            exit 0
+          fi
+
+          if test -z "${FEISHU_PR_BOT_WEBHOOK}" || test -z "${FEISHU_PR_BOT_SECRET}"; then
+            echo "Both FEISHU_PR_BOT_WEBHOOK and FEISHU_PR_BOT_SECRET must be configured."
+            exit 1
+          fi
+
+          node <<'NODE'
+          const crypto = require("node:crypto");
+          const fs = require("node:fs");
+
+          async function main() {
+            const event = JSON.parse(fs.readFileSync(process.env.EVENT_PATH, "utf8"));
+            const pr = event.pull_request;
+            const author = pr.user?.login ?? "unknown";
+            const reviewers = [
+              ...(pr.requested_reviewers ?? []).map((reviewer) => reviewer.login),
+              ...(pr.requested_teams ?? []).map((team) => `team/${team.slug}`),
+            ];
+            const reviewerText = reviewers.length > 0 ? reviewers.join(", ") : "none requested";
+            const lines = [
+              `New PR in ${process.env.REPOSITORY}`,
+              `#${pr.number} ${pr.title}`,
+              `Author: ${author}`,
+              `Reviewers: ${reviewerText}`,
+              `Branch: ${pr.head.label} -> ${pr.base.ref}`,
+              pr.html_url,
+            ];
+            const timestamp = String(Math.floor(Date.now() / 1000));
+            const stringToSign = `${timestamp}\n${process.env.FEISHU_PR_BOT_SECRET}`;
+            const sign = crypto.createHmac("sha256", stringToSign).update("").digest("base64");
+
+            const response = await fetch(process.env.FEISHU_PR_BOT_WEBHOOK, {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({
+                timestamp,
+                sign,
+                msg_type: "text",
+                content: { text: lines.join("\n") },
+              }),
+            });
+            const text = await response.text();
+
+            if (!response.ok) {
+              throw new Error(`Feishu webhook returned ${response.status}: ${text}`);
+            }
+
+            let payload;
+            try {
+              payload = JSON.parse(text);
+            } catch {
+              throw new Error(`Feishu webhook returned an invalid JSON response: ${text}`);
+            }
+
+            const succeeded = payload.code === 0 || payload.StatusCode === 0;
+            if (!succeeded) {
+              throw new Error(`Feishu webhook failed: ${text}`);
+            }
+
+            console.log("Feishu PR notification sent.");
+          }
+
+          main().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE

--- a/.github/workflows/feishu-pr-notification.yml
+++ b/.github/workflows/feishu-pr-notification.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, ready_for_review]
 
 permissions:
+  contents: read
   pull-requests: read
 
 jobs:
@@ -14,6 +15,11 @@ jobs:
     timeout-minutes: 5
     if: ${{ !github.event.pull_request.draft }}
     steps:
+      - name: Check out trusted workflow source
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
       - name: Send PR notification
         env:
           FEISHU_PR_BOT_WEBHOOK: ${{ secrets.FEISHU_PR_BOT_WEBHOOK }}
@@ -31,64 +37,4 @@ jobs:
             exit 1
           fi
 
-          node <<'NODE'
-          const crypto = require("node:crypto");
-          const fs = require("node:fs");
-
-          async function main() {
-            const event = JSON.parse(fs.readFileSync(process.env.EVENT_PATH, "utf8"));
-            const pr = event.pull_request;
-            const author = pr.user?.login ?? "unknown";
-            const reviewers = [
-              ...(pr.requested_reviewers ?? []).map((reviewer) => reviewer.login),
-              ...(pr.requested_teams ?? []).map((team) => `team/${team.slug}`),
-            ];
-            const reviewerText = reviewers.length > 0 ? reviewers.join(", ") : "未指定";
-            const lines = [
-              `${process.env.REPOSITORY} 有新的 PR`,
-              `#${pr.number} ${pr.title}`,
-              `作者：${author}`,
-              `审阅人：${reviewerText}`,
-              `分支：${pr.head.label} -> ${pr.base.ref}`,
-              `PR 链接：${pr.html_url}`,
-            ];
-            const timestamp = String(Math.floor(Date.now() / 1000));
-            const stringToSign = `${timestamp}\n${process.env.FEISHU_PR_BOT_SECRET}`;
-            const sign = crypto.createHmac("sha256", stringToSign).update("").digest("base64");
-
-            const response = await fetch(process.env.FEISHU_PR_BOT_WEBHOOK, {
-              method: "POST",
-              headers: { "content-type": "application/json" },
-              body: JSON.stringify({
-                timestamp,
-                sign,
-                msg_type: "text",
-                content: { text: lines.join("\n") },
-              }),
-            });
-            const text = await response.text();
-
-            if (!response.ok) {
-              throw new Error(`Feishu webhook returned ${response.status}: ${text}`);
-            }
-
-            let payload;
-            try {
-              payload = JSON.parse(text);
-            } catch {
-              throw new Error(`Feishu webhook returned an invalid JSON response: ${text}`);
-            }
-
-            const succeeded = payload.code === 0 || payload.StatusCode === 0;
-            if (!succeeded) {
-              throw new Error(`Feishu webhook failed: ${text}`);
-            }
-
-            console.log("Feishu PR notification sent.");
-          }
-
-          main().catch((error) => {
-            console.error(error);
-            process.exit(1);
-          });
-          NODE
+          node .github/actions/feishu-pr-notification/index.cjs

--- a/.github/workflows/feishu-pr-notification.yml
+++ b/.github/workflows/feishu-pr-notification.yml
@@ -43,14 +43,14 @@ jobs:
               ...(pr.requested_reviewers ?? []).map((reviewer) => reviewer.login),
               ...(pr.requested_teams ?? []).map((team) => `team/${team.slug}`),
             ];
-            const reviewerText = reviewers.length > 0 ? reviewers.join(", ") : "none requested";
+            const reviewerText = reviewers.length > 0 ? reviewers.join(", ") : "未指定";
             const lines = [
-              `New PR in ${process.env.REPOSITORY}`,
+              `${process.env.REPOSITORY} 有新的 PR`,
               `#${pr.number} ${pr.title}`,
-              `Author: ${author}`,
-              `Reviewers: ${reviewerText}`,
-              `Branch: ${pr.head.label} -> ${pr.base.ref}`,
-              pr.html_url,
+              `作者：${author}`,
+              `审阅人：${reviewerText}`,
+              `分支：${pr.head.label} -> ${pr.base.ref}`,
+              `PR 链接：${pr.html_url}`,
             ];
             const timestamp = String(Math.floor(Date.now() / 1000));
             const stringToSign = `${timestamp}\n${process.env.FEISHU_PR_BOT_SECRET}`;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 Thank you for contributing to OpenPI. Start with the guide that matches your change:
 
 - [Fast-Forward and Linear Git History](docs/contributing/linear-git-history.md) - branch preparation, safe rebasing, pull request merge methods, and local updates.
+- [Feishu PR notifications](docs/contributing/feishu-pr-notifications.md) - repository secret setup for pull request group bot messages.
 
 The contribution guides are recommendations for the current repository workflow. Repository administrators must configure GitHub settings separately before those recommendations become enforced policy.
 

--- a/biome.json
+++ b/biome.json
@@ -5,6 +5,7 @@
       "extensions/**/*.ts",
       "tests/**/*.ts",
       "extensions/**/*.cjs",
+      ".github/actions/**/*.cjs",
       "benchmarks/**/*.ts",
       "scripts/**/*.js",
       "scripts/**/*.mjs",

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,3 +1,4 @@
 # Contributing Guides
 
 - [Fast-Forward and Linear Git History](linear-git-history.md) - prepare, review, merge, and update branches while keeping history linear.
+- [Feishu PR notifications](feishu-pr-notifications.md) - configure the group bot notification for newly opened pull requests.

--- a/docs/contributing/feishu-pr-notifications.md
+++ b/docs/contributing/feishu-pr-notifications.md
@@ -11,4 +11,6 @@ To enable it:
 
 The workflow skips notifications when neither secret exists and fails when only one is configured. The webhook URL and signing secret are never included in the message or logs.
 
-The workflow runs when a pull request is opened or marked ready for review. It uses `pull_request_target` so the repository secret is available for PRs from forks, but it does not check out or execute pull request code.
+The workflow runs when a pull request is opened or marked ready for review. It uses `pull_request_target` so the repository secret is available for PRs from forks. It checks out only `github.workflow_sha`, the trusted commit that supplied the workflow, and never checks out or executes pull request code.
+
+Notifications are event-driven: if an author moves a pull request back to draft and then marks it ready again, the group receives another notification.

--- a/docs/contributing/feishu-pr-notifications.md
+++ b/docs/contributing/feishu-pr-notifications.md
@@ -1,0 +1,14 @@
+# Feishu PR notifications
+
+The Feishu group bot notification is handled by `.github/workflows/feishu-pr-notification.yml`.
+
+To enable it:
+
+1. Enable **Signature Verification** (加签) in the Feishu group bot's security settings and copy the signing secret.
+2. In the GitHub repository, open **Settings > Secrets and variables > Actions**.
+3. Add `FEISHU_PR_BOT_WEBHOOK` with the bot's webhook URL.
+4. Add `FEISHU_PR_BOT_SECRET` with the bot's signing secret.
+
+The workflow skips notifications when neither secret exists and fails when only one is configured. The webhook URL and signing secret are never included in the message or logs.
+
+The workflow runs when a pull request is opened or marked ready for review. It uses `pull_request_target` so the repository secret is available for PRs from forks, but it does not check out or execute pull request code.

--- a/tests/github/feishu-pr-notification.test.ts
+++ b/tests/github/feishu-pr-notification.test.ts
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+
+interface PullRequestEvent {
+  pull_request: {
+    number: number;
+    title: string;
+    user?: { login: string };
+    requested_reviewers?: Array<{ login: string }>;
+    requested_teams?: Array<{ slug: string }>;
+    head: { label: string };
+    base: { ref: string };
+    html_url: string;
+  };
+}
+
+interface NotificationModule {
+  formatNotificationText(event: PullRequestEvent, repository: string): string;
+  sanitizeFeishuField(value: unknown, maxCodePoints?: number): string;
+  isSuccessfulResponse(payload: unknown): boolean;
+  sendNotification(options: {
+    event: PullRequestEvent;
+    repository: string;
+    webhook: string;
+    secret: string;
+    now?: () => number;
+  }): Promise<void>;
+}
+
+const notification =
+  require("../../.github/actions/feishu-pr-notification/index.cjs") as NotificationModule;
+
+test("the privileged workflow executes only its trusted workflow commit", () => {
+  const workflow = readFileSync(
+    ".github/workflows/feishu-pr-notification.yml",
+    "utf8",
+  );
+  assert.match(
+    workflow,
+    /actions\/checkout@[0-9a-f]{40} # v6/u,
+    "checkout stays pinned to an immutable commit",
+  );
+  assert.match(workflow, /ref: \$\{\{ github\.workflow_sha \}\}/u);
+  assert.match(workflow, /persist-credentials: false/u);
+  assert.doesNotMatch(workflow, /pull_request\.head\.sha|github\.head_ref/u);
+});
+
+function event(overrides: Partial<PullRequestEvent["pull_request"]> = {}) {
+  return {
+    pull_request: {
+      number: 270,
+      title: "feat(ci): notify Feishu for new pull requests",
+      user: { login: "contributor" },
+      requested_reviewers: [{ login: "reviewer" }],
+      requested_teams: [{ slug: "release-managers" }],
+      head: { label: "contributor:feature" },
+      base: { ref: "main" },
+      html_url: "https://github.com/openpi-dev/openpi/pull/270",
+      ...overrides,
+    },
+  } satisfies PullRequestEvent;
+}
+
+test("benign pull request metadata keeps the existing notification", () => {
+  assert.equal(
+    notification.formatNotificationText(event(), "openpi-dev/openpi"),
+    [
+      "openpi-dev/openpi 有新的 PR",
+      "#270 feat(ci): notify Feishu for new pull requests",
+      "作者：contributor",
+      "审阅人：reviewer, team/release-managers",
+      "分支：contributor:feature -> main",
+      "PR 链接：https://github.com/openpi-dev/openpi/pull/270",
+    ].join("\n"),
+  );
+  assert.equal(
+    notification.sanitizeFeishuField(
+      "fix A & B, AT&T · 支持①号 ﬃ ligature &#600; &#620; &#x3ca; &#x3e0;",
+    ),
+    "fix A & B, AT&T · 支持①号 ﬃ ligature &#600; &#620; &#x3ca; &#x3e0;",
+  );
+});
+
+test("untrusted metadata cannot inject Feishu tags or message fields", () => {
+  const text = notification.formatNotificationText(
+    event({
+      title:
+        '<at user_id="all">所有人</at> &lt;at&gt; &ltat&gt; &LT/at&gt; &#60;at&gt; &#60/at&gt; &#x3c;at&gt; ＆ｌｔ；at\r\n作者：伪造\u202e\u2066',
+      user: { login: "evil\n审阅人：伪造" },
+      requested_reviewers: [{ login: "reviewer\u2028PR 链接：伪造" }],
+      head: { label: "fork\u2029作者：伪造" },
+    }),
+    "openpi-dev/openpi",
+  );
+  const lines = text.split("\n");
+
+  assert.equal(lines.length, 6, "untrusted metadata cannot add message lines");
+  assert.equal(
+    lines.filter((line) => line.startsWith("作者：")).length,
+    1,
+    "the canonical author field stays unique",
+  );
+  assert.doesNotMatch(
+    text,
+    /<|&|[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/u,
+  );
+  assert.match(lines[1]!, /‹at user_id="all"›所有人‹\/at›/);
+  assert.doesNotMatch(text.normalize("NFKC"), /<at/u);
+});
+
+test("field bounds count Unicode code points without splitting emoji", () => {
+  assert.equal(notification.sanitizeFeishuField("🙂".repeat(10), 4), "🙂🙂🙂…");
+});
+
+test("reviewer aggregates stay bounded and missing metadata keeps its fallback", () => {
+  const bounded = notification
+    .formatNotificationText(
+      event({
+        requested_reviewers: Array.from({ length: 100 }, (_, index) => ({
+          login: `reviewer-${index}-${"🙂".repeat(20)}`,
+        })),
+        requested_teams: [],
+      }),
+      "openpi-dev/openpi",
+    )
+    .split("\n")[3]!;
+  assert.ok(Array.from(bounded.slice("审阅人：".length)).length <= 512);
+  assert.ok(bounded.endsWith("…"));
+
+  const fallback = notification.formatNotificationText(
+    event({
+      user: undefined,
+      requested_reviewers: [],
+      requested_teams: [],
+    }),
+    "openpi-dev/openpi",
+  );
+  assert.match(fallback, /^\u4f5c\u8005：unknown$/mu);
+  assert.match(fallback, /^\u5ba1\u9605\u4eba：未指定$/mu);
+});
+
+test("current and legacy Feishu success responses remain accepted", () => {
+  assert.equal(notification.isSuccessfulResponse({ code: 0 }), true);
+  assert.equal(notification.isSuccessfulResponse({ StatusCode: 0 }), true);
+  assert.equal(notification.isSuccessfulResponse({ code: 19021 }), false);
+  assert.equal(notification.isSuccessfulResponse(null), false);
+});
+
+test("the HTTP payload uses the sanitized formatter and expected signature", async (t) => {
+  let requestBody = "";
+  const server = createServer((request, response) => {
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => {
+      requestBody += chunk;
+    });
+    request.on("end", () => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ code: 0 }));
+    });
+  });
+  t.after(() => server.close());
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+
+  const now = 1_700_000_000_000;
+  const secret = "test-secret";
+  await notification.sendNotification({
+    event: event({
+      title:
+        '<at user_id="all">所有人</at> &ltat user_id="all"&gt &LT/at&gt &#60at&gt &#60/at&gt',
+    }),
+    repository: "openpi-dev/openpi",
+    webhook: `http://127.0.0.1:${address.port}`,
+    secret,
+    now: () => now,
+  });
+
+  const payload = JSON.parse(requestBody) as {
+    timestamp: string;
+    sign: string;
+    msg_type: string;
+    content: { text: string };
+  };
+  const timestamp = String(now / 1_000);
+  const expectedSign = createHmac("sha256", `${timestamp}\n${secret}`)
+    .update("")
+    .digest("base64");
+
+  assert.equal(payload.timestamp, timestamp);
+  assert.equal(payload.sign, expectedSign);
+  assert.equal(payload.msg_type, "text");
+  assert.doesNotMatch(payload.content.text, /<at/u);
+  assert.doesNotMatch(payload.content.text.normalize("NFKC"), /<at/u);
+  assert.doesNotMatch(payload.content.text, /&(?:lt|gt|#)/iu);
+  assert.equal(payload.content.text.split("\n").length, 6);
+});


### PR DESCRIPTION
## Problem

New pull requests were not announced automatically in the project Feishu group, and public PR metadata could be interpreted as Feishu text markup if forwarded verbatim.

## Value

The repository can notify the Feishu group immediately while keeping the webhook and signing secret protected, while hostile titles or other metadata cannot inject mentions or extra message fields.

## Approach

Add a `pull_request_target` workflow for opened and ready-for-review events. It checks out only the trusted `github.workflow_sha` with credentials disabled, never PR code, then signs and sends a bounded six-line plain-text notification. All public PR metadata is projected through a Unicode-aware sanitizer before the HTTP payload is built. The workflow accepts both current and legacy Feishu success response formats.

## Validation

- Focused formatter and real local HTTP payload tests: 7/7 passed
- `bun run check`: passed (258 files)
- `bun run test`: passed (966 passed, 1 skipped)
- `git diff --check`: passed
- Two independent final reviews: no findings
- Adversarial entity and Unicode matrix: 324 combinations, 0 bypass
- Live Feishu notification: not sent; runtime acceptance requires the workflow on the default branch and a later matching PR event

## Impact

User-visible behavior: Feishu receives one message for newly opened non-draft PRs and another whenever a draft is marked ready. Repeated draft-to-ready transitions intentionally produce repeated notifications.

Model-visible context/tools: None.

Runtime/lifecycle: Adds one bounded GitHub Actions job per relevant PR event.

Persisted config/data: Requires `FEISHU_PR_BOT_WEBHOOK` and `FEISHU_PR_BOT_SECRET` repository secrets.

Compatibility or risk: Benign notification text, signing, response handling, and missing/partial-secret behavior are preserved. Hostile, control, bidi, and overlong metadata is safely bounded.