### PR TITLE
docs: adopt knowledge and evidence governance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,14 @@ If those answers are unclear, investigate before adding surface area.
 - Runtime provenance: before diagnosing installed behavior, provider compatibility, a manual Pi smoke, or any UI result, read README section “开发运行时：区分 npm 与当前源码”. Prove both the checkout revision and the single OpenPI source reported by `pi list` before reasoning from source code.
 - Preserve ignored local evidence as user work. Never use `git clean -fdx`; ignored benchmark runs, logs, and harnesses may be the only local copy.
 
+### Knowledge and evidence
+
+- Use GitHub Issues for discussion and work tracking. Preserve a reusable conclusion in the appropriate `docs/` category and link the Issue and record both ways.
+- Keep facts, inferences, recommendations, unknowns, protocols, and validated results distinct. A research recommendation or complete-looking design is not a project constraint without an accepted Decision.
+- Formal Benchmark records must retain frozen source, model, task, and verifier identities; usage accounting; failure classification; limitations; and a verifiable evidence reference.
+- Before publishing or materially revising a governed record, read [`docs/README.md`](docs/README.md) and the relevant category index. Existing legacy documents are not silently reclassified or rewritten.
+- Preserve large or sensitive raw evidence outside the repository under a stable identity. Never bulk-add, move, overwrite, clean, or publish ignored Benchmark assets, credentials, or private Session data.
+
 ## Package configuration contract
 
 - `/openpi-setup [natural-language request]` is the single canonical user-facing configuration entry point. `/my-pi-setup` is a compatibility alias only. Do not add extension-specific setup commands for package-owned choices.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# OpenPI documentation
+
+This directory is the canonical home for durable project knowledge. GitHub Issues remain the public discussion and work-tracking surface; a repository record preserves a reusable conclusion without replacing the Issue history that produced it.
+
+## Choose the record
+
+| Need | Record | Boundary |
+| --- | --- | --- |
+| Discuss a question or track work | GitHub Issue | Context, alternatives, status, and decisions still needed |
+| Explain contribution procedures | [`contributing/`](contributing/) | Current contributor workflow, not architecture or research |
+| Preserve sourced investigation | [`research/`](research/) | Facts, sources, inferences, recommendations, and unknowns |
+| Preserve design exploration | [`design/`](design/) | Alternatives and trade-offs; not an adopted project constraint by itself |
+| Adopt a durable project constraint | [`decisions/`](decisions/) | Accepted choice, rationale, alternatives, consequences, and replacement history |
+| Describe stable runtime structure | [`architecture/`](architecture/) | Current ownership, seams, lifecycle, and authority at a named revision |
+| Publish a formal measurement | [`benchmarks/`](benchmarks/) | Frozen protocol, identities, results, limitations, and evidence references |
+| Describe shipped user behavior | Release notes | Version-specific, user-visible release facts |
+
+Link a durable record to its source Issue and relevant PRs when available. Link the Issue back to the record. The record is a reviewed projection, not a rewrite of the discussion.
+
+## Evidence and adoption are different axes
+
+Research, design, architecture, and Benchmark records may be:
+
+- `draft`: incomplete or not yet checked at the stated boundary;
+- `validated`: checked against the named sources, revision, or evidence receipt;
+- `superseded`: retained for history and linked to its replacement.
+
+Decision records instead use `proposed`, `accepted`, `rejected`, or `superseded`. A validated observation can support a Decision, but it does not adopt the Decision automatically.
+
+New or materially revised governed records should state their status, creation and verification dates, applicable source boundary, related Issues and PRs, and superseding relationship. Existing documents predate this contract and remain legacy records until a scoped review migrates them; their presence does not imply validation under the new policy.
+
+## Evidence boundary
+
+Separate verified facts from interpretation and recommendations. Repository validation proves that a record is well-formed and reachable; it does not prove a Benchmark conclusion, runtime behavior, release, deployment, or public acceptance.
+
+A formal Benchmark publication needs independently reviewable source, model, task, verifier, isolation, accounting, failure, and limitation evidence. A hash alone identifies bytes only when the referenced bytes are retrievable. Keep large JSONL, logs, Sessions, candidate workspaces, caches, credentials, and private settings outside Git under a stable archive identity with bounded receipts.
+
+Historical conclusions are append-only in meaning. Amend a record or mark it `superseded`; do not silently rewrite what an earlier revision claimed.
+
+## Governance
+
+[`Decision 0001`](decisions/0001-documentation-and-evidence-governance.md) adopts this information architecture. Category indexes define local shape without widening that Decision. Changes that alter category ownership, evidence states, or publication gates require a new or superseding Decision.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This directory is the canonical home for durable project knowledge. GitHub Issue
 | --- | --- | --- |
 | Discuss a question or track work | GitHub Issue | Context, alternatives, status, and decisions still needed |
 | Explain contribution procedures | [`contributing/`](contributing/) | Current contributor workflow, not architecture or research |
+| Track an engineering promise and its enforcement | [`disciplines.md`](disciplines.md) | Inventory of adopted or grandfathered constraints and their CI or manual checks; not an adoption path |
 | Preserve sourced investigation | [`research/`](research/) | Facts, sources, inferences, recommendations, and unknowns |
 | Preserve design exploration | [`design/`](design/) | Alternatives and trade-offs; not an adopted project constraint by itself |
 | Adopt a durable project constraint | [`decisions/`](decisions/) | Accepted choice, rationale, alternatives, consequences, and replacement history |
@@ -27,6 +28,8 @@ Research, design, architecture, and Benchmark records may be:
 
 Decision records instead use `proposed`, `accepted`, `rejected`, or `superseded`. A validated observation can support a Decision, but it does not adopt the Decision automatically.
 
+The engineering discipline ledger uses enforcement states (`enforced` or `manual`) and CI reachability (`yes` or `no`). Those fields describe how a promise is checked, not whether it is adopted or whether supporting evidence is validated. Adding an `OP-*` row does not adopt a new durable constraint; new constraints still require accepted Decision provenance. Rows that predate Decision 0001 are grandfathered as legacy constraints while their existing checks remain operational.
+
 New or materially revised governed records should state their status, creation and verification dates, applicable source boundary, related Issues and PRs, and superseding relationship. Existing documents predate this contract and remain legacy records until a scoped review migrates them; their presence does not imply validation under the new policy.
 
 ## Evidence boundary
@@ -39,4 +42,4 @@ Historical conclusions are append-only in meaning. Amend a record or mark it `su
 
 ## Governance
 
-[`Decision 0001`](decisions/0001-documentation-and-evidence-governance.md) adopts this information architecture. Category indexes define local shape without widening that Decision. Changes that alter category ownership, evidence states, or publication gates require a new or superseding Decision.
+[`Decision 0001`](decisions/0001-documentation-and-evidence-governance.md) adopts this information architecture. Category indexes and the discipline ledger describe local shape and enforcement without widening that Decision. Changes that add or remove a durable project constraint, or alter category ownership, evidence states, or publication gates, require a new or superseding Decision.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,7 @@
+# Architecture records
+
+Architecture records describe OpenPI ownership boundaries, lifecycle seams, and runtime contracts at a named source revision and declare their evidence status. Only a `validated` record represents structure checked at its stated boundary. Runtime behavior remains defined by code and current user documentation.
+
+Keep unresolved alternatives and implementation proposals in [`../design/`](../design/). Promote a constraint through an accepted [`Decision`](../decisions/) before treating it as architecture policy.
+
+Each new or materially revised architecture record should identify its evidence status, source revision, affected Pi primitive, current invariants, related Issues and Decisions, and any record it supersedes.

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -1,0 +1,9 @@
+# Benchmark records
+
+This category will hold reusable Benchmark protocols, result templates, and dated formal reports. GitHub Issues remain the public summary and discussion surface.
+
+A protocol is not a result. A passing repository check is not independent validation. A dated report must identify its source, model, thinking level, task and verifier, sample size, isolation, accounting, failure classification, limitations, rerun boundary, and retrievable evidence reference.
+
+Commit only reviewed, credential-free summaries and bounded evidence receipts. Keep large JSONL, logs, Sessions, candidate workspaces, caches, credentials, and private settings outside Git under a stable archive identity.
+
+No formal Benchmark result is published by [`Decision 0001`](../decisions/0001-documentation-and-evidence-governance.md). Protocols, templates, and individual results require separate review.

--- a/docs/decisions/0001-documentation-and-evidence-governance.md
+++ b/docs/decisions/0001-documentation-and-evidence-governance.md
@@ -5,7 +5,7 @@ last-reviewed: 2026-08-29
 applies-to: OpenPI repository documentation from this Decision forward
 owner: OpenPI maintainers
 related-issues: "#198, #277"
-related-prs: none
+related-prs: "#278"
 supersedes: none
 ---
 

--- a/docs/decisions/0001-documentation-and-evidence-governance.md
+++ b/docs/decisions/0001-documentation-and-evidence-governance.md
@@ -1,0 +1,49 @@
+---
+decision-status: accepted
+created: 2026-08-29
+last-reviewed: 2026-08-29
+applies-to: OpenPI repository documentation from this Decision forward
+owner: OpenPI maintainers
+related-issues: "#198, #277"
+related-prs: none
+supersedes: none
+---
+
+# Decision: Documentation and evidence governance
+
+## Context
+
+GitHub Issues currently carry discussion, implementation tracking, research, design proposals, and Benchmark summaries in the same timeline. Reusable conclusions become hard to find, and readers can mistake a recommendation, a successful repository check, or an unavailable local artifact for an adopted or independently verified result.
+
+## Decision
+
+Issues remain the canonical discussion and work-tracking surface. The repository `docs/` tree is the canonical home for reusable research, design history, accepted Decisions, architecture descriptions, contribution procedures, and formal Benchmark records.
+
+Evidence validation and project adoption are separate. Research, design, architecture, and Benchmark records use evidence states; Decision records use adoption states. A recommendation becomes a project constraint only through an accepted Decision.
+
+This policy is forward-only. Existing documents remain legacy records until a scoped review migrates them. No automated rewrite or bulk metadata migration is implied.
+
+## Evidence boundary
+
+This Decision adopts information architecture and publication boundaries. It does not validate any existing Benchmark result, adopt any candidate runtime design, add a documentation validator, or change runtime behavior.
+
+Repository checks may later verify structure and reachability, but they cannot prove the truth of a Benchmark conclusion. Formal results require independently reviewable identities, accounting, failure classification, limitations, and retrievable evidence.
+
+## Alternatives considered
+
+- **Keep reusable conclusions only in Issues:** rejected because conclusions remain difficult to discover and version with code.
+- **Treat every complete design document as authoritative:** rejected because document completeness is not project adoption.
+- **Retrofit every historical document immediately:** rejected because it creates a broad rewrite with weak review provenance.
+- **Publish complete raw evidence in Git:** rejected because logs, Sessions, credentials, caches, and workspaces may be large or sensitive.
+
+## Consequences
+
+- Contributors have one entry point for choosing a durable record.
+- Accepted constraints require explicit Decision provenance.
+- Existing records do not become validated merely because they are indexed.
+- Benchmark protocol, automated validation, and individual result publication can proceed as separate changes with their own evidence gates.
+- Large or sensitive raw artifacts remain outside Git under stable, reviewable identities.
+
+## Amendments
+
+None.

--- a/docs/decisions/0001-documentation-and-evidence-governance.md
+++ b/docs/decisions/0001-documentation-and-evidence-governance.md
@@ -21,6 +21,8 @@ Issues remain the canonical discussion and work-tracking surface. The repository
 
 Evidence validation and project adoption are separate. Research, design, architecture, and Benchmark records use evidence states; Decision records use adoption states. A recommendation becomes a project constraint only through an accepted Decision.
 
+The engineering discipline ledger is an enforcement projection of constraints adopted by a Decision or explicitly retained as grandfathered legacy constraints. Its `enforced` or `manual` status and CI reachability describe how a promise is checked; they do not adopt the promise or validate its evidence. Adding a ledger row alone cannot create a new durable project constraint.
+
 This policy is forward-only. Existing documents remain legacy records until a scoped review migrates them. No automated rewrite or bulk metadata migration is implied.
 
 ## Evidence boundary
@@ -40,6 +42,7 @@ Repository checks may later verify structure and reachability, but they cannot p
 
 - Contributors have one entry point for choosing a durable record.
 - Accepted constraints require explicit Decision provenance.
+- The discipline ledger reports enforcement separately from adoption; rows that predate this Decision remain operational as grandfathered legacy constraints without gaining retroactive Decision provenance.
 - Existing records do not become validated merely because they are indexed.
 - Benchmark protocol, automated validation, and individual result publication can proceed as separate changes with their own evidence gates.
 - Large or sensitive raw artifacts remain outside Git under stable, reviewable identities.

--- a/docs/decisions/0001-documentation-and-evidence-governance.md
+++ b/docs/decisions/0001-documentation-and-evidence-governance.md
@@ -5,7 +5,7 @@ last-reviewed: 2026-08-29
 applies-to: OpenPI repository documentation from this Decision forward
 owner: OpenPI maintainers
 related-issues: "#198, #277"
-related-prs: "#278"
+related-prs: "#278, #290"
 supersedes: none
 ---
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,18 @@
+# Decision records
+
+Decision records capture project choices that constrain future implementation. Research and design records may recommend a choice, but only an accepted Decision adopts it.
+
+## Adoption states
+
+- `proposed`: under review and not authoritative;
+- `accepted`: adopted within the stated scope;
+- `rejected`: considered and explicitly not adopted;
+- `superseded`: historical Decision replaced by a linked successor.
+
+Decision adoption is separate from evidence validation. Record the supporting evidence boundary, credible alternatives, consequences, owner, related Issues and PRs, and replacement relationship.
+
+Start from [`TEMPLATE.md`](TEMPLATE.md).
+
+## Records
+
+- [`0001-documentation-and-evidence-governance.md`](0001-documentation-and-evidence-governance.md) — repository knowledge categories, evidence states, and publication boundaries.

--- a/docs/decisions/TEMPLATE.md
+++ b/docs/decisions/TEMPLATE.md
@@ -1,0 +1,36 @@
+---
+decision-status: proposed
+created: YYYY-MM-DD
+last-reviewed: YYYY-MM-DD
+applies-to: <OpenPI version or source boundary>
+owner: <maintainer or team>
+related-issues: "#<number>"
+related-prs: none
+supersedes: none
+---
+
+# Decision: <short name>
+
+## Context
+
+What problem and evidence require a durable project choice?
+
+## Decision
+
+What constraint is proposed or adopted, and within what scope?
+
+## Evidence boundary
+
+Which facts are validated, which are inferred, and what remains unknown?
+
+## Alternatives considered
+
+Which credible alternatives were evaluated, and why were they not selected?
+
+## Consequences
+
+What becomes easier, harder, required, or explicitly deferred?
+
+## Amendments
+
+Append later changes and link any superseding Decision. Do not silently rewrite the historical choice.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -2,6 +2,8 @@
 
 These documents preserve the research, alternatives, and evaluations that led to the current implementation. Runtime behavior is defined by the code and current user documentation.
 
+These records predate [`Decision 0001`](../decisions/0001-documentation-and-evidence-governance.md) and have not been migrated to its metadata contract. Indexing preserves their history; it does not mark every statement as currently validated or adopted.
+
 - [`TASKS_DESIGN.md`](TASKS_DESIGN.md) — original Session Tasks research and proposal
 - [`TASKS_EVALUATION.md`](TASKS_EVALUATION.md) — multi-model review of that proposal
 - [`BLOG_SESSION_TASKS_DESIGN.md`](BLOG_SESSION_TASKS_DESIGN.md) — narrative account of the design process

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -9,4 +9,5 @@ These records predate [`Decision 0001`](../decisions/0001-documentation-and-evid
 - [`BLOG_SESSION_TASKS_DESIGN.md`](BLOG_SESSION_TASKS_DESIGN.md) — narrative account of the design process
 - [`PI_CONFIGURATION_ECOSYSTEM_RESEARCH.md`](PI_CONFIGURATION_ECOSYSTEM_RESEARCH.md) — configuration ecosystem research
 - [`PI_COMMUNITY_PACKAGE_AUDIT_2026-08-09.md`](PI_COMMUNITY_PACKAGE_AUDIT_2026-08-09.md) — code-grounded comparison of leading community packages
+- [`OPENPI_WORKFLOW_V2_DESIGN_2026-08-23.md`](OPENPI_WORKFLOW_V2_DESIGN_2026-08-23.md) — Pi-native Workflow interface and lifecycle redesign with implementation evidence
 - [`WORKFLOW_INVOCATION_GRAPH.md`](WORKFLOW_INVOCATION_GRAPH.md) — durable invocation facts, same-run handoff refs, reusable operators, and derived graph semantics

--- a/docs/disciplines.md
+++ b/docs/disciplines.md
@@ -1,9 +1,22 @@
 # Engineering disciplines
 
-This ledger is append-only. Add a new `OP-*` row at the end; do not renumber,
-rewrite, or delete an earlier row. The checker enforces consecutive IDs and
-verifies every referenced command. `CI=yes` means the command is directly or
-transitively reached from the workflow's `bun run check` or `bun run test`.
+This ledger is an enforcement inventory, not a second way to adopt project
+constraints. An `OP-*` row records a promise that an accepted Decision already
+adopted or that the repository explicitly carries as a grandfathered legacy
+constraint. Adding a row alone does not adopt a new durable constraint.
+
+The ledger is append-only. Add a new `OP-*` row at the end; do not renumber,
+rewrite, or delete an earlier row. New durable constraints require accepted
+Decision provenance in the change that adds the row. `OP-01` through `OP-12`
+predate Decision 0001 and are grandfathered as legacy constraints; their checks
+remain operational without retroactively manufacturing Decision provenance.
+
+The checker enforces consecutive IDs and verifies every referenced command.
+`Status=enforced` means a repository check covers the promise; `Status=manual`
+means contributors must verify it outside repository-only state. `CI=yes` means
+the command is directly or transitively reached from the workflow's
+`bun run check` or `bun run test`. These fields describe enforcement and CI
+reachability, not adoption or evidence-validation state.
 
 | ID | Promise | Status | CI | Check |
 | --- | --- | --- | --- | --- |

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,12 @@
+# Research index
+
+Research records preserve sourced investigation and distinguish observations, inferences, recommendations, and unknowns. They are not accepted Decisions or proof of runtime behavior by themselves.
+
+## Legacy records
+
+The following records predate [`Decision 0001`](../decisions/0001-documentation-and-evidence-governance.md). They remain useful historical sources but have not been migrated to the new metadata contract as part of this change:
+
+- [`CLAUDE_CODE_WORKFLOW_FANOUT_POLICY_2026-08-23.md`](CLAUDE_CODE_WORKFLOW_FANOUT_POLICY_2026-08-23.md) — official-source research on dynamic fan-out and bounded execution.
+- [`CLAUDE_CODE_WORKFLOW_RUNTIME_CONTRACT_2026-08-23.md`](CLAUDE_CODE_WORKFLOW_RUNTIME_CONTRACT_2026-08-23.md) — version-scoped Workflow contract interview and evidence boundary.
+
+When research changes a project constraint, preserve the adopted choice in a Decision. Amend or supersede a historical record rather than silently rewriting its original conclusion.


### PR DESCRIPTION
## Replacement

Supersedes #278. The original protected source branch could not be linearly rebased after `main` advanced because repository rules correctly forbid force-pushes. This replacement preserves a linear history from current `main@25fd64d` and includes the post-review discipline-ledger integration.

Related to #198 and #277.

## Problem

Reusable research, designs, Decisions, architecture records, and Benchmark results need a canonical repository home without turning Issues, repository checks, or historical documents into false evidence or adoption claims. Current `main` also has an append-only engineering discipline ledger whose enforcement status must not become a second authority for adopting project constraints.

## Value

Contributors get one discoverable information architecture and explicit boundaries between discussion, evidence validation, Decision adoption, enforcement, runtime acceptance, and publication. Historical records remain available without being silently upgraded.

## Approach

- Add root and category documentation indexes plus Decision 0001 and a Decision template.
- Keep GitHub Issues as the discussion and work-tracking source.
- Separate evidence states from Decision adoption states.
- Define `docs/disciplines.md` as an enforcement projection, not an adoption path: new durable constraints still require accepted Decision provenance.
- Grandfather OP-01 through OP-12 only for missing retroactive Decision provenance while preserving their current checks and CI obligations.
- Keep the policy forward-only; do not bulk-migrate or validate historical records.
- Add the governance contract to AGENTS.md without adding a runtime or documentation validator.

## Validation

- `bun run check` — passed.
- `bun run test` — 1011 passed, 1 platform skip, 0 failed.
- Vitest — 30 passed.
- `git diff --check` — passed.
- Two independent final reviews found no actionable findings after the discipline-ledger integration.

## Impact

- Runtime, package, configuration, permissions, and persisted data: none.
- Model and maintainer workflow: governed records must distinguish evidence, adoption, and enforcement and follow category indexes.
- Benchmark publication remains fail-closed and requires retrievable, independently reviewable evidence.
- Existing discipline checks remain operational; no OP row or validator is removed or weakened.
