### PR TITLE
fix(repo): enforce LF checkouts across platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,17 @@ Thank you for contributing to OpenPI. Start with the guide that matches your cha
 The contribution guides are recommendations for the current repository workflow. Repository administrators must configure GitHub settings separately before those recommendations become enforced policy.
 
 Before opening a pull request, run the checks documented in the guide and use the pull request template in `.github/PULL_REQUEST_TEMPLATE.md`.
+
+## Line endings
+
+The repository enforces LF line endings for text files through the root `.gitattributes` file. This keeps checkouts identical on Windows, macOS, and Linux regardless of a user's global `core.autocrlf` setting.
+
+After pulling this policy into an existing checkout, first confirm that the worktree is clean, then re-check out tracked files so Git applies the attributes:
+
+```bash
+git status --short
+git restore --source=HEAD --worktree -- .
+git ls-files --eol
+```
+
+The final command should report `w/lf` for tracked text files. If the worktree is not clean, commit or stash the changes before running the restore command.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,13 @@ Before opening a pull request, run the checks documented in the guide and use th
 
 The repository enforces LF line endings for text files through the root `.gitattributes` file. This keeps checkouts identical on Windows, macOS, and Linux regardless of a user's global `core.autocrlf` setting.
 
-After pulling this policy into an existing checkout, first confirm that the worktree is clean, then re-check out tracked files so Git applies the attributes:
+Pulling this policy into an existing checkout can leave CRLF files unchanged, even when `git status` is clean. To get an LF checkout, keep the existing directory intact and clone into a new, unused directory from its parent directory:
 
 ```bash
-git status --short
-git restore --source=HEAD --worktree -- .
-git ls-files --eol
+git clone https://github.com/openpi-dev/openpi.git openpi-lf
+git -C openpi-lf ls-files --eol
 ```
 
-The final command should report `w/lf` for tracked text files. If the worktree is not clean, commit or stash the changes before running the restore command.
+The cloned revision must include this policy. The final command should report `w/lf` for tracked text files with line endings; files without line endings can report `w/none`, and binary files are excluded from this policy.
+
+A fresh clone only includes commits available on the remote. It does not copy unpushed commits, uncommitted changes, untracked files, or ignored files such as local configuration and evidence. Keep the old checkout until you have deliberately transferred any local work you need.


### PR DESCRIPTION
Closes #291

## Problem

仓库此前没有 `.gitattributes` 或其他仓库级换行策略，工作树中的行尾由开发者机器的 Git 配置决定。

在 Windows 且系统 Git 使用常见配置 `core.autocrlf=true` 时，最新 `main` 的干净 checkout 会出现：

```text
323 files: i/lf w/crlf
0 files:   i/lf w/lf
```

`i/lf w/crlf` 表示索引保存 LF，但工作树实际使用 CRLF。Git 比较时会自动归一化，因此 `git status` 仍显示干净，问题很难从工作区状态中发现。

这会直接破坏仓库的本地验证契约。Biome 按实际工作树字节检查格式，因此一个没有源码修改、`git status` 干净的 Windows checkout 会在 `bun run format:check` 中报告约 270 个格式错误，建议改动基本都是删除行尾的 `\r`。Windows 贡献者因而无法在干净 checkout 上可靠执行仓库要求的 `bun run check`，而自动格式化还可能产生覆盖全仓库的换行噪声。

本问题与 #69 中用户输入包含 CRLF 时 fenced Markdown 的解析问题不同。本 PR 只处理仓库源码的 checkout 策略。

## Value

本修复让仓库自身成为换行策略的来源，而不再依赖每位贡献者的全局 Git 配置：

- Windows、macOS 和 Linux 获得一致的文本文件工作树字节；
- Windows 的干净 checkout 可以直接通过 Biome 格式检查；
- 避免自动格式化产生全仓库换行重写，减少无意义 diff 和 review 成本；
- 提高文本测试、构建输入和 npm 发布输入的跨平台可重复性；
- 避免 `git status` 干净但格式检查失败的隐蔽故障。

## Approach

在仓库根目录增加：

```gitattributes
* text=auto eol=lf
```

这条规则要求 Git 将识别为文本的文件以 LF 写入工作树，同时继续通过 `text=auto` 区分文本和二进制文件。

本 PR 没有提交全仓库换行重写，因此不会引入源码内容层面的噪声 diff。提交只包含：

- 新增根目录 `.gitattributes`；
- 在 `CONTRIBUTING.md` 中记录保留旧目录、clone 到新目录的迁移与验证步骤。

如果后续出现确实需要 CRLF 的 Windows 专用文件，可以针对具体路径增加更窄的属性规则。

## Validation

验证环境为 Windows，系统 Git 配置 `core.autocrlf=true`。

属性解析：

```text
README.md: text: auto
README.md: eol: lf
CONTRIBUTING.md: text: auto
CONTRIBUTING.md: eol: lf
package.json: text: auto
package.json: eol: lf
```

应用策略并重新生成当前工作树后：

```text
w/crlf=0
w/lf=323
```

使用包含本 PR 提交的隔离 checkout，在 `core.autocrlf=true` 下验证：

```text
w/crlf=0
w/lf=324
```

仓库检查：

```text
bun run check
✓ config contract
✓ discipline ledger
✓ format:check: Checked 270 files. No fixes applied.
✓ lint: Checked 270 files. No fixes applied.
✓ typecheck
```

`bun run check` 完整通过。

### Windows 全量测试说明

本地执行 `bun run test` 时，完整测试集中的三个 Windows 进程终止测试出现了间歇性失败：

```text
kill settles a never-exiting process as killed and resolves after settle; repeat kill is a no-op
concurrent overlapping multi-id kills observe each settlement exactly once
taskkill terminates a Windows descendant process tree
```

本 PR 不修改运行时代码、进程管理代码或测试代码，这些失败也不经过 `.gitattributes` 或贡献文档的代码路径。

进一步隔离验证结果：

- 三个测试分别单独运行：全部通过；
- 三个测试在同一命令中运行：全部通过；
- 相关 `background-terminals` 测试串行运行：全部通过；
- 失败仅在 Windows 全量测试并行运行多个真实子进程和 `taskkill /T` 清理流程时出现。

这些测试会真实创建长时间运行的 Node 子进程，并在固定 teardown 时间窗口内调用 `taskkill`、等待进程树退出和触发 settlement。Node test runner 并行执行多个测试文件时，Windows 的进程调度和清理时序会使这些严格时间窗口产生竞争。

因此这里没有把 `bun run test` 标记为通过。现有证据表明这是 Windows 全量并行测试的既有时序稳定性问题，而不是本 PR 引入的行为回归。为保持本 PR 聚焦，本次没有夹带测试基础设施改动；相关测试的 Windows 并发控制适合独立处理。

## Impact

- 用户可见行为：文本文件在所有平台统一以 LF 检出。
- 模型可见上下文或工具：无变化。
- 运行时与生命周期：无变化。
- 持久化配置或数据：无变化。
- 兼容性：覆盖用户全局 `core.autocrlf` 对本仓库文本 checkout 的影响。
- 风险：低。二进制文件仍由 `text=auto` 识别，确需 CRLF 的文件可以增加路径级例外。
- Diff 范围：仅 `.gitattributes` 和 `CONTRIBUTING.md`，没有源码内容重写。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on the project’s LF line-ending policy.
  * Included steps for safely normalizing existing checkouts and verifying line endings.

* **Chores**
  * Standardized tracked text files to use LF line endings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Maintainer revision and validation — 2026-08-31

Final head: `9bb796e4a9d3abc2ecfcc3424c19ceb320ceba47`, rebased onto `main@f474f60fb5305a9053609aa0ab569bc22ab951ac`.

- 修正文档中的迁移步骤：已复现旧 CRLF checkout 即使 `git status` 干净，普通 `git restore --source=HEAD --worktree -- .` 也不会强制重写文件。现在建议保留旧目录、clone 到一个未使用的新目录；明确未推送提交、未提交改动、未跟踪/忽略文件不会自动迁移。没有添加脚本或运行时机制。
- 最终 diff 仍仅为 `.gitattributes` 与 `CONTRIBUTING.md`，一行原生 Git 策略不变，无源码重写。
- 本次本地环境：macOS、Node 24.18.0、Bun 1.3.14。`bun install --frozen-lockfile`、`bun run check`、`bun run test` 均通过：Node 1086 passed / 1 platform skip / 0 failed；Vitest 30 passed。
- 从最终 head 创建全新隔离 clone（`core.autocrlf=true`）：334 个文本文件均为 `i/lf w/lf`，0 个 `w/crlf`，2 个二进制文件字节哈希与 Git blob 一致；新 clone 格式检查 278 files passed，工作树干净。旧 CRLF 复现目录保留不动。
- 独立 Standards 与 Spec 复核均为 0 项发现。

上述本次验证不是原生 Windows 全量测试验收；前文作者的 Windows 历史验证与失败说明保留。新 head 的 GitHub CI 与实际合并状态另行确认。
