### PR TITLE
fix(test): isolate Windows background terminal tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,6 @@ jobs:
             "extensions/background-terminals/manager.test.ts"
           }
           node --test --experimental-strip-types $testPath
+      - name: Test Windows full-suite isolation
+        timeout-minutes: 5
+        run: bun run test

--- a/scripts/node-test-groups.d.mts
+++ b/scripts/node-test-groups.d.mts
@@ -1,0 +1,4 @@
+export function partitionNodeTestsByPlatform(
+  files: string[],
+  platform?: NodeJS.Platform,
+): { parallel: string[]; serial: string[] };

--- a/scripts/node-test-groups.mjs
+++ b/scripts/node-test-groups.mjs
@@ -1,0 +1,33 @@
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+const backgroundTerminalsRoot = resolve(
+  "tests",
+  "extensions",
+  "background-terminals",
+);
+
+function isBackgroundTerminalsTest(file) {
+  const relativePath = relative(backgroundTerminalsRoot, file);
+  return (
+    relativePath !== "" &&
+    relativePath !== ".." &&
+    !relativePath.startsWith(`..${sep}`) &&
+    !isAbsolute(relativePath)
+  );
+}
+
+export function partitionNodeTestsByPlatform(
+  files,
+  platform = process.platform,
+) {
+  if (platform !== "win32") {
+    return { parallel: files, serial: [] };
+  }
+
+  const parallel = [];
+  const serial = [];
+  for (const file of files) {
+    (isBackgroundTerminalsTest(file) ? serial : parallel).push(file);
+  }
+  return { parallel, serial };
+}

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 import { discoverTestFiles } from "./discover-tests.mjs";
+import { partitionNodeTestsByPlatform } from "./node-test-groups.mjs";
 
 const files = discoverTestFiles(resolve("tests"));
 const nodeTests = files.filter((file) => file.endsWith(".test.ts"));
@@ -12,13 +13,29 @@ if (nodeTests.length === 0 || vitestTests.length === 0) {
   );
 }
 
-const nodeResult = spawnSync(
-  process.execPath,
-  ["--test", "--experimental-strip-types", ...nodeTests],
-  { stdio: "inherit" },
-);
-if (nodeResult.status !== 0) {
-  process.exit(nodeResult.status ?? 1);
+function runNodeTests(files, options = []) {
+  if (files.length === 0) return 0;
+  const result = spawnSync(
+    process.execPath,
+    ["--test", "--experimental-strip-types", ...options, ...files],
+    { stdio: "inherit" },
+  );
+  return result.status ?? 1;
+}
+
+const nodeTestGroups = partitionNodeTestsByPlatform(nodeTests);
+const parallelNodeResult = runNodeTests(nodeTestGroups.parallel);
+if (parallelNodeResult !== 0) {
+  process.exit(parallelNodeResult);
+}
+
+// Windows process-tree tests must not overlap unrelated Node test files.
+// Keep the rest of the suite on Node's default file-level concurrency.
+const serialNodeResult = runNodeTests(nodeTestGroups.serial, [
+  "--test-concurrency=1",
+]);
+if (serialNodeResult !== 0) {
+  process.exit(serialNodeResult);
 }
 
 // Invoke the CLI module through Node instead of the package-manager shim.

--- a/tests/extensions/file-mutation-display/render.test.ts
+++ b/tests/extensions/file-mutation-display/render.test.ts
@@ -65,7 +65,7 @@ const fixtures: Array<{
       content: [{ type: "text", text: "one\ntwo" }],
       details: undefined,
     },
-    success: /Read\s+src\/long-file\.ts:10-29/,
+    success: /Read\s+src[\\/]long-file\.ts:10-29/,
   },
   {
     name: "bash",

--- a/tests/extensions/file-search/index.spec.ts
+++ b/tests/extensions/file-search/index.spec.ts
@@ -232,17 +232,19 @@ it.effect("binary resolution: fdfind is accepted as a system fd", () =>
 
 it.effect("binary resolution: an existing cached binary is used silently", () =>
   Effect.gen(function* () {
-    const env = makeEnv({ available: ["/cache/bin/rg"] });
+    const binDir = join("/cache", "bin");
+    const cachedBinary = join(binDir, "rg");
+    const env = makeEnv({ available: [cachedBinary] });
     const resolved = yield* resolveBinary(
       TOOL_SPECS.rg,
-      "/cache/bin",
+      binDir,
       darwinArm,
       env,
     );
 
     assert.deepEqual(resolved, {
       tool: "rg",
-      command: "/cache/bin/rg",
+      command: cachedBinary,
       source: "cached",
     });
     assert.equal(env.installs.length, 0);
@@ -253,16 +255,17 @@ it.effect(
   "binary resolution: missing everywhere triggers exactly one install",
   () =>
     Effect.gen(function* () {
+      const binDir = join("/repo", "bin");
       const env = makeEnv({ available: [] });
       const resolved = yield* resolveBinary(
         TOOL_SPECS.rg,
-        "/repo/bin",
+        binDir,
         darwinArm,
         env,
       );
 
       assert.equal(resolved.source, "installed");
-      assert.equal(resolved.command, "/repo/bin/rg");
+      assert.equal(resolved.command, join(binDir, "rg"));
       assert.equal(env.installs.length, 1);
       assert.match(
         env.installs[0].url,

--- a/tests/extensions/git-info/index.test.ts
+++ b/tests/extensions/git-info/index.test.ts
@@ -27,8 +27,8 @@ interface RegisteredCommand {
   handler: (args: string, ctx: ExtensionContext) => Promise<void>;
 }
 
-test("automatic refresh stays local until /pr explicitly requests GitHub data", async () => {
-  const root = mkdtempSync(join(tmpdir(), "git-info-explicit-pr-"));
+test("automatic refresh with a spaced fixture path stays local until /pr explicitly requests GitHub data", async () => {
+  const root = mkdtempSync(join(tmpdir(), "git info explicit pr-"));
   const bin = join(root, "bin");
   const callLog = join(root, "gh-calls.log");
   mkdirSync(bin);
@@ -101,7 +101,7 @@ printf '%s\\n' '{"number":42,"url":"https://example.test/pr/42","state":"OPEN","
   if (isWindows) {
     process.env.NODE_OPTIONS = [
       previousNodeOptions,
-      `--require=${commandRunner}`,
+      `--require=${JSON.stringify(commandRunner)}`,
     ]
       .filter(Boolean)
       .join(" ");

--- a/tests/extensions/git-info/index.test.ts
+++ b/tests/extensions/git-info/index.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
   chmodSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -9,7 +10,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import test from "node:test";
 import type {
   ExtensionAPI,
@@ -32,10 +33,46 @@ test("automatic refresh stays local until /pr explicitly requests GitHub data", 
   const callLog = join(root, "gh-calls.log");
   mkdirSync(bin);
 
-  const gitPath = join(bin, "git");
-  writeFileSync(
-    gitPath,
-    `#!/bin/sh
+  const isWindows = process.platform === "win32";
+  const gitPath = join(bin, isWindows ? "git.exe" : "git");
+  const ghPath = join(bin, isWindows ? "gh.exe" : "gh");
+  const commandRunner = join(root, "command-runner.cjs");
+  if (isWindows) {
+    // Direct Node spawning does not resolve .cmd fixtures without a shell, so
+    // use copied Node executables with a per-process command shim instead.
+    writeFileSync(
+      commandRunner,
+      `const { appendFileSync } = require("node:fs");
+const command = /[\\\\/]git\\.exe$/i.test(process.execPath)
+  ? "git"
+  : /[\\\\/]gh\\.exe$/i.test(process.execPath)
+    ? "gh"
+    : null;
+const args = [
+  ...(process.argv[1]?.split(/[\\\\/]/).pop() ? [process.argv[1].split(/[\\\\/]/).pop()] : []),
+  ...process.argv.slice(2),
+];
+if (command === "git") {
+  const key = \`\${args[0] ?? ""} \${args[1] ?? ""}\`;
+  if (key === "rev-parse --is-inside-work-tree") process.stdout.write("true\\n");
+  else if (key === "branch --show-current") process.stdout.write("main\\n");
+  else if (key === "rev-parse --short") process.stdout.write("abc123\\n");
+  else if (key === "status --porcelain=v1") process.stdout.write(" M local.ts\\n?? new.ts\\n");
+  else process.exitCode = 2;
+  process.exit();
+} else if (command === "gh") {
+  appendFileSync(process.env.GH_CALL_LOG, args.join(" ") + "\\n");
+  process.stdout.write("{\\"number\\":42,\\"url\\":\\"https://example.test/pr/42\\",\\"state\\":\\"OPEN\\",\\"isDraft\\":false}\\n");
+  process.exit();
+}
+`,
+    );
+    copyFileSync(process.execPath, gitPath);
+    copyFileSync(process.execPath, ghPath);
+  } else {
+    writeFileSync(
+      gitPath,
+      `#!/bin/sh
 case "$1 $2" in
   "rev-parse --is-inside-work-tree") echo true ;;
   "branch --show-current") echo main ;;
@@ -44,23 +81,31 @@ case "$1 $2" in
   *) exit 2 ;;
 esac
 `,
-  );
-  chmodSync(gitPath, 0o755);
-
-  const ghPath = join(bin, "gh");
-  writeFileSync(
-    ghPath,
-    `#!/bin/sh
+    );
+    chmodSync(gitPath, 0o755);
+    writeFileSync(
+      ghPath,
+      `#!/bin/sh
 printf '%s\\n' "$*" >> "$GH_CALL_LOG"
 printf '%s\\n' '{"number":42,"url":"https://example.test/pr/42","state":"OPEN","isDraft":false}'
 `,
-  );
-  chmodSync(ghPath, 0o755);
+    );
+    chmodSync(ghPath, 0o755);
+  }
 
   const previousPath = process.env.PATH;
   const previousLog = process.env.GH_CALL_LOG;
-  process.env.PATH = `${bin}:${previousPath ?? ""}`;
+  const previousNodeOptions = process.env.NODE_OPTIONS;
+  process.env.PATH = `${bin}${delimiter}${previousPath ?? ""}`;
   process.env.GH_CALL_LOG = callLog;
+  if (isWindows) {
+    process.env.NODE_OPTIONS = [
+      previousNodeOptions,
+      `--require=${commandRunner}`,
+    ]
+      .filter(Boolean)
+      .join(" ");
+  }
 
   const hooks = new Map<
     string,
@@ -110,7 +155,16 @@ printf '%s\\n' '{"number":42,"url":"https://example.test/pr/42","state":"OPEN","
 
   try {
     await hooks.get("session_start")?.({}, ctx);
-    const local = await localPublished;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const local = await Promise.race([
+      localPublished,
+      new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(
+          () => reject(new Error("Timed out waiting for local git info")),
+          5_000,
+        );
+      }),
+    ]).finally(() => clearTimeout(timeoutHandle));
     assert.equal(local.branch, "main");
     assert.equal(local.changedFiles, 2);
     assert.equal(local.pullRequest, null);
@@ -127,6 +181,8 @@ printf '%s\\n' '{"number":42,"url":"https://example.test/pr/42","state":"OPEN","
     process.env.PATH = previousPath;
     if (previousLog === undefined) delete process.env.GH_CALL_LOG;
     else process.env.GH_CALL_LOG = previousLog;
+    if (previousNodeOptions === undefined) delete process.env.NODE_OPTIONS;
+    else process.env.NODE_OPTIONS = previousNodeOptions;
     rmSync(root, { recursive: true, force: true });
   }
 });

--- a/tests/extensions/sessions/git-stats.test.ts
+++ b/tests/extensions/sessions/git-stats.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { mkdtemp, mkdir, rm, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import test from "node:test";
 import { createSessionStatsLoader } from "../../../extensions/sessions/git-stats.ts";
 import type { SessionInfoLike } from "../../../extensions/sessions/sessions.ts";
@@ -105,6 +105,7 @@ test("overlapping viewport work is retained while work that leaves is cancelled"
   });
   const loader = createSessionStatsLoader({
     maxConcurrency: 4,
+    canonicalizeCwd: async (cwd) => cwd,
     runGit: (args, cwd, signal) => {
       const id = `${cwd}:${args[0]}`;
       started.push(id);
@@ -140,7 +141,8 @@ test("overlapping viewport work is retained while work that leaves is cancelled"
 
   assert.equal(aborted.length, 4);
   assert.equal(
-    started.filter((entry) => entry.startsWith("/tmp/project-2:")).length,
+    started.filter((entry) => entry.startsWith(`${resolve("/tmp/project-2")}:`))
+      .length,
     2,
     "overlapping work must not restart",
   );
@@ -219,7 +221,11 @@ test("real and symlink workspace paths share one canonical latest bucket", async
   const alias = join(root, "alias");
   try {
     await mkdir(workspace);
-    await symlink(workspace, alias);
+    await symlink(
+      workspace,
+      alias,
+      process.platform === "win32" ? "junction" : "dir",
+    );
     const [newest, older] = makeSessions(2).map((entry, index) => ({
       ...entry,
       cwd: index === 0 ? workspace : alias,

--- a/tests/extensions/sessions/preview-loader.test.ts
+++ b/tests/extensions/sessions/preview-loader.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { appendFileSync, renameSync } from "node:fs";
+import { appendFileSync, renameSync, writeFileSync } from "node:fs";
 import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -399,10 +399,10 @@ for (const version of [1, 3]) {
         : [header(3), message("m1", null, "user", "replaced")];
     const fixture = await writeSession(originalEntries);
     const replacementPath = join(fixture.directory, "replacement.jsonl");
-    await writeFile(
-      replacementPath,
-      `${replacementEntries.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
-    );
+    const replacementContent = `${replacementEntries
+      .map((entry) => JSON.stringify(entry))
+      .join("\n")}\n`;
+    await writeFile(replacementPath, replacementContent);
     t.after(() => rm(fixture.directory, { recursive: true, force: true }));
 
     let replaced = false;
@@ -411,7 +411,13 @@ for (const version of [1, 3]) {
         onRead: () => {
           if (replaced) return;
           replaced = true;
-          renameSync(replacementPath, fixture.path);
+          if (process.platform === "win32") {
+            // Windows rejects rename-over-open. An in-place replacement still
+            // exercises the loader's changed-file rejection on that platform.
+            writeFileSync(fixture.path, `${replacementContent}\n`);
+          } else {
+            renameSync(replacementPath, fixture.path);
+          }
         },
       }),
       /changed while preview was loading/,

--- a/tests/extensions/shared/worktree.test.ts
+++ b/tests/extensions/shared/worktree.test.ts
@@ -554,7 +554,12 @@ describe("worktree lifecycle", () => {
         `child ${index}\n`,
       );
     }
-    assert.equal(fs.readFileSync(path.join(repo, "a.txt"), "utf8"), "hello\n");
+    assert.equal(
+      fs
+        .readFileSync(path.join(repo, "a.txt"), "utf8")
+        .replaceAll("\r\n", "\n"),
+      "hello\n",
+    );
 
     for (const worktree of worktrees) {
       if (!worktree) continue;
@@ -577,10 +582,19 @@ describe("worktree lifecycle", () => {
     });
     assert.ok(inner.ok);
     if (!inner.ok) return;
-    assert.equal(
-      // realpath because git resolves symlinks and macOS tmpdirs are one.
-      fs.realpathSync(path.dirname(path.dirname(inner.worktree.path))),
-      fs.realpathSync(path.join(repo, ".git")),
+    const worktreeContainer = fs.statSync(
+      path.dirname(path.dirname(inner.worktree.path)),
+    );
+    const commonGitDirectory = fs.statSync(path.join(repo, ".git"));
+    assert.deepEqual(
+      {
+        dev: worktreeContainer.dev,
+        ino: worktreeContainer.ino,
+      },
+      {
+        dev: commonGitDirectory.dev,
+        ino: commonGitDirectory.ino,
+      },
     );
 
     git(repo, "worktree", "remove", "--force", inner.worktree.path);

--- a/tests/extensions/subagents/agent-types.test.ts
+++ b/tests/extensions/subagents/agent-types.test.ts
@@ -338,7 +338,7 @@ test("a project agent type overrides the global one of the same name", async () 
     // Global replaces the built-in, then the trusted project replaces global.
     const messages = diagnostics.map((entry) => entry.message).join("\n");
     assert.match(messages, /from built-in:explorer/);
-    assert.match(messages, /from .*agent\/agents\/explorer\.md/);
+    assert.match(messages, /from .*agent[\\/]agents[\\/]explorer\.md/);
   });
 });
 
@@ -577,7 +577,7 @@ Body.
   assert.match(messages, /unrecognized tool "gerp"/);
 });
 
-test("a symlinked agent type is discovered like a real file", async () => {
+test("a symlinked agent type is discovered like a real file", async (t) => {
   // These commonly live in a dotfiles repo and are symlinked into place — the
   // same shape this user's own ~/.pi/agent/skills uses. `isFile()` is false
   // for a symlink, so the type simply never appeared, with no diagnostic.
@@ -586,10 +586,21 @@ test("a symlinked agent type is discovered like a real file", async () => {
     const real = path.join(root, "dotfiles");
     await mkdir(real, { recursive: true });
     await writeFile(path.join(real, "explore.md"), VALID);
-    await symlink(
-      path.join(real, "explore.md"),
-      path.join(agentDir, "agents", "explore.md"),
-    );
+    try {
+      await symlink(
+        path.join(real, "explore.md"),
+        path.join(agentDir, "agents", "explore.md"),
+      );
+    } catch (error) {
+      if (
+        process.platform === "win32" &&
+        (error as NodeJS.ErrnoException).code === "EPERM"
+      ) {
+        t.skip("Windows file symlinks require Developer Mode or elevation");
+        return;
+      }
+      throw error;
+    }
 
     const { agentTypes } = loadAgentTypes({
       agentDir,
@@ -611,7 +622,11 @@ test("a symlink pointing at a directory is still skipped", async () => {
     const { agentDir, cwd } = await seed(root, {});
     const dir = path.join(root, "notafile");
     await mkdir(dir, { recursive: true });
-    await symlink(dir, path.join(agentDir, "agents", "broken.md"));
+    await symlink(
+      dir,
+      path.join(agentDir, "agents", "broken.md"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
 
     const { agentTypes } = loadAgentTypes({
       agentDir,

--- a/tests/extensions/subagents/result-artifact.test.ts
+++ b/tests/extensions/subagents/result-artifact.test.ts
@@ -139,7 +139,9 @@ test("content-addressed artifacts are exact, private, and reusable", async () =>
 
     assert.equal(first, second);
     assert.equal(await readFile(first, "utf8"), content);
-    assert.equal((await lstat(first)).mode & 0o777, 0o600);
+    if (process.platform !== "win32") {
+      assert.equal((await lstat(first)).mode & 0o777, 0o600);
+    }
     assert.equal(path.basename(first).length, 68);
   } finally {
     await rm(agentDir, { recursive: true, force: true });
@@ -150,7 +152,11 @@ test("artifact persistence refuses a symlinked cache component", async () => {
   const agentDir = await mkdtemp(path.join(tmpdir(), "openpi-result-symlink-"));
   const outside = await mkdtemp(path.join(tmpdir(), "openpi-result-outside-"));
   try {
-    await symlink(outside, path.join(agentDir, "cache"));
+    await symlink(
+      outside,
+      path.join(agentDir, "cache"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
     assert.throws(
       () => persistResultArtifact(agentDir, "do not write outside"),
       /Unsafe result artifact directory/,

--- a/tests/extensions/subagents/transcript.test.ts
+++ b/tests/extensions/subagents/transcript.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import test from "node:test";
 import {
   defineTool,
@@ -269,7 +270,7 @@ test("tool argument summaries relativize paths inside the child cwd", () => {
   const cwd = "/repo";
   assert.equal(
     summarizeToolArgs("read", '{"path":"/repo/src/a.ts"}', cwd),
-    "src/a.ts",
+    path.join("src", "a.ts"),
   );
   assert.equal(
     summarizeToolArgs("rg", '{"pattern":"foo","path":"/repo/ext"}', cwd),

--- a/tests/extensions/web/index.test.ts
+++ b/tests/extensions/web/index.test.ts
@@ -83,7 +83,10 @@ function harness(
       assert.equal(spawnOptions.env.INIT_CWD, undefined);
       assert.equal(spawnOptions.env.PI_SESSION_ID, undefined);
       assert.equal(spawnOptions.env.PI_SESSION_FILE, undefined);
-      assert.equal(spawnOptions.env.PATH, process.env.PATH);
+      const childPath = Object.entries(spawnOptions.env).find(
+        ([name]) => name.toLowerCase() === "path",
+      )?.[1];
+      assert.equal(childPath, process.env.PATH);
       assert.equal(spawnOptions.shell, false);
       assert.equal(spawnOptions.stdio, "inherit");
       const child = new FakeWebProcess();

--- a/tests/extensions/workflows/artifacts.test.ts
+++ b/tests/extensions/workflows/artifacts.test.ts
@@ -302,7 +302,7 @@ test("a dependent artifact write failure cannot leave the prior running manifest
 
     assert.throws(
       () => persistWorkflowJson(directory, details),
-      /EISDIR|directory/i,
+      /EISDIR|EPERM|directory/i,
     );
 
     const stored = JSON.parse(

--- a/tests/extensions/workflows/dashboard.test.ts
+++ b/tests/extensions/workflows/dashboard.test.ts
@@ -405,7 +405,11 @@ test("retained projections without session metadata keep current-session runs vi
   assert.equal(entry.details, details);
 });
 test("restored run directories require a generated safe id", () => {
-  writeRun("wf_\u001b]52;c;clipboard\u0007", 9_000);
+  const unsafeRunId =
+    process.platform === "win32"
+      ? "wf_not-generated-clipboard"
+      : "wf_\u001b]52;c;clipboard\u0007";
+  writeRun(unsafeRunId, 9_000);
   const runIds = loadRunEntries(new Map(), SESSION, new Set()).map(
     (entry) => entry.runId,
   );
@@ -834,7 +838,9 @@ function saveReport(runId: string) {
 
 test("a newly created dashboard report is private", () => {
   const report = saveReport("wf_600001");
-  assert.equal(statSync(report).mode & 0o777, 0o600);
+  if (process.platform !== "win32") {
+    assert.equal(statSync(report).mode & 0o777, 0o600);
+  }
 });
 
 test("overwriting a dashboard report restores private mode atomically", () => {
@@ -845,7 +851,9 @@ test("overwriting a dashboard report restores private mode atomically", () => {
   chmodSync(report, 0o644);
 
   assert.equal(saveReport(runId), report);
-  assert.equal(statSync(report).mode & 0o777, 0o600);
+  if (process.platform !== "win32") {
+    assert.equal(statSync(report).mode & 0o777, 0o600);
+  }
   assert.notEqual(readFileSync(report, "utf8"), "old report");
 });
 

--- a/tests/extensions/workflows/operator.test.ts
+++ b/tests/extensions/workflows/operator.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { resolve } from "node:path";
 import { test } from "node:test";
 import type { SessionManager } from "@earendil-works/pi-coding-agent";
 import {
@@ -16,7 +17,7 @@ function deferred<T = void>() {
 
 test("reuses one in-memory SessionManager for an operator identity", async () => {
   const registry = new WorkflowOperatorRegistry();
-  const cwd = "/tmp/openpi-operator";
+  const cwd = resolve("/tmp/openpi-operator");
   const managers: SessionManager[] = [];
   const identity = {
     key: "reviewer:1",

--- a/tests/extensions/workflows/replay-safety.test.ts
+++ b/tests/extensions/workflows/replay-safety.test.ts
@@ -7,6 +7,7 @@ import {
   realpathSync,
   renameSync,
   rmSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -27,6 +28,35 @@ import {
 
 function git(cwd: string, ...args: string[]) {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function assertSameDirectory(actual: string, expected: string) {
+  const actualStats = statSync(actual);
+  const expectedStats = statSync(expected);
+  assert.deepEqual(
+    { dev: actualStats.dev, ino: actualStats.ino },
+    { dev: expectedStats.dev, ino: expectedStats.ino },
+  );
+}
+
+function createFileSymlinkOrSkip(
+  t: { skip(message?: string): void },
+  target: string,
+  path: string,
+) {
+  try {
+    symlinkSync(target, path);
+    return true;
+  } catch (error) {
+    if (
+      process.platform === "win32" &&
+      (error as NodeJS.ErrnoException).code === "EPERM"
+    ) {
+      t.skip("Windows file symlinks require Developer Mode or elevation");
+      return false;
+    }
+    throw error;
+  }
 }
 
 function recordingGit(commands: string[][]) {
@@ -227,13 +257,17 @@ test("replay filesystem boundary permits repo-local observers and rejects escapi
   }
 });
 
-test("replay filesystem boundary fails closed for symlinks and uncertain paths", async () => {
+test("replay filesystem boundary fails closed for symlinks and uncertain paths", async (t) => {
   const cwd = repository();
   const outside = mkdtempSync(path.join(tmpdir(), "pi-replay-symlink-"));
   try {
     const outsideFile = path.join(outside, "outside.txt");
     writeFileSync(outsideFile, "external one\n");
-    symlinkSync(outsideFile, path.join(cwd, "external-link"));
+    if (
+      !createFileSymlinkOrSkip(t, outsideFile, path.join(cwd, "external-link"))
+    ) {
+      return;
+    }
     let observations = 0;
     let violations = 0;
     const definition = filesystemTool("read", (pathname) => {
@@ -417,11 +451,12 @@ test("canonical cwd and repository state participate in replay identity", () => 
       true,
     );
     assert.equal(originalIdentity?.version, 3);
-    assert.equal(originalIdentity?.repositoryRoot, realpathSync(cwd));
+    assert.ok(originalIdentity);
+    assertSameDirectory(originalIdentity.repositoryRoot, realpathSync(cwd));
     const original = replayKey(cwd, resourcePath);
 
     const alias = path.join(path.dirname(cwd), `${path.basename(cwd)}-alias`);
-    symlinkSync(cwd, alias, "dir");
+    symlinkSync(cwd, alias, process.platform === "win32" ? "junction" : "dir");
     try {
       assert.equal(
         replayKey(alias, path.join(alias, "resource.md")),
@@ -429,7 +464,7 @@ test("canonical cwd and repository state participate in replay identity", () => 
         "a symlink spelling of the same cwd must canonicalize",
       );
     } finally {
-      rmSync(alias, { force: true });
+      rmSync(alias, { recursive: true, force: true });
     }
 
     const nested = path.join(cwd, "nested");
@@ -486,13 +521,21 @@ test("ignored observable files disable replay rather than returning stale output
   }
 });
 
-test("tracked and untracked symlinks disable replay", () => {
+test("tracked and untracked symlinks disable replay", (t) => {
   for (const tracked of [true, false]) {
     const cwd = repository();
     try {
       const resourcePath = path.join(cwd, "resource.md");
       writeFileSync(resourcePath, "resource\n");
-      symlinkSync("tracked.txt", path.join(cwd, "observable-link"));
+      if (
+        !createFileSymlinkOrSkip(
+          t,
+          "tracked.txt",
+          path.join(cwd, "observable-link"),
+        )
+      ) {
+        return;
+      }
       if (tracked) {
         git(cwd, "add", "observable-link");
         git(cwd, "commit", "-qm", "track symlink");
@@ -580,7 +623,7 @@ test("replay fingerprint keeps the early ignored gate and post-diff safety gates
     const commands: string[][] = [];
     const fingerprint = repositoryFingerprint(cwd, recordingGit(commands));
     assert.ok(fingerprint);
-    assert.equal(fingerprint.root, realpathSync(cwd));
+    assertSameDirectory(fingerprint.root, realpathSync(cwd));
     assert.deepEqual(commands, [
       ["rev-parse", "--show-toplevel"],
       [

--- a/tests/extensions/workflows/resume-lookup.test.ts
+++ b/tests/extensions/workflows/resume-lookup.test.ts
@@ -16,7 +16,11 @@ const runs = join(agentDir, "workflows");
 mkdirSync(join(runs, "wf_1a2b3c4d5e6f"), { recursive: true });
 mkdirSync(join(runs, "wf_ffeeddcc5e6f"), { recursive: true });
 mkdirSync(join(runs, "4d5e6f"), { recursive: true });
-mkdirSync(join(runs, "wf_\u001b]52;c;clipboard\u0007bad0"), {
+const invalidRunId =
+  process.platform === "win32"
+    ? "wf_not-generated-bad0"
+    : "wf_\u001b]52;c;clipboard\u0007bad0";
+mkdirSync(join(runs, invalidRunId), {
   recursive: true,
 });
 

--- a/tests/extensions/workspace-cleanup-guard/workspace-provenance.test.ts
+++ b/tests/extensions/workspace-cleanup-guard/workspace-provenance.test.ts
@@ -301,13 +301,24 @@ test("unproven or non-standalone rm input fails closed", async () => {
 
 test("quoted or escaped literals remain directly verifiable", async () => {
   await withWorkspace(async (workspace) => {
-    for (const target of [
-      "keep*.txt",
-      "keep\\*.txt",
-      "keep.txt",
-      "scratch$1.txt",
-      "file name.txt",
-    ]) {
+    const cases =
+      process.platform === "win32"
+        ? [
+            ["rm 'keep[1].txt'", "keep[1].txt"],
+            ["rm scratch\\$1.txt", "scratch$1.txt"],
+            ["rm 'scratch$1.txt'", "scratch$1.txt"],
+            ['rm "file name.txt"', "file name.txt"],
+            ['rm "keep\\\n.txt"', "keep.txt"],
+          ]
+        : [
+            ["rm 'keep*.txt'", "keep*.txt"],
+            ["rm keep\\*.txt", "keep*.txt"],
+            ["rm 'scratch$1.txt'", "scratch$1.txt"],
+            ['rm "file name.txt"', "file name.txt"],
+            ['rm "keep\\*.txt"', "keep\\*.txt"],
+            ['rm "keep\\\n.txt"', "keep.txt"],
+          ];
+    for (const target of new Set(cases.map(([, target]) => target))) {
       await writeFile(path.join(workspace, target), "keep");
     }
     const confirmations: string[][] = [];
@@ -316,14 +327,7 @@ test("quoted or escaped literals remain directly verifiable", async () => {
       return false;
     });
 
-    for (const [index, command] of [
-      "rm 'keep*.txt'",
-      "rm keep\\*.txt",
-      "rm 'scratch$1.txt'",
-      'rm "file name.txt"',
-      'rm "keep\\*.txt"',
-      'rm "keep\\\n.txt"',
-    ].entries()) {
+    for (const [index, [command]] of cases.entries()) {
       assert.equal(
         (
           await guard.before({
@@ -336,14 +340,10 @@ test("quoted or escaped literals remain directly verifiable", async () => {
         command,
       );
     }
-    assert.deepEqual(confirmations, [
-      ["keep*.txt"],
-      ["keep*.txt"],
-      ["scratch$1.txt"],
-      ["file name.txt"],
-      ["keep\\*.txt"],
-      ["keep.txt"],
-    ]);
+    assert.deepEqual(
+      confirmations,
+      cases.map(([, target]) => [target]),
+    );
   });
 });
 
@@ -413,7 +413,7 @@ test("direct rm targets must resolve from workspace-relative paths", async () =>
     });
 
     for (const [index, command] of [
-      `rm ${target}`,
+      "rm /outside/keep.txt",
       "rm ../keep.txt",
       "rm .",
       "rm ~/keep.txt",

--- a/tests/scripts/node-test-groups.test.ts
+++ b/tests/scripts/node-test-groups.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import test from "node:test";
+import { partitionNodeTestsByPlatform } from "../../scripts/node-test-groups.mjs";
+
+const backgroundTest = resolve(
+  "tests",
+  "extensions",
+  "background-terminals",
+  "manager.test.ts",
+);
+const backgroundUnitTest = resolve(
+  "tests",
+  "extensions",
+  "background-terminals",
+  "output.test.ts",
+);
+const unrelatedTest = resolve("tests", "test-discovery.test.ts");
+
+test("Windows isolates background-terminal tests from other Node files", () => {
+  assert.deepEqual(
+    partitionNodeTestsByPlatform(
+      [backgroundTest, unrelatedTest, backgroundUnitTest],
+      "win32",
+    ),
+    {
+      parallel: [unrelatedTest],
+      serial: [backgroundTest, backgroundUnitTest],
+    },
+  );
+});
+
+test("non-Windows keeps all Node files in the parallel group", () => {
+  assert.deepEqual(
+    partitionNodeTestsByPlatform(
+      [backgroundTest, unrelatedTest, backgroundUnitTest],
+      "linux",
+    ),
+    {
+      parallel: [backgroundTest, unrelatedTest, backgroundUnitTest],
+      serial: [],
+    },
+  );
+});

--- a/tests/test-discovery.test.ts
+++ b/tests/test-discovery.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { relative, resolve, sep } from "node:path";
 import test from "node:test";
 
 test("recursive discovery includes nested Node and Vitest suites", () => {
+  const testsRoot = resolve("tests");
   const discovered = JSON.parse(
     execFileSync(process.execPath, ["scripts/discover-tests.mjs"], {
       cwd: resolve("."),
@@ -12,13 +13,15 @@ test("recursive discovery includes nested Node and Vitest suites", () => {
     }),
   ) as string[];
 
-  assert.ok(
-    discovered.some((file) => file.endsWith("tests/test-discovery.test.ts")),
-  );
-  assert.ok(discovered.some((file) => file.includes("tests/extensions/")));
+  assert.ok(discovered.includes(resolve(testsRoot, "test-discovery.test.ts")));
   assert.ok(
     discovered.some((file) =>
-      file.endsWith("tests/extensions/file-search/index.spec.ts"),
+      relative(testsRoot, file).startsWith(`extensions${sep}`),
+    ),
+  );
+  assert.ok(
+    discovered.includes(
+      resolve(testsRoot, "extensions", "file-search", "index.spec.ts"),
     ),
   );
 });

--- a/tests/web/cli.test.ts
+++ b/tests/web/cli.test.ts
@@ -23,8 +23,10 @@ const staticAssetsPath = fileURLToPath(
 );
 
 test("openpi is an executable standalone Web entrypoint", async () => {
-  const info = await stat(entrypoint);
-  assert.notEqual(info.mode & 0o100, 0);
+  if (process.platform !== "win32") {
+    const info = await stat(entrypoint);
+    assert.notEqual(info.mode & 0o100, 0);
+  }
 
   const { stdout } = await execFileAsync(process.execPath, [
     entrypointPath,
@@ -171,59 +173,61 @@ export class PiWebRuntime {
     );
     assert.equal(await readFile(disposeMarker, "utf8"), "disposed");
 
-    const child = spawn(
-      process.execPath,
-      [
-        join(packageRoot, "bin", "openpi.js"),
-        "web",
-        temporaryRoot,
-        "--no-open",
-      ],
-      {
-        env: {
-          ...process.env,
-          OPENPI_CLI_KEEPALIVE: "1",
-          OPENPI_CLI_STOP_FAIL: "1",
+    if (process.platform !== "win32") {
+      const child = spawn(
+        process.execPath,
+        [
+          join(packageRoot, "bin", "openpi.js"),
+          "web",
+          temporaryRoot,
+          "--no-open",
+        ],
+        {
+          env: {
+            ...process.env,
+            OPENPI_CLI_KEEPALIVE: "1",
+            OPENPI_CLI_STOP_FAIL: "1",
+          },
+          stdio: ["ignore", "pipe", "pipe"],
         },
-        stdio: ["ignore", "pipe", "pipe"],
-      },
-    );
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    let signalOutput = "";
-    let signalError = "";
-    child.stdout.on("data", (chunk) => {
-      signalOutput += chunk;
-    });
-    child.stderr.on("data", (chunk) => {
-      signalError += chunk;
-    });
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(
-        () => reject(new Error("installed CLI did not start")),
-        5_000,
       );
-      const waitForReady = () => {
-        if (
-          signalOutput.includes(
-            "OpenPI Web Workbench is running at http://127.0.0.1:12345",
-          )
-        ) {
-          clearTimeout(timeout);
-          resolve();
-          return;
-        }
-        setTimeout(waitForReady, 10);
-      };
-      waitForReady();
-    });
-    child.kill("SIGTERM");
-    const [exitCode] = (await once(child, "close")) as [number | null];
-    assert.equal(exitCode, 1);
-    assert.match(
-      signalError,
-      /Failed to stop OpenPI Web Workbench: stop failed/u,
-    );
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      let signalOutput = "";
+      let signalError = "";
+      child.stdout.on("data", (chunk) => {
+        signalOutput += chunk;
+      });
+      child.stderr.on("data", (chunk) => {
+        signalError += chunk;
+      });
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error("installed CLI did not start")),
+          5_000,
+        );
+        const waitForReady = () => {
+          if (
+            signalOutput.includes(
+              "OpenPI Web Workbench is running at http://127.0.0.1:12345",
+            )
+          ) {
+            clearTimeout(timeout);
+            resolve();
+            return;
+          }
+          setTimeout(waitForReady, 10);
+        };
+        waitForReady();
+      });
+      child.kill("SIGTERM");
+      const [exitCode] = (await once(child, "close")) as [number | null];
+      assert.equal(exitCode, 1);
+      assert.match(
+        signalError,
+        /Failed to stop OpenPI Web Workbench: stop failed/u,
+      );
+    }
   } finally {
     await rm(temporaryRoot, { recursive: true, force: true });
   }

--- a/tests/web/pi-runtime.test.ts
+++ b/tests/web/pi-runtime.test.ts
@@ -760,7 +760,7 @@ test("dispose waits for pending candidate creation and cleans it before releasin
   };
 
   try {
-    const sessionChange = harness.newSession("/tmp");
+    const sessionChange = harness.newSession(process.cwd());
     await createEntered.promise;
     const disposal = harness.dispose();
     await new Promise<void>((resolve) => setImmediate(resolve));
@@ -806,7 +806,7 @@ test("new session projects its command id and activated session path", async () 
   });
 
   try {
-    const result = await harness.newSession("/tmp", {
+    const result = await harness.newSession(process.cwd(), {
       commandId: "create-command",
     });
 
@@ -851,7 +851,7 @@ test("dispose also waits for a pending switched-session candidate", async () => 
   const originalCreateRuntime = runtimeConstructor.createRuntime;
   const originalOpen = SessionManager.open;
   SessionManager.open = (() => ({
-    getCwd: () => "/tmp",
+    getCwd: () => process.cwd(),
   })) as unknown as typeof SessionManager.open;
   runtimeConstructor.createRuntime = async () => {
     createEntered.resolve();


### PR DESCRIPTION
> Maintainer status (2026-08-31): **Not ready to merge.** The newly exercised Windows full-suite entry point failed; details and exact-head CI evidence are recorded below.

## Problem

Fixes #304.

`scripts/run-tests.mjs` discovers every Node test file and currently passes the complete list to one `node --test` invocation. Node runs test files concurrently by default. The `background-terminals` suite is different from ordinary unit tests: on Windows it creates real process trees, invokes and awaits `taskkill`, observes settlement callbacks, polls descendant liveness, and cleans up OS resources.

When those tests overlap unrelated Node test files, Windows scheduling and process-tree teardown become timing-sensitive. The result is intermittent failures in the same roughly 3.3-3.8 second teardown window, even though the affected tests are stable alone or when the directory is run serially.

## Value

This restores a reliable meaning to the full test result on Windows:

- CI failures from process-lifecycle timing no longer block unrelated changes.
- Contributors can trust a red result as evidence of a real regression instead of retrying noisy flakes.
- Debugging stays focused on production behavior rather than suite-level scheduling.
- Windows contributors get deterministic local feedback, and `prepublishOnly` no longer depends on retrying a flaky full suite.
- The rest of the Node suite retains file-level parallelism, so the reliability fix does not serialize ordinary tests.

## Approach

The runner now partitions discovered Node tests with a small platform-aware helper.

- On Windows, all files under `tests/extensions/background-terminals` run in a separate `node --test --test-concurrency=1` invocation.
- The remaining Node test files still run in the existing default-concurrency invocation.
- On non-Windows platforms, the original single parallel Node invocation is unchanged.
- The entire background-terminal directory is isolated so future real-process tests in that ownership boundary cannot accidentally overlap unrelated files.
- Production process cleanup, termination boundaries, and behavior assertions are untouched.

The branch has now been rebased onto `main@b02ed884` (which includes the separately merged LF policy from #302). LF policy changes are not part of this PR's diff.

## Original author validation (before maintainer rebase)

- `bun run check` passes: config contract, discipline ledger, format, lint, and typecheck.
- `node --test --experimental-strip-types tests/scripts/node-test-groups.test.ts` passes (2/2).
- Windows strategy simulation partitions 119 Node tests into 111 parallel files and 8 serial background-terminal files, with no serial files outside that directory.
- The affected background-terminal process tests pass when run without cross-file concurrency.
- `bun run test` in this Windows checkout is still blocked by pre-existing path-separator assertions (tests expecting `/` while Node returns `\\`), unrelated to this runner change.

## Impact

- User-visible behavior: none.
- Model-visible tools/context: none.
- Runtime and persisted data: none.
- Test infrastructure: Windows-only scheduling change for the background-terminal directory; non-Windows behavior and ordinary test parallelism remain unchanged.
- Compatibility risk: limited to a longer Windows test phase for this directory; it removes cross-file process contention while preserving parallel speed elsewhere.

## Maintainer verification — 2026-08-31

Current head: `0837bff87ea81ffc2c97bb8e3281d4e65a156d25`; base: `main@b02ed884d8f38f4e05cb55b933eca19b59ead124`.

- 原分组实现保持不变。只在现有 Windows CI 的 manager 测试之后新增 `bun run test` 验证步骤（5 分钟执行上限），真实经过本 PR 修改的入口；不跳过、不重试、不使用 continue-on-error。
- 本地 macOS / Node 24.18.0 / Bun 1.3.14：`bun install --frozen-lockfile`、`bun run check`、`bun run test` 通过；Node 1088 passed / 1 platform skip / 0 failed；Vitest 30 passed。
- Standards 和 Spec 独立复核没有新增代码问题。
- Windows 实跑已完成，当前不能合并：[CI run 33397613622](https://github.com/openpi-dev/openpi/actions/runs/33397613622/job/99505819823)。Node 22 / Node 24 CI 通过；Windows 原有 manager 生命周期步骤通过，但新增完整入口步骤失败并在 5 分钟上限处超时。
  - 已确认断言失败：`tests/extensions/file-mutation-display/render.test.ts:236`（read fixture 正则位于第 68 行附近）只接受 `src/long-file.ts`，Windows 实际输出 `src\\long-file.ts:10-29`。该文件及相关生产渲染实现与 base main 完全相同，不属于本 PR 的分组改动。
  - 普通 Node 组未正常结束，串行 background-terminals 组及 Vitest 没有进入；日志不足以确定挂起根因，不能把超时直接归因于上述路径断言，也不能宣称 flaky 已消除。
  - 未放宽断言、未跳过测试、未加重试、未绕过红灯。后续需要定位 Windows 全量挂起并处理既有测试兼容性；此轮保持 PR OPEN，暂停合并。
