### PR TITLE
fix(workflows): enforce text projection line bounds

### DIFF
--- a/extensions/shared/text-projection.ts
+++ b/extensions/shared/text-projection.ts
@@ -1,6 +1,13 @@
-import { formatSize, truncateHead } from "@earendil-works/pi-coding-agent";
+import {
+  formatSize,
+  truncateHead,
+  truncateTail,
+} from "@earendil-works/pi-coding-agent";
 
 const HEAD_SHARE = 0.75;
+const OMISSION_MARKER = "[... middle omitted ...]";
+// Three framing blanks, the omission marker, and the footer.
+const STATIC_PROJECTION_OVERHEAD_LINES = 5;
 
 function utf8Prefix(content: string, maxBytes: number) {
   const bytes = Buffer.from(content, "utf8");
@@ -14,16 +21,46 @@ function utf8Prefix(content: string, maxBytes: number) {
   return "";
 }
 
-function utf8Suffix(content: string, maxBytes: number) {
-  const bytes = Buffer.from(content, "utf8");
-  if (bytes.length <= maxBytes) return content;
-  let start = Math.max(0, bytes.length - maxBytes);
-  while (start < bytes.length) {
-    const value = bytes.subarray(start).toString("utf8");
-    if (!value.startsWith("�")) return value;
-    start += 1;
-  }
-  return "";
+function boundedHead(content: string, maxBytes: number, maxLines: number) {
+  const result = truncateHead(content, { maxBytes, maxLines });
+  if (result.content || !result.firstLineExceedsLimit) return result.content;
+  return utf8Prefix(content, maxBytes);
+}
+
+function compactProjection(
+  content: string,
+  maxBytes: number,
+  maxLines: number,
+) {
+  const marker =
+    maxBytes >= OMISSION_MARKER.length
+      ? OMISSION_MARKER
+      : ".".repeat(Math.min(3, maxBytes));
+  if (!marker || maxLines <= 0) return "";
+  if (maxLines === 1) return marker;
+
+  const bodyLineBudget = maxLines - 1;
+  const keepTail = bodyLineBudget >= 2;
+  const separatorBytes = keepTail ? 2 : 1;
+  const bodyByteBudget = maxBytes - marker.length - separatorBytes;
+  if (bodyByteBudget <= 0 || (keepTail && bodyByteBudget < 2)) return marker;
+
+  const headLines = keepTail
+    ? Math.max(1, Math.floor(bodyLineBudget * HEAD_SHARE))
+    : bodyLineBudget;
+  const tailLines = keepTail ? Math.max(1, bodyLineBudget - headLines) : 0;
+  const headBytes = keepTail
+    ? Math.max(1, Math.floor(bodyByteBudget * HEAD_SHARE))
+    : bodyByteBudget;
+  const tailBytes = keepTail ? Math.max(1, bodyByteBudget - headBytes) : 0;
+  const head = boundedHead(content, headBytes, headLines);
+  const tail = keepTail
+    ? truncateTail(content, {
+        maxBytes: tailBytes,
+        maxLines: tailLines,
+      }).content
+    : "";
+  return [head, marker, tail].filter(Boolean).join("\n");
 }
 
 /** Keep decision context at the start and verdict/evidence at the end. */
@@ -31,7 +68,7 @@ export function projectText(
   content: string,
   options: { maxBytes: number; maxLines: number; recovery: string },
 ) {
-  if (options.maxBytes <= 0) return "";
+  if (options.maxBytes <= 0 || options.maxLines <= 0) return "";
 
   const probe = truncateHead(content, {
     maxBytes: options.maxBytes,
@@ -39,22 +76,38 @@ export function projectText(
   });
   if (!probe.truncated) return content;
 
+  const recoveryNewlines = options.recovery.split("\n").length - 1;
+  const bodyLineBudget =
+    options.maxLines - STATIC_PROJECTION_OVERHEAD_LINES - recoveryNewlines;
+  if (bodyLineBudget < 2) {
+    return compactProjection(content, options.maxBytes, options.maxLines);
+  }
+  const headLines = Math.max(1, Math.floor(bodyLineBudget * HEAD_SHARE));
+  const tailLines = Math.max(1, bodyLineBudget - headLines);
+
   let bodyBudget = options.maxBytes;
   let projected = "";
   for (let attempt = 0; attempt < 8; attempt++) {
     const headBytes = Math.max(1, Math.floor(bodyBudget * HEAD_SHARE));
     const tailBytes = Math.max(1, bodyBudget - headBytes);
-    const head = utf8Prefix(content, headBytes);
-    const tail = utf8Suffix(content, tailBytes);
+    const head = boundedHead(content, headBytes, headLines);
+    const tail = truncateTail(content, {
+      maxBytes: tailBytes,
+      maxLines: tailLines,
+    }).content;
     const shown =
       Buffer.byteLength(head, "utf8") + Buffer.byteLength(tail, "utf8");
     const footer = `[Projection bounded: showing ${formatSize(shown)} of ${formatSize(probe.totalBytes)} across the head and tail. ${options.recovery}]`;
-    projected = `${head}\n\n[... middle omitted ...]\n\n${tail}\n\n${footer}`;
+    projected = `${head}\n\n${OMISSION_MARKER}\n\n${tail}\n\n${footer}`;
     const overflow = Buffer.byteLength(projected, "utf8") - options.maxBytes;
     if (overflow <= 0 || bodyBudget <= overflow + 2) break;
     bodyBudget -= overflow;
   }
-  return Buffer.byteLength(projected, "utf8") <= options.maxBytes
-    ? projected
-    : utf8Prefix(content, options.maxBytes);
+  const projectedProbe = truncateHead(projected, {
+    maxBytes: options.maxBytes,
+    maxLines: options.maxLines,
+  });
+  return projectedProbe.truncated
+    ? compactProjection(content, options.maxBytes, options.maxLines)
+    : projected;
 }

--- a/tests/extensions/shared/text-projection.test.ts
+++ b/tests/extensions/shared/text-projection.test.ts
@@ -2,11 +2,57 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { projectText } from "../../../extensions/shared/text-projection.ts";
 
-test("zero-byte projections are empty", () => {
+function lineCount(content: string) {
+  if (!content) return 0;
+  const lines = content.split("\n");
+  if (content.endsWith("\n")) lines.pop();
+  return lines.length;
+}
+
+function assertWithinBudgets(
+  content: string,
+  maxBytes: number,
+  maxLines: number,
+  label: string,
+) {
+  assert.ok(
+    Buffer.byteLength(content, "utf8") <= maxBytes,
+    `${label}: exceeded ${maxBytes} bytes`,
+  );
+  assert.ok(
+    lineCount(content) <= maxLines,
+    `${label}: exceeded ${maxLines} lines`,
+  );
+  assert.doesNotMatch(content, /�/, `${label}: split a UTF-8 character`);
+}
+
+test("content inside both budgets passes through byte-for-byte", () => {
+  for (const content of ["", "one line", "first\nsecond\n", "中文\r\n🙂"]) {
+    assert.equal(
+      projectText(content, {
+        maxBytes: 1024,
+        maxLines: 10,
+        recovery: "unused",
+      }),
+      content,
+    );
+  }
+});
+
+test("zero byte or line budgets produce no projection", () => {
+  const content = "🙂".repeat(100);
   assert.equal(
-    projectText("🙂".repeat(100), {
+    projectText(content, {
       maxBytes: 0,
       maxLines: 20,
+      recovery: "kept in artifacts",
+    }),
+    "",
+  );
+  assert.equal(
+    projectText(content, {
+      maxBytes: 2048,
+      maxLines: 0,
       recovery: "kept in artifacts",
     }),
     "",
@@ -20,7 +66,137 @@ test("tiny projections never exceed their UTF-8 byte budget", () => {
       maxLines: 20,
       recovery: "kept in artifacts",
     });
-    assert.ok(Buffer.byteLength(projected, "utf8") <= maxBytes);
-    assert.doesNotMatch(projected, /�/);
+    assertWithinBudgets(projected, maxBytes, 20, `${maxBytes}-byte cap`);
+    assert.match(projected, /(?:middle omitted|^\.+$)/m);
   }
+});
+
+test("line-only projections respect the hard line cap without duplicating content", () => {
+  const content = Array.from({ length: 40 }, (_, index) => `L${index}`).join(
+    "\n",
+  );
+  const projected = projectText(content, {
+    maxBytes: 2048,
+    maxLines: 10,
+    recovery: "kept in artifacts",
+  });
+
+  assert.equal(lineCount(projected), 10);
+  assert.match(projected, /^L0$/m);
+  assert.match(projected, /^L39$/m);
+  assert.deepEqual(
+    projected.split("\n").filter((line) => /^L\d+$/.test(line)),
+    ["L0", "L1", "L2", "L38", "L39"],
+  );
+  assert.match(projected, /\[\.\.\. middle omitted \.\.\.\]/);
+  assertWithinBudgets(projected, 2048, 10, "line-only projection");
+});
+
+test("small line budgets use a visible compact omission projection", () => {
+  const lines = Array.from({ length: 20 }, (_, index) => `L${index}`);
+  const content = lines.join("\n");
+
+  for (const maxLines of [1, 2, 3, 4, 5, 6]) {
+    const projected = projectText(content, {
+      maxBytes: 2048,
+      maxLines,
+      recovery: "kept in artifacts",
+    });
+    assert.match(projected, /middle omitted/);
+    if (maxLines >= 3) {
+      assert.match(projected, /^L0$/m);
+      assert.match(projected, /^L19$/m);
+    }
+    assertWithinBudgets(projected, 2048, maxLines, `${maxLines}-line fallback`);
+  }
+
+  assert.equal(
+    projectText(content, {
+      maxBytes: 2048,
+      maxLines: 3,
+      recovery: "kept in artifacts",
+    }),
+    "L0\n[... middle omitted ...]\nL19",
+  );
+});
+
+test("multi-line recovery text is included in the hard line budget", () => {
+  const content = Array.from({ length: 40 }, (_, index) => `L${index}`).join(
+    "\n",
+  );
+  const projected = projectText(content, {
+    maxBytes: 2048,
+    maxLines: 12,
+    recovery: "artifact line one\nartifact line two",
+  });
+
+  assert.equal(lineCount(projected), 12);
+  assert.match(projected, /^L0$/m);
+  assert.match(projected, /^L39$/m);
+  assert.match(projected, /artifact line one\nartifact line two\]$/);
+  assertWithinBudgets(projected, 2048, 12, "multi-line recovery");
+});
+
+test("byte-only truncation keeps valid UTF-8 at both ends", () => {
+  const content = `BEGIN-${"中🙂".repeat(100)}-END`;
+  const projected = projectText(content, {
+    maxBytes: 256,
+    maxLines: 20,
+    recovery: "kept in artifacts",
+  });
+
+  assert.match(projected, /^BEGIN-/);
+  assert.match(projected, /-END/);
+  assert.match(projected, /\[\.\.\. middle omitted \.\.\.\]/);
+  assertWithinBudgets(projected, 256, 20, "byte-only projection");
+});
+
+test("byte and line caps hold across encodings and newline styles", () => {
+  const samples = [
+    Array.from({ length: 40 }, (_, index) => `ASCII-${index}`).join("\n"),
+    Array.from({ length: 40 }, (_, index) => `CRLF-${index}`).join("\r\n"),
+    Array.from({ length: 40 }, (_, index) => `中文-${index}`).join("\n"),
+    Array.from({ length: 40 }, (_, index) => `🙂-${index}`).join("\n"),
+    `BEGIN-${"中🙂".repeat(100)}-END`,
+  ];
+  const byteLimits = [1, 4, 16, 64, 256, 2048];
+  const lineLimits = [0, 1, 3, 6, 7, 10, 20];
+  const recoveries = ["artifact", "artifact one\nartifact two"];
+  let cases = 0;
+
+  for (const content of samples) {
+    for (const maxBytes of byteLimits) {
+      for (const maxLines of lineLimits) {
+        for (const recovery of recoveries) {
+          const projected = projectText(content, {
+            maxBytes,
+            maxLines,
+            recovery,
+          });
+          const label = JSON.stringify({
+            sample: samples.indexOf(content),
+            maxBytes,
+            maxLines,
+            recoveryLines: lineCount(recovery),
+          });
+          assertWithinBudgets(projected, maxBytes, maxLines, label);
+          const fitsWithoutProjection =
+            Buffer.byteLength(content, "utf8") <= maxBytes &&
+            lineCount(content) <= maxLines;
+          if (fitsWithoutProjection) {
+            assert.equal(projected, content, `${label}: changed bounded input`);
+          } else if (maxBytes > 0 && maxLines > 0) {
+            assert.match(
+              projected,
+              /(?:middle omitted|^\.+$)/m,
+              `${label}: silently omitted content`,
+            );
+          }
+          cases++;
+        }
+      }
+    }
+  }
+
+  assert.equal(cases, 420);
 });


### PR DESCRIPTION
## Problem

Closes #329.

`projectText()` detects overflow with both `maxBytes` and `maxLines`, but the existing head/tail projection only applies byte limits. Its final validation also checks only the byte count.

A 40-line, 149-byte input projected with `maxLines: 3` and `maxBytes: 2048` therefore produces 85 lines and duplicates the complete input around the omission marker. The footer reports `showing 298 B of 149 B`, confirming that the selected head and tail overlap.

This affects bounded Workflow result messages, completion batches, handoffs, and operator-facing completion reports.

## Value

This change makes the `{ maxBytes, maxLines }` contract dependable. A caller that allocates 400 lines can treat that value as a hard upper bound rather than a hint that is checked once and then lost during projection. The byte limit cannot replace the line limit: logs, file lists, and compact records can contain hundreds of short lines while remaining well below their byte budget.

For model-facing Workflow results, enforcing both limits keeps projected output within the context shape selected by the caller. The current bug can turn a small line-only overflow into a larger result by including the same source text as both the head and the tail. Removing that overlap avoids spending context on duplicate evidence and leaves the available projection budget for distinct information from the beginning and end of the result.

This also improves the quality of the evidence presented to the model. Repeating the same conclusion or error text can give it disproportionate weight during synthesis, even though the repetition was introduced by the projection layer rather than the Workflow itself. A non-overlapping head/tail projection preserves more of the source's actual coverage and does not manufacture repetition.

The same helper is used for parent-model result delivery, background completion batches, downstream handoffs, and expanded operator reports. Fixing the shared projection contract gives those paths consistent behavior without adding separate truncation rules to each Workflow surface.

Finally, projection diagnostics become internally consistent. A footer such as `showing 298 B of 149 B` is impossible when the selected source ranges do not overlap, and the reported bounds once again describe the text that was actually returned.

The change is limited to derived projections. Workflow execution, canonical results, persisted audit artifacts, and configured production limits are unchanged. Content that already fits both limits still passes through byte-for-byte, while the exact source remains recoverable from the existing artifacts when projection is required.

## Approach

- Apply both byte and line budgets when selecting the projected head and tail.
- Preserve the existing 75/25 head-to-tail allocation.
- Include omission markers, separator lines, the footer, and multi-line recovery text in the line budget.
- Use a compact, visibly omitted representation when the line budget cannot fit the normal framed projection.
- Validate the completed projection against both limits before returning it.
- Preserve byte-for-byte passthrough for input that already fits both limits.
- Add regression coverage for line-only overflow, small budgets, UTF-8 input, LF/CRLF input, and combined byte/line limits.

## Validation

Passed:

- `git diff --check`
- Target-file Biome format check
- Target-file Biome lint with `--error-on-warnings`
- `bun run lint` — 280 files checked
- `tsc --noEmit`
- `node scripts/check-config-contract.mjs` — 14 persisted fields checked
- `node scripts/check-discipline-ledger.mjs` — 12 append-only rows checked
- Relevant Node tests:

  ```text
  node --test --experimental-strip-types \
    tests/extensions/shared/text-projection.test.ts \
    tests/extensions/workflows/prompt.test.ts \
    tests/extensions/workflows/handoff.test.ts
  ```

  Result: 40 passed, 0 failed.

Not completed cleanly in the existing Windows checkout:

- `bun run check` reaches `format:check`, which reports 262 formatting diagnostics caused by pre-existing CRLF working-tree files outside this PR. Both changed files pass the same formatter, and full lint plus type checking pass separately.
- `bun run test` reaches the existing Windows `background-terminals` process-termination failures and then stops making progress. Four failures were observed in that area before the run was interrupted. This matches #304; this PR does not modify background terminal code.

No benchmark was run because the change affects bounded text selection rather than a performance-sensitive execution path.

## Impact

- User-visible behavior: truncated Workflow reports stay within their configured line limit and no longer repeat overlapping source text.
- Model-visible context: bounded Workflow results and handoffs may contain a more compact projection when line limits are reached.
- Runtime and lifecycle: no change.
- Persisted configuration and data: no change.
- Compatibility: input that fits both limits remains unchanged. Exact truncated content remains recoverable from the existing Workflow audit artifacts.