### PR TITLE
chore(deps): update and align supported Pi baseline to 0.84.4 (#328)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/@tt-a1i/openpi"><img alt="npm version" src="https://img.shields.io/npm/v/@tt-a1i/openpi?style=flat-square&color=cb3837"></a>
   <a href="https://github.com/openpi-dev/openpi/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/openpi-dev/openpi/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="https://github.com/earendil-works/pi-mono"><img alt="Pi 0.84.1+" src="https://img.shields.io/badge/Pi-0.84.1%2B-2f81f7?style=flat-square"></a>
+  <a href="https://github.com/earendil-works/pi-mono"><img alt="Pi 0.84.3+" src="https://img.shields.io/badge/Pi-0.84.3%2B-2f81f7?style=flat-square"></a>
   <img alt="Node.js 22.19+" src="https://img.shields.io/badge/Node.js-22.19%2B-3fb950?style=flat-square&logo=nodedotjs&logoColor=white">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-3fb950?style=flat-square"></a>
 </p>
@@ -445,7 +445,7 @@ Footer 布局以 `footerLines` 作为唯一持久化格式。旧版 `footerItems
 
 ### 安装要求与来源
 
-- Pi `0.84.1` 或更新版本；
+- Pi `0.84.3` 或更新版本；
 - Node.js `22.19.0` 或更新版本；
 - npm 安装：`pi install npm:@tt-a1i/openpi`；
 - GitHub 安装：`pi install git:github.com/openpi-dev/openpi`。

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/@tt-a1i/openpi"><img alt="npm version" src="https://img.shields.io/npm/v/@tt-a1i/openpi?style=flat-square&color=cb3837"></a>
   <a href="https://github.com/openpi-dev/openpi/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/openpi-dev/openpi/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="https://github.com/earendil-works/pi-mono"><img alt="Pi 0.84.3+" src="https://img.shields.io/badge/Pi-0.84.3%2B-2f81f7?style=flat-square"></a>
+  <a href="https://github.com/earendil-works/pi-mono"><img alt="Pi 0.84.4+" src="https://img.shields.io/badge/Pi-0.84.4%2B-2f81f7?style=flat-square"></a>
   <img alt="Node.js 22.19+" src="https://img.shields.io/badge/Node.js-22.19%2B-3fb950?style=flat-square&logo=nodedotjs&logoColor=white">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-3fb950?style=flat-square"></a>
 </p>
@@ -445,7 +445,7 @@ Footer 布局以 `footerLines` 作为唯一持久化格式。旧版 `footerItems
 
 ### 安装要求与来源
 
-- Pi `0.84.3` 或更新版本；
+- Pi `0.84.4` 或更新版本；
 - Node.js `22.19.0` 或更新版本；
 - npm 安装：`pi install npm:@tt-a1i/openpi`；
 - GitHub 安装：`pi install git:github.com/openpi-dev/openpi`。

--- a/bun.lock
+++ b/bun.lock
@@ -11,9 +11,9 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.8",
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-coding-agent": "^0.84.1",
-        "@earendil-works/pi-tui": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.84.3",
+        "@earendil-works/pi-coding-agent": "^0.84.3",
+        "@earendil-works/pi-tui": "^0.84.3",
         "@effect/tsgo": "^0.24.2",
         "@effect/vitest": "^4.0.0-beta.99",
         "@types/node": "^26.1.1",
@@ -102,19 +102,19 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.8", "", { "os": "win32", "cpu": "x64" }, "sha512-I2czzXTY61f3nFJxXoMDq80t7MivxDEnCjE+8sDKoFfcKMaoQdkqhIFQ3KyY0XLzeSpUBYeNAXgD+iOV/BU0VA=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.1", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.1", "@earendil-works/pi-telemetry": "^0.84.1", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, ""],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.4", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.4", "@earendil-works/pi-telemetry": "^0.84.4", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-HyUnjaOXj6oN/6SNcr8A1J/ElRQA50FtIE0XUTSKAQVqmdlb9qdojOyUQwF/jULE5+yOEtGuVgi/N1RnBiNG+g=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.1", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.4", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.4", "@google/genai": "1.52.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.40.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw=="],
 
-    "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.1", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.1" } }, ""],
+    "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.4", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.4" } }, "sha512-q398WY/3ZQHTizk7IKxApzqFV0xt4yM9LkSkwyqeLK5Bj5RwRjOWxESt26z4LgNp4O+8hqhqFPf/8fj4H5rE4A=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.84.1", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.84.1", "@earendil-works/pi-ai": "^0.84.1", "@earendil-works/pi-client": "^0.84.1", "@earendil-works/pi-protocol": "^0.84.1", "@earendil-works/pi-tui": "^0.84.1", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "grok-mermaid": "0.2.2", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.9.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.84.4", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.84.4", "@earendil-works/pi-ai": "^0.84.4", "@earendil-works/pi-client": "^0.84.4", "@earendil-works/pi-protocol": "^0.84.4", "@earendil-works/pi-tui": "^0.84.4", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "grok-mermaid": "0.2.2", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.9.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/bundle/cli.js" } }, "sha512-jmOlrqUmvhh/siNWFRXjYLJzhKFIHNsAQaysRwzQPQFnPAaV/vhqHsLH/MBsIISA1Rjj7WTUFR3nJrpXoLx39w=="],
 
-    "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.1", "", { "dependencies": { "typebox": "1.3.7" } }, ""],
+    "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.4", "", { "dependencies": { "typebox": "1.3.7" } }, "sha512-acyE9ozxkMiWiz/xyWpU0O9vwnYv0hyG889Vniv6Sg9c9zfsX+8MePnDNphBacY2Fvm1rxdsGmiVDSZl9yuDFA=="],
 
-    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.1", "", {}, "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ=="],
+    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.4", "", {}, "sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.1", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.4", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-nPUnwDkLtupPXnZQYrCwPFcuTydCDqTY6ZbFqhsL4S4kVq0AT418kPa/6uXwtaCD+MjBNBltb7ScTYX65yeE1w=="],
 
     "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.103", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.103", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.103", "ioredis": "^5.7.0" } }, "sha512-VD8fbpendwFokMwzC7/MxazjhEVDihPC5NZtomYEyZwGaA1LXMvwP1y8pfXwfshUkG56TN4EMQqzu72c0B9FhA=="],
 
@@ -166,8 +166,6 @@
 
     "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
 
-    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
-
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
@@ -183,8 +181,6 @@
     "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
-
-    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.142.0", "", {}, "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ=="],
 
@@ -396,8 +392,6 @@
 
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
-    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
-
     "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
@@ -470,8 +464,6 @@
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
-    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
-
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msgpackr": ["msgpackr@2.0.5", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA=="],
@@ -490,7 +482,7 @@
 
     "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
-    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "bin": "bin/cli" }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+    "openai": ["openai@6.40.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"] }, "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA=="],
 
     "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
 
@@ -499,8 +491,6 @@
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
-
-    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -588,13 +578,9 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
-
     "@effect/platform-node/undici": ["undici@8.10.0", "", {}, "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ=="],
 
     "@effect/platform-node-shared/ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
-
-    "@mistralai/mistralai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 

--- a/docs/decisions/0003-supported-pi-baseline.md
+++ b/docs/decisions/0003-supported-pi-baseline.md
@@ -1,0 +1,58 @@
+---
+decision-status: proposed
+created: 2026-09-01
+last-reviewed: 2026-09-01
+applies-to: Pi 0.84.3+; OpenPI 0.1.0+
+owner: OpenPI maintainers
+related-issues: "#328"
+related-prs: "#269"
+supersedes: none
+---
+
+# Decision 0003: Define and enforce the supported Pi baseline (0.84.3+)
+
+## Context
+
+OpenPI previously expressed three conflicting compatibility boundaries:
+- `README.md` documented support for Pi 0.84.1+;
+- `package.json` specified `^0.84.1` for Pi devDependencies;
+- `bun.lock` locked dependencies to `0.84.1`, while `peerDependencies` permitted any compatible version via `*`.
+
+This baseline drift created behavioral divergence between fresh installations and frozen-lock environments. Specifically, upstream Pi introduced critical lifecycle fixes in `v0.84.3`:
+1. `4495469a5 fix(coding-agent): compact without provider usage` enables native message-history token estimation and automatic compaction for sessions where provider token usage is missing or zero (e.g. Cursor or output-only providers). In Pi 0.84.1, `AgentSession.prototype._checkCompaction` returned false on zero usage, preventing threshold compaction.
+2. `e5dde9a76 feat(ai): add simple tool choice option` added tool choice options to `@earendil-works/pi-ai`.
+
+To keep OpenPI aligned with upstream Pi primitives without forcing downstream provider extensions to implement ad-hoc compaction workarounds or fake token metrics, a unified project-level baseline must be established.
+
+## Decision
+
+- Elevate the official supported baseline to **Pi 0.84.3+**.
+- Align all manifest and documentation boundaries to this baseline:
+  - `package.json` devDependencies floor updated from `^0.84.1` to `^0.84.3`.
+  - `bun.lock` refreshed to the latest compatible release (0.84.4).
+  - `README.md` badge and requirements updated to `Pi 0.84.3+`.
+- Downstream provider PRs (such as PR #269) must rely on Pi 0.84.3+ native compaction and token estimation rather than inventing custom provider-local compaction lifecycles or falsifying token usage.
+
+## Evidence boundary
+
+- Pi upstream commit `4495469a5` was first packaged in `@earendil-works/pi-coding-agent@0.84.3`.
+- Tested on `AgentSession.prototype._checkCompaction` with empty/zero usage:
+  - Pi 0.84.1: `compactCalls=0`;
+  - Pi 0.84.4: `compactCalls=1` (estimated from message history).
+- Full OpenPI test suite passes under Pi 0.84.4 across Node 22 and Node 24 (1138+ passed tests, 0 failures).
+
+## Alternatives considered
+
+- **Maintain 0.84.1 as the baseline**: Rejected because providers lacking full token metrics (e.g. Cursor) would remain unable to trigger native compaction without fragile custom hacks.
+- **Refresh lockfile without changing package.json caret floor**: Rejected because `README.md` and `package.json` would continue to promise a floor version (0.84.1) that does not support full lifecycle behavior.
+- **Upgrade dependencies directly inside provider PRs (e.g. #269)**: Rejected to preserve separation of concerns between project-wide infrastructure governance and individual provider features.
+
+## Consequences
+
+- All developers, CI jobs, and published packages share a coherent dependency baseline.
+- Future providers can safely rely on Pi 0.84.3+ context estimation without polyfilling compaction.
+- Existing sessions and runtime configurations remain unaffected as Pi 0.84.3+ is backwards-compatible with 0.84.1 session formats.
+
+## Amendments
+
+None.

--- a/docs/decisions/0003-supported-pi-baseline.md
+++ b/docs/decisions/0003-supported-pi-baseline.md
@@ -1,37 +1,38 @@
 ---
-decision-status: proposed
+decision-status: accepted
 created: 2026-09-01
 last-reviewed: 2026-09-01
-applies-to: Pi 0.84.3+; OpenPI 0.1.0+
+applies-to: OpenPI development and CI baseline from this Decision forward
 owner: OpenPI maintainers
 related-issues: "#328"
-related-prs: "#269"
+related-prs: "#269, #330"
 supersedes: none
 ---
 
-# Decision 0003: Define and enforce the supported Pi baseline (0.84.3+)
+# Decision 0003: Update and align the supported Pi development baseline (0.84.4+)
 
 ## Context
 
-OpenPI previously expressed three conflicting compatibility boundaries:
+OpenPI previously expressed conflicting compatibility boundaries across repository assets:
 - `README.md` documented support for Pi 0.84.1+;
 - `package.json` specified `^0.84.1` for Pi devDependencies;
-- `bun.lock` locked dependencies to `0.84.1`, while `peerDependencies` permitted any compatible version via `*`.
+- `bun.lock` locked development and CI test environments to `0.84.1`, while `peerDependencies` permitted any compatible version via `*`.
 
-This baseline drift created behavioral divergence between fresh installations and frozen-lock environments. Specifically, upstream Pi introduced critical lifecycle fixes in `v0.84.3`:
+This baseline drift created behavioral divergence between fresh installations and frozen-lock CI environments. Specifically, upstream Pi introduced critical lifecycle fixes in `v0.84.3` and enhancements in `v0.84.4`:
 1. `4495469a5 fix(coding-agent): compact without provider usage` enables native message-history token estimation and automatic compaction for sessions where provider token usage is missing or zero (e.g. Cursor or output-only providers). In Pi 0.84.1, `AgentSession.prototype._checkCompaction` returned false on zero usage, preventing threshold compaction.
 2. `e5dde9a76 feat(ai): add simple tool choice option` added tool choice options to `@earendil-works/pi-ai`.
 
-To keep OpenPI aligned with upstream Pi primitives without forcing downstream provider extensions to implement ad-hoc compaction workarounds or fake token metrics, a unified project-level baseline must be established.
+To keep OpenPI aligned with upstream Pi primitives without forcing downstream provider extensions to implement ad-hoc compaction workarounds or fake token metrics, the declared development baseline and frozen lockfile must be unified.
 
 ## Decision
 
-- Elevate the official supported baseline to **Pi 0.84.3+**.
-- Align all manifest and documentation boundaries to this baseline:
-  - `package.json` devDependencies floor updated from `^0.84.1` to `^0.84.3`.
-  - `bun.lock` refreshed to the latest compatible release (0.84.4).
-  - `README.md` badge and requirements updated to `Pi 0.84.3+`.
-- Downstream provider PRs (such as PR #269) must rely on Pi 0.84.3+ native compaction and token estimation rather than inventing custom provider-local compaction lifecycles or falsifying token usage.
+- Update and align the declared and verified development baseline to **Pi 0.84.4+**.
+- Align manifest and documentation boundaries to this baseline:
+  - `package.json` devDependencies floor updated from `^0.84.1` to `^0.84.4`.
+  - `bun.lock` locked to the verified release `@earendil-works/pi-coding-agent@0.84.4`.
+  - `README.md` badge and installation requirements updated to `Pi 0.84.4+`.
+- In accordance with Pi extension package conventions, published packages continue to express `peerDependencies: { "@earendil-works/pi-ai": "*", "@earendil-works/pi-coding-agent": "*", "@earendil-works/pi-tui": "*" }` and do not introduce an artificial runtime host-rejection layer.
+- Downstream provider PRs (such as PR #269) must rely on native Pi message-history compaction rather than inventing custom provider-local compaction lifecycles or falsifying token usage.
 
 ## Evidence boundary
 
@@ -39,19 +40,19 @@ To keep OpenPI aligned with upstream Pi primitives without forcing downstream pr
 - Tested on `AgentSession.prototype._checkCompaction` with empty/zero usage:
   - Pi 0.84.1: `compactCalls=0`;
   - Pi 0.84.4: `compactCalls=1` (estimated from message history).
-- Full OpenPI test suite passes under Pi 0.84.4 across Node 22 and Node 24 (1138+ passed tests, 0 failures).
+- Full OpenPI test suite passes under Pi 0.84.4 across Node 22 and Node 24 (1108 Node tests passed, 1 platform skip; Vitest 30/30 passed; total 1138 passed tests, 0 failures).
 
 ## Alternatives considered
 
 - **Maintain 0.84.1 as the baseline**: Rejected because providers lacking full token metrics (e.g. Cursor) would remain unable to trigger native compaction without fragile custom hacks.
-- **Refresh lockfile without changing package.json caret floor**: Rejected because `README.md` and `package.json` would continue to promise a floor version (0.84.1) that does not support full lifecycle behavior.
-- **Upgrade dependencies directly inside provider PRs (e.g. #269)**: Rejected to preserve separation of concerns between project-wide infrastructure governance and individual provider features.
+- **Declare 0.84.3 while locking 0.84.4 without dedicated sub-version CI**: Rejected to avoid expressing an unverified sub-version floor that drifts from the locked CI evidence.
+- **Introduce an install-time version rejection gate**: Rejected because Pi package installation manages peer resolution natively, and OpenPI avoids non-native runtime barriers.
 
 ## Consequences
 
-- All developers, CI jobs, and published packages share a coherent dependency baseline.
-- Future providers can safely rely on Pi 0.84.3+ context estimation without polyfilling compaction.
-- Existing sessions and runtime configurations remain unaffected as Pi 0.84.3+ is backwards-compatible with 0.84.1 session formats.
+- Developers, CI jobs, and documentation share an exact, verified dependency baseline.
+- Future providers can safely rely on Pi 0.84.4+ context estimation without polyfilling compaction.
+- Existing sessions and runtime configurations remain unaffected as Pi 0.84.4 is backwards-compatible with 0.84.1 session formats.
 
 ## Amendments
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -17,4 +17,4 @@ Start from [`TEMPLATE.md`](TEMPLATE.md).
 
 - [`0001-documentation-and-evidence-governance.md`](0001-documentation-and-evidence-governance.md) — repository knowledge categories, evidence states, and publication boundaries.
 - [`0002-native-skill-lifecycle.md`](0002-native-skill-lifecycle.md) — use Pi's native Skill loading and Session lifecycle without an OpenPI body-recovery layer.
-- [`0003-supported-pi-baseline.md`](0003-supported-pi-baseline.md) — define and enforce the supported Pi baseline (0.84.3+) across manifest, lockfile, and docs.
+- [`0003-supported-pi-baseline.md`](0003-supported-pi-baseline.md) — update and align the supported Pi development baseline (0.84.4+) across manifest, lockfile, and docs.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -17,3 +17,4 @@ Start from [`TEMPLATE.md`](TEMPLATE.md).
 
 - [`0001-documentation-and-evidence-governance.md`](0001-documentation-and-evidence-governance.md) — repository knowledge categories, evidence states, and publication boundaries.
 - [`0002-native-skill-lifecycle.md`](0002-native-skill-lifecycle.md) — use Pi's native Skill loading and Session lifecycle without an OpenPI body-recovery layer.
+- [`0003-supported-pi-baseline.md`](0003-supported-pi-baseline.md) — define and enforce the supported Pi baseline (0.84.3+) across manifest, lockfile, and docs.

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.8",
-    "@earendil-works/pi-ai": "^0.84.1",
-    "@earendil-works/pi-coding-agent": "^0.84.1",
-    "@earendil-works/pi-tui": "^0.84.1",
+    "@earendil-works/pi-ai": "^0.84.3",
+    "@earendil-works/pi-coding-agent": "^0.84.3",
+    "@earendil-works/pi-tui": "^0.84.3",
     "@effect/tsgo": "^0.24.2",
     "@effect/vitest": "^4.0.0-beta.99",
     "@types/node": "^26.1.1",

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.8",
-    "@earendil-works/pi-ai": "^0.84.3",
-    "@earendil-works/pi-coding-agent": "^0.84.3",
-    "@earendil-works/pi-tui": "^0.84.3",
+    "@earendil-works/pi-ai": "^0.84.4",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
+    "@earendil-works/pi-tui": "^0.84.4",
     "@effect/tsgo": "^0.24.2",
     "@effect/vitest": "^4.0.0-beta.99",
     "@types/node": "^26.1.1",


### PR DESCRIPTION
## Problem

Closes #328. Relates to #269.

OpenPI previously expressed conflicting compatibility boundaries across repository assets:
- `README.md` documented support for Pi 0.84.1+;
- `package.json` specified `^0.84.1` for Pi devDependencies;
- `bun.lock` locked development and CI test environments to `0.84.1`, while `peerDependencies` permitted any compatible version via `*`.

This baseline drift created behavioral divergence between fresh installations and frozen-lock CI environments. Specifically, upstream Pi introduced critical lifecycle fixes in `v0.84.3` (compaction without token usage) and `v0.84.4` (tool choice).

## Value

- Unifies the verified development baseline and CI environment at Pi 0.84.4.
- Unlocks downstream provider implementations (e.g. PR #269) by allowing them to rely directly on Pi 0.84.3+/0.84.4+ native message-history context estimation and compaction without inventing custom workarounds or falsifying token usage.
- Retains OpenPI's core design stance: preserving Pi as the single source of truth for Session lifecycles.

## Approach

1. **Manifest & Lockfile Floor**: Updated `@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, and `@earendil-works/pi-tui` devDependencies in `package.json` from `^0.84.1` to `^0.84.4`, with `bun.lock` locked to the verified release `@0.84.4`.
2. **Published Peer Contract**: Maintained `peerDependencies: { ...: "*" }` as standard for Pi packages without introducing an artificial runtime host-rejection layer.
3. **Documentation Sync**: Updated the Pi version badge and requirements in `README.md` to `Pi 0.84.4+`.
4. **Decision Record**: Added `docs/decisions/0003-supported-pi-baseline.md` (status: `accepted`, applies from this Decision forward) documenting the baseline decision, factual boundaries, and rejected alternatives.

## Validation

- `bun run check:config-contract` -> passed (14 persisted fields)
- `bun run check:discipline` -> passed (12 append-only rows)
- `bun run format:check` -> 280 files checked, no fixes needed
- `bun run lint` -> 280 files checked, 0 errors, 0 warnings
- `bun run typecheck` -> passed (`tsc --noEmit`)
- `bun run test` (Node 22) -> 1108 passed, 1 platform skip; Vitest 30/30 passed (total 1138 passed tests, 0 failures)

## Impact

- **User-visible behavior**: None directly. Users on Pi 0.84.4+ receive consistent native context estimation.
- **Model-visible context/tools**: None.
- **Runtime/lifecycle**: Enables Pi-native message-history compaction for providers with zero or output-only usage.
- **Persisted config/data**: None. Backward compatible with existing session records.
- **Compatibility or risk**: Low. Baseline aligned to verified Pi 0.84.4 release.