### PR TITLE
chore: add release managers as workflow owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # All ordinary repository changes may be approved by any collaborator with write access.
 
 /.github/CODEOWNERS @tt-a1i
-/.github/workflows/** @tt-a1i
-/.github/actions/** @tt-a1i
+/.github/workflows/** @tt-a1i @openpi-dev/release-managers
+/.github/actions/** @tt-a1i @openpi-dev/release-managers


### PR DESCRIPTION
## Summary
- add `@openpi-dev/release-managers` as a CODEOWNER for GitHub workflows
- add the team as a CODEOWNER for reusable GitHub Actions
- keep `@tt-a1i` as an owner for cross-coverage

## Validation
- `bun run check`
- `bun run test`