### PR TITLE
ci: pin workflow actions by commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
       matrix:
         node-version: [22.19.0, 24]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
       - name: Install dependencies
@@ -66,11 +66,11 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22.19.0
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- pin every action used by the main CI workflow to a full immutable commit SHA
- retain readable major-version comments and the existing Node/Linux/Windows job behavior
- prepare the repository for SHA-pinning enforcement

## Validation

- verified each SHA matches the current `v4`, `v4`, and `v2` tag ref in its official repository
- `bun run check`
- `bun run test` (959 Node tests: 958 pass, 1 skip; 30 Vitest tests pass)
- two independent final-diff reviews: no blocking findings
