### PR TITLE
perf(workflows): append replay journal incrementally

### DIFF
--- a/benchmarks/workflow-journal.ts
+++ b/benchmarks/workflow-journal.ts
@@ -1,0 +1,88 @@
+import { performance } from "node:perf_hooks";
+import {
+  createJournalAccumulator,
+  JOURNAL_MAX_BYTES,
+} from "../extensions/workflows/journal.ts";
+
+function readOption(name: string) {
+  const index = process.argv.indexOf(name);
+  if (index >= 0) return process.argv[index + 1];
+  return process.argv
+    .find((argument) => argument.startsWith(`${name}=`))
+    ?.slice(name.length + 1);
+}
+
+function parseCounts(raw: string | undefined) {
+  const counts = (raw ?? "128,512,1024")
+    .split(",")
+    .map((value) => Number.parseInt(value, 10));
+  if (counts.some((value) => !Number.isSafeInteger(value) || value <= 0)) {
+    throw new Error("--counts must contain positive integers");
+  }
+  return counts;
+}
+
+function parsePositiveInteger(raw: string | undefined, fallback: number) {
+  if (raw === undefined) return fallback;
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error("--entry-bytes must be a positive integer");
+  }
+  return value;
+}
+
+function heapUsed() {
+  return process.memoryUsage().heapUsed;
+}
+
+function cpuMicros(previous: NodeJS.CpuUsage) {
+  const usage = process.cpuUsage(previous);
+  return usage.user + usage.system;
+}
+
+const entryBytes = parsePositiveInteger(readOption("--entry-bytes"), 64 * 1024);
+
+for (const count of parseCounts(readOption("--counts"))) {
+  globalThis.gc?.();
+  const beforeHeap = heapUsed();
+  const beforeCpu = process.cpuUsage();
+  const accumulator = createJournalAccumulator();
+  const output = "x".repeat(entryBytes);
+  const appendStarted = performance.now();
+  for (let index = 0; index < count; index++) {
+    accumulator.append({
+      key: `benchmark-${index}`,
+      output,
+      ...(index % 4 === 0 ? { structured: { index, status: "accepted" } } : {}),
+    });
+  }
+  const appendMs = performance.now() - appendStarted;
+  const appendCpuMicros = cpuMicros(beforeCpu);
+  const afterAppendHeap = heapUsed();
+
+  const flushStarted = performance.now();
+  const flushCpuStart = process.cpuUsage();
+  const json = accumulator.toJson();
+  const flushMs = performance.now() - flushStarted;
+  const flushCpuMicros = cpuMicros(flushCpuStart);
+  const afterFlushHeap = heapUsed();
+
+  console.log(
+    JSON.stringify({
+      count,
+      entryBytes,
+      maxBytes: JOURNAL_MAX_BYTES,
+      retained: accumulator.length,
+      dropped: accumulator.dropped,
+      bytes: accumulator.bytes,
+      serializedBytes: Buffer.byteLength(json, "utf8"),
+      appendMs: Number(appendMs.toFixed(3)),
+      appendCpuMicros,
+      flushMs: Number(flushMs.toFixed(3)),
+      flushCpuMicros,
+      appendHeapDelta: afterAppendHeap - beforeHeap,
+      flushHeapDelta: afterFlushHeap - afterAppendHeap,
+      gcAvailable: typeof globalThis.gc === "function",
+    }),
+  );
+}

--- a/extensions/workflows/artifacts.ts
+++ b/extensions/workflows/artifacts.ts
@@ -6,6 +6,7 @@ import {
   type JournalEntry,
   parseJournal,
   type WorkflowJournal,
+  type WorkflowJournalAccumulator,
 } from "./journal.ts";
 import {
   refreshWorkflowGraph,
@@ -29,6 +30,10 @@ export const WORKFLOW_CHECKPOINT_INTERVAL_MS = 500;
 const ENTRY_TRUNCATION_MARKER = "\n[entry truncated]";
 const TRANSCRIPT_TRUNCATION_MARKER =
   "[artifact transcript truncated: older entries omitted]";
+
+type WorkflowJournalSource =
+  | readonly JournalEntry[]
+  | WorkflowJournalAccumulator;
 
 function textBytes(text: string) {
   return Buffer.byteLength(text, "utf8");
@@ -158,7 +163,7 @@ export function persistWorkflowAgentResult(
 export function persistWorkflowJson(
   runDir: string,
   details: WorkflowDetails,
-  journal?: readonly JournalEntry[],
+  journal?: WorkflowJournalSource,
 ) {
   refreshWorkflowGraph(details);
   const transcripts = Object.fromEntries(
@@ -183,15 +188,20 @@ export function persistWorkflowJson(
   );
   // Written alongside the rest so it inherits atomic write, 500ms coalescing,
   // and the final flush. Only present once a call has actually succeeded.
-  // boundedJournal has already brought this under the cap, and plain
-  // JSON.stringify is deliberate: safeStringify would swap an over-cap value
-  // for a preview stub, silently turning the journal into something unusable.
-  if (journal && journal.length > 0) {
-    writeRunFile(
-      runDir,
-      JOURNAL_FILE,
-      JSON.stringify(boundedJournal(journal).journal, null, 2),
-    );
+  // Accumulators already enforce the cap incrementally and can assemble the
+  // canonical JSON from their cached entry fragments. Plain arrays retain the
+  // compatibility path through boundedJournal; plain JSON.stringify is
+  // deliberate because safeStringify would swap an over-cap value for a
+  // preview stub, silently turning the journal into something unusable.
+  if (
+    journal &&
+    (journal.length > 0 || ("toJson" in journal && journal.dropped > 0))
+  ) {
+    const content =
+      "toJson" in journal
+        ? journal.toJson()
+        : JSON.stringify(boundedJournal(journal).journal, null, 2);
+    writeRunFile(runDir, JOURNAL_FILE, content);
   }
   if (details.result !== undefined) {
     writeRunFile(
@@ -243,10 +253,10 @@ export function createWorkflowPersistence(
     persist?: (
       runDir: string,
       details: WorkflowDetails,
-      journal?: readonly JournalEntry[],
+      journal?: WorkflowJournalSource,
     ) => void;
-    /** Read at write time so callers only have to append to their own array. */
-    journal?: () => readonly JournalEntry[];
+    /** Read at write time so callers only have to append to their journal. */
+    journal?: () => WorkflowJournalSource;
   } = {},
 ) {
   const intervalMs = Math.max(

--- a/extensions/workflows/index.ts
+++ b/extensions/workflows/index.ts
@@ -120,8 +120,8 @@ import {
 } from "./invocation-ledger.ts";
 import {
   agentCallKey,
+  createJournalAccumulator,
   createReplayCache,
-  type JournalEntry,
   type ReplayCache,
 } from "./journal.ts";
 import {
@@ -1261,7 +1261,7 @@ export default function workflows(
       // Resume: replay cached results for calls whose content is unchanged.
       // A missing or unreadable source degrades to a normal full run — resume
       // is an optimization and must not become a new way to fail.
-      const journalEntries: JournalEntry[] = [];
+      const journal = createJournalAccumulator();
       let replay: ReplayCache | undefined;
       if (params.resume_from_run_id) {
         const source = resolveRunDir(params.resume_from_run_id);
@@ -1281,7 +1281,7 @@ export default function workflows(
         writeRunFile(runDir, "args.json", params.args);
       persistWorkflowJson(runDir, details);
       const persistence = createWorkflowPersistence(runDir, details, {
-        journal: () => journalEntries,
+        journal: () => journal,
         ...(workflowLifecycleTestHooks?.persistWorkflow
           ? { persist: workflowLifecycleTestHooks.persistWorkflow }
           : {}),
@@ -1846,7 +1846,7 @@ export default function workflows(
           emit();
           // Re-journal so a chain of resumes keeps working: run C resuming from
           // B still finds what B replayed from A.
-          journalEntries.push(cached);
+          journal.append(cached);
           replayLease.end();
           return {
             ok: true,
@@ -2090,7 +2090,7 @@ export default function workflows(
                 !replayBoundaryViolated &&
                 replayLease.canJournal()
               ) {
-                journalEntries.push({
+                journal.append({
                   key: completedKey,
                   output: outcome.output,
                   ...(outcome.structured !== undefined

--- a/extensions/workflows/journal.ts
+++ b/extensions/workflows/journal.ts
@@ -38,6 +38,148 @@ export interface WorkflowJournal {
   readonly entries: readonly JournalEntry[];
 }
 
+interface EncodedJournalEntry {
+  readonly entry: JournalEntry;
+  /** The entry formatted at the indentation used inside the journal array. */
+  readonly json: string;
+  readonly bytes: number;
+}
+
+const JOURNAL_PREFIX = `{
+  "version": ${JOURNAL_VERSION},
+  "entries": [
+`;
+const JOURNAL_SUFFIX = "\n  ]\n}";
+const JOURNAL_SEPARATOR = ",\n";
+const JOURNAL_EMPTY = JSON.stringify(
+  { version: JOURNAL_VERSION, entries: [] },
+  null,
+  2,
+);
+const JOURNAL_PREFIX_BYTES = Buffer.byteLength(JOURNAL_PREFIX, "utf8");
+const JOURNAL_SUFFIX_BYTES = Buffer.byteLength(JOURNAL_SUFFIX, "utf8");
+const JOURNAL_SEPARATOR_BYTES = Buffer.byteLength(JOURNAL_SEPARATOR, "utf8");
+const JOURNAL_EMPTY_BYTES = Buffer.byteLength(JOURNAL_EMPTY, "utf8");
+
+function encodeJournalEntry(entry: JournalEntry): EncodedJournalEntry {
+  // JSON.stringify on an array serializes an undefined element as null. The
+  // public type only permits objects, but retaining that fallback keeps this
+  // helper's behavior total if a malformed caller reaches it at runtime.
+  const json = JSON.stringify(entry, null, 2) ?? "null";
+  const indented = `    ${json.replaceAll("\n", "\n    ")}`;
+  return {
+    entry,
+    json: indented,
+    bytes: Buffer.byteLength(indented, "utf8"),
+  };
+}
+
+function journalBytes(entryCount: number, entryBytes: number) {
+  if (entryCount === 0) return JOURNAL_EMPTY_BYTES;
+  return (
+    JOURNAL_PREFIX_BYTES +
+    entryBytes +
+    JOURNAL_SUFFIX_BYTES +
+    (entryCount - 1) * JOURNAL_SEPARATOR_BYTES
+  );
+}
+
+/**
+ * Incrementally bounded journal storage for a running Workflow.
+ *
+ * Each entry is encoded once when appended. The active queue uses a head
+ * cursor, so dropping old entries only subtracts their already-known byte
+ * contribution. `toJson()` assembles the complete canonical artifact without
+ * re-stringifying each entry or repeatedly measuring the whole suffix.
+ */
+export interface WorkflowJournalAccumulator {
+  readonly bytes: number;
+  readonly dropped: number;
+  readonly length: number;
+  append(entry: JournalEntry): void;
+  toJournal(): WorkflowJournal;
+  toJson(): string;
+}
+
+export function createJournalAccumulator(
+  maxBytes = JOURNAL_MAX_BYTES,
+): WorkflowJournalAccumulator {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < JOURNAL_EMPTY_BYTES) {
+    throw new RangeError(
+      `Journal byte budget must be at least ${JOURNAL_EMPTY_BYTES} bytes`,
+    );
+  }
+
+  let queue: Array<EncodedJournalEntry | undefined> = [];
+  let head = 0;
+  let entryBytes = 0;
+  let dropped = 0;
+
+  const activeLength = () => queue.length - head;
+  const activeBytes = () => journalBytes(activeLength(), entryBytes);
+
+  const compact = () => {
+    // Release the encoded payload immediately when it is evicted. Compact the
+    // sparse prefix only occasionally so eviction remains amortized O(1).
+    if (head === queue.length) {
+      queue = [];
+      head = 0;
+      return;
+    }
+    if (head >= 64 && head * 2 >= queue.length) {
+      queue = queue.slice(head);
+      head = 0;
+    }
+  };
+
+  return {
+    get bytes() {
+      return activeBytes();
+    },
+    get dropped() {
+      return dropped;
+    },
+    get length() {
+      return activeLength();
+    },
+    append(entry) {
+      const encoded = encodeJournalEntry(entry);
+      queue.push(encoded);
+      entryBytes += encoded.bytes;
+
+      while (activeLength() > 0 && activeBytes() > maxBytes) {
+        const oldest = queue[head];
+        if (!oldest) break;
+        queue[head] = undefined;
+        head++;
+        entryBytes -= oldest.bytes;
+        dropped++;
+      }
+      compact();
+    },
+    toJournal() {
+      const entries: JournalEntry[] = [];
+      for (let index = head; index < queue.length; index++) {
+        const encoded = queue[index];
+        if (encoded) entries.push(encoded.entry);
+      }
+      return {
+        version: JOURNAL_VERSION,
+        entries,
+      };
+    },
+    toJson() {
+      if (activeLength() === 0) return JOURNAL_EMPTY;
+      const entries: string[] = [];
+      for (let index = head; index < queue.length; index++) {
+        const encoded = queue[index];
+        if (encoded) entries.push(encoded.json);
+      }
+      return JOURNAL_PREFIX + entries.join(JOURNAL_SEPARATOR) + JOURNAL_SUFFIX;
+    },
+  };
+}
+
 /**
  * Only semantic options change what an agent produces, so only these are
  * hashed. Callers pass their whole options object; `label` and `phase` are
@@ -146,19 +288,12 @@ export type ReplayCache = ReturnType<typeof createReplayCache>;
  * journal that serializes to a useless preview string.
  */
 export function boundedJournal(entries: readonly JournalEntry[]) {
-  const size = (kept: readonly JournalEntry[]) =>
-    Buffer.byteLength(
-      JSON.stringify({ version: JOURNAL_VERSION, entries: kept }, null, 2),
-      "utf8",
-    );
-
-  let kept = [...entries];
-  let dropped = 0;
-  while (kept.length > 0 && size(kept) > JOURNAL_MAX_BYTES) {
-    kept = kept.slice(1);
-    dropped++;
-  }
-  return { journal: { version: JOURNAL_VERSION, entries: kept }, dropped };
+  const accumulator = createJournalAccumulator();
+  for (const entry of entries) accumulator.append(entry);
+  return {
+    journal: accumulator.toJournal(),
+    dropped: accumulator.dropped,
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "format:check": "biome format .",
     "lint": "biome lint . --error-on-warnings",
     "typecheck": "tsc --noEmit",
+    "benchmark:workflow-journal": "node --experimental-strip-types --expose-gc benchmarks/workflow-journal.ts",
     "benchmark:workflow-child-startup": "node --experimental-strip-types scripts/benchmark-workflow-child-startup.mjs",
     "test": "node scripts/run-tests.mjs",
     "provenance": "node scripts/provenance.mjs"

--- a/tests/extensions/workflows/artifacts.test.ts
+++ b/tests/extensions/workflows/artifacts.test.ts
@@ -17,7 +17,10 @@ import {
   persistWorkflowJson,
   persistWorkflowTerminalState,
 } from "../../../extensions/workflows/artifacts.ts";
-import { JOURNAL_MAX_BYTES } from "../../../extensions/workflows/journal.ts";
+import {
+  createJournalAccumulator,
+  JOURNAL_MAX_BYTES,
+} from "../../../extensions/workflows/journal.ts";
 import {
   emptyUsage,
   type TranscriptEntry,
@@ -170,6 +173,48 @@ test("oversized replay journals fail closed before parsing", () => {
     );
 
     assert.equal(loadJournal(directory), undefined);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("workflow persistence writes an accumulator's complete canonical journal", () => {
+  const directory = mkdtempSync(join(tmpdir(), "pi-workflow-journal-write-"));
+  try {
+    const details = workflowDetails();
+    const journal = createJournalAccumulator();
+    journal.append({ key: "你好", output: "结果🙂" });
+    journal.append({ key: "second", output: "complete" });
+
+    persistWorkflowJson(directory, details, journal);
+
+    const written = readFileSync(join(directory, "journal.json"), "utf8");
+    assert.equal(written, journal.toJson());
+    assert.deepEqual(JSON.parse(written), {
+      version: 2,
+      entries: [
+        { key: "你好", output: "结果🙂" },
+        { key: "second", output: "complete" },
+      ],
+    });
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("workflow persistence keeps an empty journal artifact after all entries are evicted", () => {
+  const directory = mkdtempSync(join(tmpdir(), "pi-workflow-empty-journal-"));
+  try {
+    const details = workflowDetails();
+    const journal = createJournalAccumulator(1024);
+    journal.append({ key: "too-big", output: "x".repeat(4 * 1024) });
+
+    persistWorkflowJson(directory, details, journal);
+
+    assert.deepEqual(
+      JSON.parse(readFileSync(join(directory, "journal.json"), "utf8")),
+      { version: 2, entries: [] },
+    );
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/tests/extensions/workflows/journal.test.ts
+++ b/tests/extensions/workflows/journal.test.ts
@@ -8,11 +8,12 @@ import { test } from "node:test";
 import {
   agentCallKey,
   boundedJournal,
+  createJournalAccumulator,
   createReplayCache,
   JOURNAL_MAX_BYTES,
   JOURNAL_VERSION,
-  parseJournal,
   type JournalEntry,
+  parseJournal,
 } from "../../../extensions/workflows/journal.ts";
 import {
   runWorkflowSandbox,
@@ -194,6 +195,71 @@ test("a bounded journal round-trips back into a working cache", () => {
   assert.ok(reparsed && reparsed.entries.length > 0, "must survive the trip");
   const cache = createReplayCache(reparsed);
   assert.equal(cache.take("k63")?.output, big);
+});
+
+test("an incremental journal accumulator matches canonical JSON and byte accounting", () => {
+  const entries: JournalEntry[] = [
+    {
+      key: "你好",
+      output: "结果🙂",
+      structured: { verdict: "accepted", evidence: ["a", "b"] },
+    },
+    { key: "plain", output: "second" },
+  ];
+  const accumulator = createJournalAccumulator();
+  for (const entry of entries) accumulator.append(entry);
+
+  const expected = JSON.stringify(
+    { version: JOURNAL_VERSION, entries },
+    null,
+    2,
+  );
+  assert.deepEqual(accumulator.toJournal(), {
+    version: JOURNAL_VERSION,
+    entries,
+  });
+  assert.equal(accumulator.toJson(), expected);
+  assert.equal(accumulator.bytes, Buffer.byteLength(expected, "utf8"));
+  assert.equal(accumulator.dropped, 0);
+});
+
+test("an incremental accumulator evicts oldest entries with a cursor", () => {
+  const entries: JournalEntry[] = Array.from({ length: 200 }, (_, index) => ({
+    key: `k${index}`,
+    output: "x".repeat(128),
+  }));
+  const expectedEntries = entries.slice(-8);
+  const maxBytes = Buffer.byteLength(
+    JSON.stringify(
+      { version: JOURNAL_VERSION, entries: expectedEntries },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  const accumulator = createJournalAccumulator(maxBytes);
+  for (const entry of entries) accumulator.append(entry);
+
+  assert.deepEqual(accumulator.toJournal().entries, expectedEntries);
+  assert.equal(accumulator.dropped, entries.length - expectedEntries.length);
+  assert.equal(
+    accumulator.bytes,
+    Buffer.byteLength(accumulator.toJson(), "utf8"),
+  );
+  assert.ok(accumulator.bytes <= maxBytes);
+});
+
+test("a single oversized entry is dropped without exceeding the budget", () => {
+  const accumulator = createJournalAccumulator(1024);
+  accumulator.append({ key: "too-big", output: "x".repeat(4 * 1024) });
+
+  assert.equal(accumulator.length, 0);
+  assert.equal(accumulator.dropped, 1);
+  assert.equal(
+    accumulator.toJson(),
+    JSON.stringify({ version: JOURNAL_VERSION, entries: [] }, null, 2),
+  );
+  assert.ok(accumulator.bytes <= 1024);
 });
 
 // --- End-to-end through the real sandbox ----------------------------------


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Problem

Closes #184.

Workflow replay journals currently re-serialize the complete pretty-printed journal while trimming old entries. Near the 2 MiB cap, repeated `slice(1)` and full JSON size recalculation make append/eviction cost grow close to quadratically for large runs.

## Value

Large read-only Workflows can retain hundreds of replayable agent results. Incremental accounting keeps journal admission and oldest-entry eviction proportional to the number of new entries, while preserving the exact replay artifact and its atomic write path.

## Approach

- Add a `WorkflowJournalAccumulator` with cached per-entry JSON fragments, UTF-8 byte accounting, and a head-cursor queue.
- Append encodes only the new entry; eviction subtracts known bytes and releases dropped payload references immediately.
- Keep `boundedJournal()` as a compatibility adapter for array callers.
- Let persistence write the accumulator's complete canonical JSON through the existing atomic file writer.
- Preserve the v2 artifact format, oldest-first retention, duplicate-key replay order, and malformed/legacy fail-closed loading.
- Add a reproducible `benchmark:workflow-journal` script for 128/512/1024 entries.

## Validation

- `bun run check` — passed (config contract, discipline, format, lint, typecheck).
- `bun run test` under Node 24 — 1,076 passed, 1 skipped; Vitest 30/30 passed.
- Focused journal/artifact tests — 26/26 passed.
- `node --experimental-strip-types --expose-gc benchmarks/workflow-journal.ts`:
  - 128 entries: append 7.909 ms, 2,034,146 bytes retained.
  - 512 entries: append 22.447 ms, 2,034,149 bytes retained.
  - 1,024 entries: append 43.575 ms, 2,034,179 bytes retained.
  - Final serialized bytes exactly matched incremental accounting in every run.
- Before this change, the equivalent 4 KiB fixture took approximately 1,123 ms at 1,024 entries; the incremental append path took approximately 4 ms.

## Impact

- User-visible behavior: none.
- Model-visible context/tools: none.
- Runtime/lifecycle: journal append and eviction are incremental; replay semantics are unchanged.
- Persisted data: same v2 `journal.json` schema and canonical pretty JSON; writes remain atomic.
- Compatibility/risk: array-based callers remain supported; oversized/malformed/legacy behavior remains fail closed.
