### PR TITLE
ci: label pull requests by ownership area

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,55 @@
+# Keep this taxonomy focused on stable ownership boundaries. The labeler may
+# apply more than one area label when a pull request crosses those boundaries.
+
+area:workflows:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/workflows/**"
+          - "skills/workflows/**"
+          - "tests/extensions/workflows/**"
+
+area:subagents:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/subagents/**"
+          - "skills/subagents/**"
+          - "tests/extensions/subagents/**"
+
+area:background-terminals:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/background-terminals/**"
+          - "skills/background-terminals/**"
+          - "tests/extensions/background-terminals/**"
+
+area:setup:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/setup/**"
+          - "extensions/shared/setup-*.ts"
+          - "tests/extensions/setup/**"
+          - "SETUP.md"
+
+area:ui:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/file-mutation-display/**"
+          - "extensions/ui-customization/**"
+          - "extensions/user-input-fold/**"
+          - "themes/**"
+          - "assets/**"
+          - "tests/extensions/file-mutation-display/**"
+          - "tests/extensions/ui-customization/**"
+          - "tests/extensions/user-input-fold/**"
+
+area:github:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "tests/github/**"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,23 @@
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    name: Apply area labels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # This privileged event reads configuration from the base branch only.
+      # Never check out or execute code from the pull request in this job.
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
+        with:
+          sync-labels: true
+

--- a/tests/github/automation-workflows.test.ts
+++ b/tests/github/automation-workflows.test.ts
@@ -52,3 +52,30 @@ test("project-specific CI remains defined in this repository", () => {
   assert.match(source, /Background terminals \(Windows\)/u);
   assert.doesNotMatch(source, /openpi-dev\/automation/u);
 });
+
+test("the PR labeler is pinned, least-privileged, and does not execute PR code", () => {
+  const source = workflow("labeler");
+
+  assert.match(source, /^\s*pull_request_target:/mu);
+  assert.match(source, /uses: actions\/labeler@[0-9a-f]{40} # v7\.0\.0/u);
+  assert.match(source, /^\s*pull-requests: write$/mu);
+  assert.match(source, /^\s*contents: read$/mu);
+  assert.match(source, /^\s*sync-labels: true$/mu);
+  assert.doesNotMatch(source, /actions\/checkout|\brun:/u);
+});
+
+test("the PR labeler covers OpenPI's stable ownership boundaries", () => {
+  const source = readFileSync(".github/labeler.yml", "utf8");
+
+  for (const label of [
+    "area:workflows",
+    "area:subagents",
+    "area:background-terminals",
+    "area:setup",
+    "area:ui",
+    "area:github",
+    "documentation",
+  ]) {
+    assert.match(source, new RegExp(`^${label}:`, "mu"));
+  }
+});


### PR DESCRIPTION
## Problem

Pull requests are not consistently classified by the OpenPI area they change. Maintainers must inspect each diff before they can filter, route, or summarize work by ownership boundary.

## Value

Automatic, deterministic area labels make the PR queue easier to scan and filter without adding a third-party service or asking contributors to classify their own changes.

## Approach

- Add the official GitHub Pull Request Labeler, pinned to the reviewed v7.0.0 commit.
- Classify stable OpenPI ownership boundaries: workflows, subagents, background terminals, setup, UI, GitHub infrastructure, and documentation.
- Run on `pull_request_target` so fork PRs can receive labels, while reading only base-branch configuration and never checking out or executing contributor code.
- Grant only `contents: read` and `pull-requests: write` to the labeling job.
- Synchronize configured labels when a PR's changed-file set changes.
- Add repository tests that pin the action contract, permissions, security boundary, and label taxonomy.

## Validation

- `node --test tests/github/automation-workflows.test.ts` — 6 passed.
- `./node_modules/.bin/biome format .` — passed.
- `./node_modules/.bin/biome lint . --error-on-warnings` — passed.
- `node_modules/typescript/bin/tsc --noEmit` — passed.
- `node scripts/run-tests.mjs` — 1,006 passed, 5 failed, 1 skipped. Four existing setup-config process tests exhausted the sandbox's file-watch limit (`EMFILE`), and one subagent backend test could not create Pi session state under `~/.pi` (`EPERM`).
- `bun run check` and `bun run test` were not run because Bun is unavailable in this environment; the installed underlying check and test commands were run directly as listed above.

## Impact

- User-visible behavior: qualifying pull requests receive one or more `area:*` labels and Markdown changes receive `documentation`.
- Model-visible context/tools: None.
- Runtime/lifecycle: None; this is repository automation only.
- Persisted config/data: adds GitHub workflow and label rules; workflow runs update PR label assignments.
- Compatibility/risk: low. The privileged event has a narrow token and cannot execute pull-request code. Required labels already exist in the repository.
