### PR TITLE
chore: migrate canonical repository identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@tt-a1i/openpi"><img alt="npm version" src="https://img.shields.io/npm/v/@tt-a1i/openpi?style=flat-square&color=cb3837"></a>
-  <a href="https://github.com/tt-a1i/openpi/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/tt-a1i/openpi/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://github.com/openpi-dev/openpi/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/openpi-dev/openpi/actions/workflows/ci.yml/badge.svg"></a>
   <a href="https://github.com/earendil-works/pi-mono"><img alt="Pi 0.84.1+" src="https://img.shields.io/badge/Pi-0.84.1%2B-2f81f7?style=flat-square"></a>
   <img alt="Node.js 22.19+" src="https://img.shields.io/badge/Node.js-22.19%2B-3fb950?style=flat-square&logo=nodedotjs&logoColor=white">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-3fb950?style=flat-square"></a>
@@ -30,11 +30,11 @@ pi install npm:@tt-a1i/openpi
 ```
 
 <p align="center">
-  <a href="https://tt-a1i.github.io/openpi/"><strong>项目网站</strong></a> ·
+  <a href="https://openpi-dev.github.io/openpi/"><strong>项目网站</strong></a> ·
   <a href="#30-秒开始"><strong>立即开始</strong></a> ·
   <a href="#默认轻按需强">为什么默认更轻</a> ·
   <a href="#运行模型">看看它怎么工作</a> ·
-  <a href="https://github.com/tt-a1i/openpi/issues/22">查看 Benchmark</a>
+  <a href="https://github.com/openpi-dev/openpi/issues/22">查看 Benchmark</a>
 </p>
 
 <p align="center">
@@ -426,7 +426,7 @@ Footer 布局以 `footerLines` 作为唯一持久化格式。旧版 `footerItems
 - Pi `0.84.1` 或更新版本；
 - Node.js `22.19.0` 或更新版本；
 - npm 安装：`pi install npm:@tt-a1i/openpi`；
-- GitHub 安装：`pi install git:github.com/tt-a1i/openpi`。
+- GitHub 安装：`pi install git:github.com/openpi-dev/openpi`。
 
 #### 开发运行时：区分 npm 与当前源码
 
@@ -445,7 +445,7 @@ pi list
 **2. 开发时让 Pi 直接加载当前 checkout**
 
 ```bash
-git clone https://github.com/tt-a1i/openpi.git ~/work/openpi
+git clone https://github.com/openpi-dev/openpi.git ~/work/openpi
 cd ~/work/openpi
 bun install --frozen-lockfile
 
@@ -633,7 +633,7 @@ bun run test
 
 npm 仍用于发布包的 `pack` / clean-install 验证，因为用户通过 npm Registry 安装 OpenPI。
 
-测试覆盖进程树终止与竞态、Subagent 生命周期与工具边界、Workflow Sandbox / Ledger / Graph / Replay / Acceptance、Worktree 数据保全、Session 状态恢复、配置迁移和 TUI 渲染。设计记录见 [`docs/design/`](docs/design/)，问题请提交到 [GitHub Issues](https://github.com/tt-a1i/openpi/issues)。
+测试覆盖进程树终止与竞态、Subagent 生命周期与工具边界、Workflow Sandbox / Ledger / Graph / Replay / Acceptance、Worktree 数据保全、Session 状态恢复、配置迁移和 TUI 渲染。设计记录见 [`docs/design/`](docs/design/)，问题请提交到 [GitHub Issues](https://github.com/openpi-dev/openpi/issues)。
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@ OpenPI releases `@tt-a1i/openpi` through [the Release workflow](.github/workflow
 
 Before the first workflow release:
 
-1. Configure the npm trusted publisher for organization/user `tt-a1i`, repository `openpi`, workflow `release.yml`, and environment `npm`.
+1. Configure the npm trusted publisher for GitHub organization/user `openpi-dev`, repository `openpi`, workflow `release.yml`, and environment `npm`. The published npm package remains `@tt-a1i/openpi`.
 2. Protect the GitHub `npm` environment with a required reviewer and prevent unreviewed deployment from other branches or tags. Allow only the protected `main` branch and version tags matching `v*.*.*`.
 
 The workflow has no long-lived npm token. Its publish job receives an OIDC identity only after the unprivileged validation job succeeds and the `npm` environment permits the deployment. The publish job consumes only the validated package artifact and does not run repository lifecycle scripts.

--- a/SETUP.md
+++ b/SETUP.md
@@ -9,7 +9,7 @@ pi install npm:@tt-a1i/openpi
 To inspect the current source before loading it, install directly from GitHub instead:
 
 ```sh
-pi install git:github.com/tt-a1i/openpi
+pi install git:github.com/openpi-dev/openpi
 ```
 
 Pi installs the package dependencies automatically. Restart Pi or run `/reload` after installation.

--- a/extensions/shared/child-session.ts
+++ b/extensions/shared/child-session.ts
@@ -250,6 +250,9 @@ function piMatchesPublishedOpenPiSource(options: {
   return (
     packageManager.removeSourceFromSettings("npm:@tt-a1i/openpi") ||
     packageManager.removeSourceFromSettings(
+      "git:https://github.com/openpi-dev/openpi",
+    ) ||
+    packageManager.removeSourceFromSettings(
       "git:https://github.com/tt-a1i/openpi",
     )
   );

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tt-a1i/openpi.git"
+    "url": "git+https://github.com/openpi-dev/openpi.git"
   },
-  "homepage": "https://github.com/tt-a1i/openpi#readme",
+  "homepage": "https://github.com/openpi-dev/openpi#readme",
   "bugs": {
-    "url": "https://github.com/tt-a1i/openpi/issues"
+    "url": "https://github.com/openpi-dev/openpi/issues"
   },
   "files": [
     "extensions",
@@ -46,7 +46,7 @@
     "themes": [
       "./themes"
     ],
-    "image": "https://raw.githubusercontent.com/tt-a1i/openpi/main/assets/openpi-package.png"
+    "image": "https://raw.githubusercontent.com/openpi-dev/openpi/main/assets/openpi-package.png"
   },
   "dependencies": {
     "@effect/platform-node": "^4.0.0-beta.99",

--- a/tests/extensions/setup/package-contract.test.ts
+++ b/tests/extensions/setup/package-contract.test.ts
@@ -67,18 +67,21 @@ test("the public OpenPI package has complete gallery and registry metadata", () 
   );
   assert.deepEqual(manifest.repository, {
     type: "git",
-    url: "git+https://github.com/tt-a1i/openpi.git",
+    url: "git+https://github.com/openpi-dev/openpi.git",
   });
-  assert.equal(manifest.homepage, "https://github.com/tt-a1i/openpi#readme");
+  assert.equal(
+    manifest.homepage,
+    "https://github.com/openpi-dev/openpi#readme",
+  );
   assert.deepEqual(manifest.bugs, {
-    url: "https://github.com/tt-a1i/openpi/issues",
+    url: "https://github.com/openpi-dev/openpi/issues",
   });
   assert.deepEqual(manifest.pi?.extensions, ["./extensions"]);
   assert.equal(manifest.pi?.skills, undefined);
   assert.deepEqual(manifest.pi?.themes, ["./themes"]);
   assert.equal(
     manifest.pi?.image,
-    "https://raw.githubusercontent.com/tt-a1i/openpi/main/assets/openpi-package.png",
+    "https://raw.githubusercontent.com/openpi-dev/openpi/main/assets/openpi-package.png",
   );
   assert.deepEqual(manifest.files, [
     "extensions",

--- a/tests/extensions/shared/child-session.test.ts
+++ b/tests/extensions/shared/child-session.test.ts
@@ -858,7 +858,7 @@ test("nested manifestless packages are not mistaken for OpenPI", async () => {
   });
 });
 
-test("child package snapshot cannot install an unresolved historical Git source", async () => {
+test("child package snapshot handles canonical and historical package Git sources offline", async () => {
   await withTempDir(async (directory) => {
     const cwd = path.join(directory, "project");
     const agentDir = path.join(directory, "agent");
@@ -867,12 +867,18 @@ test("child package snapshot cannot install an unresolved historical Git source"
       "git:github.com/nicobailon/pi-intercom@feature/test",
       "git:git@github.com:nicobailon/pi-intercom@feature/test",
     ];
+    const openPiSources = [
+      "git:github.com/openpi-dev/openpi",
+      "git:github.com/tt-a1i/openpi",
+    ];
     const ordinarySource = "npm:ordinary-missing-package@1.0.0";
     await mkdir(cwd, { recursive: true });
     await mkdir(agentDir, { recursive: true });
     await writeFile(
       path.join(agentDir, "settings.json"),
-      JSON.stringify({ packages: [...intercomSources, ordinarySource] }),
+      JSON.stringify({
+        packages: [...intercomSources, ...openPiSources, ordinarySource],
+      }),
     );
 
     const previousOffline = process.env.PI_OFFLINE;
@@ -890,6 +896,10 @@ test("child package snapshot cannot install an unresolved historical Git source"
     }
 
     assert.deepEqual(child.settingsManager.getGlobalSettings().packages, [
+      ...openPiSources.map((source) => ({
+        source,
+        extensions: ["-extensions/git-info/index.ts"],
+      })),
       ordinarySource,
     ]);
     for (const source of intercomSources) {


### PR DESCRIPTION
## Summary

- update canonical repository, Pages, issue, install, image, and Trusted Publisher references to `openpi-dev/openpi`
- keep the published npm package identity `@tt-a1i/openpi` unchanged
- preserve both the new and historical Git package sources in child-session isolation
- update package-contract and offline compatibility tests

## Validation

- `bun run check`
- `bun run test` (959 Node tests: 958 pass, 1 skip; 30 Vitest tests pass)
- `npm pack --dry-run --ignore-scripts`
- two independent final-diff reviews: no blocking findings
