### PR TITLE
test(workflows): cover canonical agent result handoffs

### DIFF
--- a/tests/extensions/workflows/artifacts.test.ts
+++ b/tests/extensions/workflows/artifacts.test.ts
@@ -135,6 +135,7 @@ test("agent result artifacts are complete or fail without leaving a file", () =>
       output: "complete",
       structured: { verdict: "accepted", emoji: "你好🙂" },
     });
+    assert.equal(artifact, "agent-results/agent-0001.json");
     assert.deepEqual(
       JSON.parse(readFileSync(join(directory, artifact), "utf8")),
       {

--- a/tests/extensions/workflows/execute.e2e.test.ts
+++ b/tests/extensions/workflows/execute.e2e.test.ts
@@ -229,7 +229,11 @@ async function waitFor(
 }
 
 /** A minimal AgentSession stand-in for one successful child agent call. */
-function fakeAgentSession(output: string, promptGate?: Promise<void>) {
+function fakeAgentSession(
+  output: string,
+  promptGate?: Promise<void>,
+  onPrompt?: (prompt: string) => void,
+) {
   const listeners = new Set<AgentSessionEventListener>();
   // The reviewer agent type requests the read-only tool surface; the child
   // preflight in bindChildSessionExtensions requires all of them active.
@@ -279,7 +283,8 @@ function fakeAgentSession(output: string, promptGate?: Promise<void>) {
       listeners.add(listener);
       return () => listeners.delete(listener);
     },
-    async prompt() {
+    async prompt(promptValue?: unknown) {
+      onPrompt?.(typeof promptValue === "string" ? promptValue : "");
       await promptGate;
       const assistant = messages.find(
         (message) => message.role === "assistant",
@@ -1097,6 +1102,112 @@ test("replay acceptance verdicts do not create success filesystem side effects",
       false,
     );
     assert.equal(existsSync(join(runDir, "journal.json")), false);
+  }
+});
+
+test("structured agent results survive handoff refs and downstream inputs", async () => {
+  let sessionCreations = 0;
+  let downstreamPrompt = "";
+  const factory: WorkflowAgentSessionFactory = async (options) => {
+    sessionCreations++;
+    if (sessionCreations > 1) {
+      return {
+        session: fakeAgentSession("downstream output", undefined, (prompt) => {
+          downstreamPrompt = prompt;
+        }),
+      };
+    }
+
+    const structuredTool = options?.customTools?.find(
+      (tool) => tool.name === "structured_output",
+    );
+    assert.ok(structuredTool);
+    const session = fakeAgentSession("");
+    const existingTools = session.getAllTools();
+    session.getAllTools = () => [
+      ...existingTools,
+      {
+        name: structuredTool.name,
+        description: structuredTool.description,
+        parameters: structuredTool.parameters,
+        promptGuidelines: structuredTool.promptGuidelines,
+        sourceInfo: {
+          path: "<custom:structured_output>",
+          source: "custom",
+          scope: "temporary",
+          origin: "top-level",
+        },
+      },
+    ];
+    session.getActiveToolNames = () => [
+      ...existingTools.map((tool) => tool.name),
+      structuredTool.name,
+    ];
+    session.getToolDefinition = (name) =>
+      name === structuredTool.name ? structuredTool : undefined;
+    session.prompt = async () => {
+      await structuredTool.execute(
+        "structured-handoff",
+        { verdict: "accepted", score: 7 },
+        new AbortController().signal,
+        () => {},
+        ctx,
+      );
+    };
+    return { session };
+  };
+  __setWorkflowTestAgentSessionFactory(factory);
+
+  try {
+    const result = (await workflow.execute(
+      "e2e-structured-handoff",
+      {
+        script:
+          'export const meta = { name: "structured-handoff" };\n' +
+          'const first = await agent("produce a verdict", { agent_type: "reviewer", schema: { type: "object", properties: { verdict: { type: "string" }, score: { type: "number" } }, required: ["verdict", "score"] } });\n' +
+          'const second = await agent("consume the upstream verdict", { agent_type: "reviewer", inputs: [first.ref] });\n' +
+          "return { firstOk: first.ok, firstRef: first.ref ?? null, secondOk: second.ok, secondOutput: second.output };",
+        wait: true,
+      },
+      undefined,
+      undefined,
+      ctx,
+    )) as { details: { runId?: unknown } };
+
+    const runId = result.details.runId;
+    const runDir = runDirFor(runId);
+    const returned = JSON.parse(
+      readFileSync(join(runDir, "result.json"), "utf8"),
+    ) as {
+      firstOk: unknown;
+      firstRef: unknown;
+      secondOk: unknown;
+      secondOutput: unknown;
+    };
+    assert.equal(returned.firstOk, true);
+    assert.equal(typeof returned.firstRef, "string");
+    assert.equal(returned.secondOk, true);
+    assert.equal(returned.secondOutput, "downstream output");
+    assert.match(downstreamPrompt, /accepted/);
+
+    const persisted = readWorkflowJson(runId);
+    const agents = persisted.agents as Array<{
+      callId?: unknown;
+      state: unknown;
+      resultArtifact?: unknown;
+      resultRef?: unknown;
+      inputCallIds?: unknown;
+    }>;
+    assert.equal(agents.length, 2);
+    assert.equal(agents[0]?.state, "done");
+    assert.equal(agents[0]?.resultArtifact, "agent-results/agent-0001.json");
+    assert.equal(typeof agents[0]?.resultRef, "string");
+    assert.equal(agents[1]?.state, "done");
+    assert.equal(agents[1]?.resultArtifact, "agent-results/agent-0002.json");
+    assert.deepEqual(agents[1]?.inputCallIds, [agents[0]?.callId]);
+    assert.equal(sessionCreations, 2);
+  } finally {
+    __setWorkflowTestAgentSessionFactory(undefined);
   }
 });
 


### PR DESCRIPTION
## Problem

Issue #284 exposed a Windows-specific contract violation in workflow agent result handoffs: a successful child result could be written to disk with a host-native path, but its protocol-visible artifact identity used backslashes and was rejected by the strict handoff registry.

While this PR was under review, upstream independently landed the production correction in [`aa326f9`](https://github.com/openpi-dev/openpi/commit/aa326f9): persisted artifact identities use the explicit POSIX form `agent-results/agent-XXXX.json`, while `writeRunFile()` continues to translate that identity through host `path.join()` for filesystem access.

After rebasing onto current `main`, duplicating that production change would add no value. This PR therefore completes the regression coverage requested by #284 and protects the already-landed behavior.

## Value

The tests lock down the full contract, not just string construction: a structured child result must produce `ok: true`, a canonical handoff `ref`, valid downstream `inputs`, and POSIX artifact identities in persisted `workflow.json` state.

This keeps the handoff and dashboard consumers strict. The tests would fail if a future Windows change reintroduced backslash artifact identities or broke the result-to-ref-to-inputs chain.

## Approach

- Keep upstream's production implementation unchanged.
- Assert the canonical `agent-results/agent-XXXX.json` identity in the artifact persistence test.
- Add an execute-level regression for structured result -> handoff `ref` -> downstream `inputs`.
- Assert both result artifact identities persisted in `workflow.json` use `/`.
- Preserve upstream acceptance replay coverage while resolving the rebase conflict.

## Validation

- `node --test --experimental-strip-types --test-name-pattern "agent result artifacts are complete or fail without leaving a file" tests/extensions/workflows/artifacts.test.ts` - passed on Windows.
- `node --test --experimental-strip-types --test-name-pattern "structured agent results survive handoff refs and downstream inputs" tests/extensions/workflows/execute.e2e.test.ts` - passed on Windows.
- `bunx tsc --noEmit --pretty false` - passed.
- `git diff --check upstream/main...HEAD` - passed.
- `bun run check` reached the formatter after the config-contract and discipline checks passed, then reported 270 repository-wide CRLF diagnostics. The same formatter failure reproduces on a clean `main`; the separate `.gitattributes`/CRLF baseline is documented under the related work in #211 and is outside this PR.
- `bun run test` was attempted on Windows but did not complete: unrelated background-terminal termination tests failed and the runner later stopped producing output, so it was terminated. The focused workflow tests above are green. All three repository CI checks pass on this rebased commit.

## Impact

This PR is now test-only: two workflow test files, no production code, no schema changes, and no changes to tools, permissions, providers, or consumer validation. It completes regression coverage for #284 without reopening or weakening the canonical path implementation already present on `main`.