### PR TITLE
chore(deps): raise the Pi compatibility floor to 0.84.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,22 @@ permissions:
 
 jobs:
   test:
-    name: Node ${{ matrix.node-version }}
+    name: Node ${{ matrix.node-version }}${{ matrix.label }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.19.0, 24]
+        include:
+          - node-version: 22.19.0
+            pi-version: locked
+            label: ""
+          - node-version: 24
+            pi-version: locked
+            label: ""
+          - node-version: 22.19.0
+            pi-version: 0.84.3
+            label: " (Pi 0.84.3)"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -29,8 +38,46 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
-      - name: Install dependencies
+      - name: Install locked dependencies
+        if: matrix.pi-version == 'locked'
         run: bun install --frozen-lockfile
+      - name: Pin minimum supported Pi family
+        if: matrix.pi-version != 'locked'
+        env:
+          PI_VERSION: ${{ matrix.pi-version }}
+        run: |
+          node --input-type=module -e '
+            import { readFileSync, writeFileSync } from "node:fs";
+            const path = "package.json";
+            const manifest = JSON.parse(readFileSync(path, "utf8"));
+            const packages = ["agent-core", "ai", "client", "coding-agent", "protocol", "telemetry", "tui"]
+              .map((name) => `@earendil-works/pi-${name}`);
+            manifest.overrides = {
+              ...manifest.overrides,
+              ...Object.fromEntries(packages.map((name) => [name, process.env.PI_VERSION])),
+            };
+            writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
+          '
+          bun install
+          git restore package.json
+      - name: Verify minimum supported Pi family
+        if: matrix.pi-version != 'locked'
+        env:
+          EXPECTED_PI_VERSION: ${{ matrix.pi-version }}
+        run: |
+          node --input-type=module -e '
+            import { execFileSync } from "node:child_process";
+            const packages = ["agent-core", "ai", "client", "coding-agent", "protocol", "telemetry", "tui"]
+              .map((name) => `@earendil-works/pi-${name}`);
+            const output = execFileSync("bun", ["pm", "ls", "--all"], { encoding: "utf8" });
+            const resolved = [...output.matchAll(/(@earendil-works\/pi-(?:agent-core|ai|client|coding-agent|protocol|telemetry|tui))@(\d+\.\d+\.\d+)/g)]
+              .map(([, name, version]) => ({ name, version }));
+            const missing = packages.filter((name) => !resolved.some((entry) => entry.name === name));
+            const mismatches = resolved.filter((entry) => entry.version !== process.env.EXPECTED_PI_VERSION);
+            if (missing.length || mismatches.length) {
+              throw new Error(`Expected the full Pi family at ${process.env.EXPECTED_PI_VERSION}; missing=${JSON.stringify(missing)} mismatches=${JSON.stringify(mismatches)}`);
+            }
+          '
       - run: bun run check
       - run: bun run test
       - name: Smoke-test Pi package discovery

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/@tt-a1i/openpi"><img alt="npm version" src="https://img.shields.io/npm/v/@tt-a1i/openpi?style=flat-square&color=cb3837"></a>
   <a href="https://github.com/openpi-dev/openpi/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/openpi-dev/openpi/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="https://github.com/earendil-works/pi-mono"><img alt="Pi 0.84.1+" src="https://img.shields.io/badge/Pi-0.84.1%2B-2f81f7?style=flat-square"></a>
+  <a href="https://github.com/earendil-works/pi-mono"><img alt="Pi 0.84.3+" src="https://img.shields.io/badge/Pi-0.84.3%2B-2f81f7?style=flat-square"></a>
   <img alt="Node.js 22.19+" src="https://img.shields.io/badge/Node.js-22.19%2B-3fb950?style=flat-square&logo=nodedotjs&logoColor=white">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-3fb950?style=flat-square"></a>
 </p>
@@ -445,7 +445,7 @@ Footer 布局以 `footerLines` 作为唯一持久化格式。旧版 `footerItems
 
 ### 安装要求与来源
 
-- Pi `0.84.1` 或更新版本；
+- Pi `0.84.3` 或更新版本；
 - Node.js `22.19.0` 或更新版本；
 - npm 安装：`pi install npm:@tt-a1i/openpi`；
 - GitHub 安装：`pi install git:github.com/openpi-dev/openpi`。

--- a/bun.lock
+++ b/bun.lock
@@ -11,9 +11,9 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.8",
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-coding-agent": "^0.84.1",
-        "@earendil-works/pi-tui": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.84.3",
+        "@earendil-works/pi-coding-agent": "^0.84.3",
+        "@earendil-works/pi-tui": "^0.84.3",
         "@effect/tsgo": "^0.24.2",
         "@effect/vitest": "^4.0.0-beta.99",
         "@types/node": "^26.1.1",
@@ -102,19 +102,19 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.8", "", { "os": "win32", "cpu": "x64" }, "sha512-I2czzXTY61f3nFJxXoMDq80t7MivxDEnCjE+8sDKoFfcKMaoQdkqhIFQ3KyY0XLzeSpUBYeNAXgD+iOV/BU0VA=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.1", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.1", "@earendil-works/pi-telemetry": "^0.84.1", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, ""],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.4", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.4", "@earendil-works/pi-telemetry": "^0.84.4", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-HyUnjaOXj6oN/6SNcr8A1J/ElRQA50FtIE0XUTSKAQVqmdlb9qdojOyUQwF/jULE5+yOEtGuVgi/N1RnBiNG+g=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.1", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.4", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.4", "@google/genai": "1.52.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.40.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw=="],
 
-    "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.1", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.1" } }, ""],
+    "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.4", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.4" } }, "sha512-q398WY/3ZQHTizk7IKxApzqFV0xt4yM9LkSkwyqeLK5Bj5RwRjOWxESt26z4LgNp4O+8hqhqFPf/8fj4H5rE4A=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.84.1", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.84.1", "@earendil-works/pi-ai": "^0.84.1", "@earendil-works/pi-client": "^0.84.1", "@earendil-works/pi-protocol": "^0.84.1", "@earendil-works/pi-tui": "^0.84.1", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "grok-mermaid": "0.2.2", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.9.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.84.4", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.84.4", "@earendil-works/pi-ai": "^0.84.4", "@earendil-works/pi-client": "^0.84.4", "@earendil-works/pi-protocol": "^0.84.4", "@earendil-works/pi-tui": "^0.84.4", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "grok-mermaid": "0.2.2", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.9.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/bundle/cli.js" } }, "sha512-jmOlrqUmvhh/siNWFRXjYLJzhKFIHNsAQaysRwzQPQFnPAaV/vhqHsLH/MBsIISA1Rjj7WTUFR3nJrpXoLx39w=="],
 
-    "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.1", "", { "dependencies": { "typebox": "1.3.7" } }, ""],
+    "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.4", "", { "dependencies": { "typebox": "1.3.7" } }, "sha512-acyE9ozxkMiWiz/xyWpU0O9vwnYv0hyG889Vniv6Sg9c9zfsX+8MePnDNphBacY2Fvm1rxdsGmiVDSZl9yuDFA=="],
 
-    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.1", "", {}, "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ=="],
+    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.4", "", {}, "sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.1", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.4", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-nPUnwDkLtupPXnZQYrCwPFcuTydCDqTY6ZbFqhsL4S4kVq0AT418kPa/6uXwtaCD+MjBNBltb7ScTYX65yeE1w=="],
 
     "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.103", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.103", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.103", "ioredis": "^5.7.0" } }, "sha512-VD8fbpendwFokMwzC7/MxazjhEVDihPC5NZtomYEyZwGaA1LXMvwP1y8pfXwfshUkG56TN4EMQqzu72c0B9FhA=="],
 
@@ -166,8 +166,6 @@
 
     "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
 
-    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
-
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
@@ -183,8 +181,6 @@
     "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
-
-    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.142.0", "", {}, "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ=="],
 
@@ -396,8 +392,6 @@
 
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
-    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
-
     "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
@@ -470,8 +464,6 @@
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
-    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
-
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msgpackr": ["msgpackr@2.0.5", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA=="],
@@ -490,7 +482,7 @@
 
     "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
-    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "bin": "bin/cli" }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+    "openai": ["openai@6.40.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"] }, "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA=="],
 
     "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
 
@@ -499,8 +491,6 @@
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
-
-    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -588,13 +578,9 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
-
     "@effect/platform-node/undici": ["undici@8.10.0", "", {}, "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ=="],
 
     "@effect/platform-node-shared/ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
-
-    "@mistralai/mistralai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 

--- a/docs/decisions/0003-pi-compatibility-baseline.md
+++ b/docs/decisions/0003-pi-compatibility-baseline.md
@@ -1,0 +1,51 @@
+---
+decision-status: proposed
+created: 2026-09-01
+last-reviewed: 2026-09-01
+applies-to: OpenPI development dependencies, CI compatibility lanes, and documented Pi requirement
+owner: OpenPI maintainers
+related-issues: "#328"
+related-prs: "#333"
+supersedes: none
+---
+
+# Decision 0003: Set the Pi compatibility floor to 0.84.3
+
+## Context
+
+OpenPI currently documents Pi 0.84.1 and keeps its Pi development packages and lockfile on that release. Caret ranges allow newer compatible releases, but the frozen lock means normal development and CI exercise only the locked version.
+
+Pi 0.84.3 introduced two host contracts that OpenPI now relies on: threshold compaction when a provider correctly leaves usage unknown, and the public `SimpleStreamOptions.toolChoice` surface. The Cursor provider in [PR #269](https://github.com/openpi-dev/openpi/pull/269) can preserve correct unknown usage on Pi 0.84.1, but an all-Cursor session on that host cannot reach threshold compaction because the real `AgentSession._checkCompaction` entry returns before estimating a history with no usage-backed response.
+
+## Decision
+
+- Document Pi 0.84.3 as OpenPI's minimum supported host version.
+- Set the three Pi development dependencies to `^0.84.3`; retain `*` peer dependencies because Pi owns the runtime copies used by installed packages.
+- Lock normal development to the newest compatible Pi patch currently available, 0.84.4.
+- Keep the existing locked Node 22 and Node 24 CI lanes, and add one full Node 22 lane that transiently overrides and verifies the entire resolved Pi package family at 0.84.3 before running the same checks, tests, and package smoke acceptance.
+- Handle future baseline changes in their own Issue and PR with an explicit minimum-version lane and a locked-version lane.
+
+## Evidence boundary
+
+The Pi source change [`4495469a5`](https://github.com/earendil-works/pi/commit/4495469a5) adds compaction without provider usage and is first released in Pi 0.84.3. The public tool-choice change [`e5dde9a76`](https://github.com/earendil-works/pi/commit/e5dde9a76) is also first released in 0.84.3.
+
+For PR #269, the provider regression invokes the real `_checkCompaction` entry. Local isolated runs observed no threshold compaction on Pi 0.84.1 and one native threshold compaction call on Pi 0.84.4; both versions passed the static checks, full test suite, source-install smoke, and packed-package smoke. The new minimum-version CI lane is the acceptance evidence for exact Pi 0.84.3. Real-account provider behavior and future Pi releases remain outside this Decision's evidence.
+
+Decision 0002's Pi 0.84.1 references remain historical evidence for that Skill lifecycle decision; this proposal does not rewrite them.
+
+## Alternatives considered
+
+- Keep 0.84.1 as the project floor and document the Cursor limitation indefinitely. This preserves installation breadth but leaves a core Session lifecycle incomplete for a supported provider.
+- Pin every Pi package exactly to 0.84.4. This narrows compatible patch uptake and conflicts with the repository's caret-based development dependency policy.
+- Change runtime peer dependencies from `*` to `>=0.84.3`. This would make npm express the floor, but conflicts with OpenPI's Pi-host package contract: the host owns those packages, while OpenPI keeps development copies only for checks and tests.
+- Upgrade the dependencies inside PR #269. This would mix a project-wide runtime baseline decision into a provider feature and make either change harder to review or revert independently.
+
+## Consequences
+
+Development and the main locked CI lanes exercise Pi 0.84.4, while a separate lane prevents accidental use of APIs newer than the documented 0.84.3 floor. Provider code no longer needs to describe Pi 0.84.1 as fully supporting unknown-usage threshold compaction.
+
+Users on Pi 0.84.1 or 0.84.2 must upgrade Pi to receive the documented OpenPI support boundary. Because peer dependencies remain host-owned wildcards, README and release notes must communicate this requirement; npm alone will not reject an older host. Each additional CI lane increases test time, but the minimum lane carries an independent compatibility invariant rather than duplicating an unbounded version matrix.
+
+## Amendments
+
+None. This record remains proposed until maintainers merge the implementation PR.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -17,3 +17,4 @@ Start from [`TEMPLATE.md`](TEMPLATE.md).
 
 - [`0001-documentation-and-evidence-governance.md`](0001-documentation-and-evidence-governance.md) — repository knowledge categories, evidence states, and publication boundaries.
 - [`0002-native-skill-lifecycle.md`](0002-native-skill-lifecycle.md) — use Pi's native Skill loading and Session lifecycle without an OpenPI body-recovery layer.
+- [`0003-pi-compatibility-baseline.md`](0003-pi-compatibility-baseline.md) — propose Pi 0.84.3 as the documented and continuously tested OpenPI compatibility floor.

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.8",
-    "@earendil-works/pi-ai": "^0.84.1",
-    "@earendil-works/pi-coding-agent": "^0.84.1",
-    "@earendil-works/pi-tui": "^0.84.1",
+    "@earendil-works/pi-ai": "^0.84.3",
+    "@earendil-works/pi-coding-agent": "^0.84.3",
+    "@earendil-works/pi-tui": "^0.84.3",
     "@effect/tsgo": "^0.24.2",
     "@effect/vitest": "^4.0.0-beta.99",
     "@types/node": "^26.1.1",

--- a/tests/extensions/setup/package-contract.test.ts
+++ b/tests/extensions/setup/package-contract.test.ts
@@ -35,6 +35,10 @@ const HOST_PACKAGES = [
   "typebox",
 ] as const;
 
+const PI_HOST_PACKAGES = HOST_PACKAGES.filter((packageName) =>
+  packageName.startsWith("@earendil-works/pi-"),
+);
+
 test("Pi host packages stay peers while local checks keep development copies", () => {
   for (const packageName of HOST_PACKAGES) {
     assert.equal(manifest.peerDependencies?.[packageName], "*");
@@ -45,6 +49,12 @@ test("Pi host packages stay peers while local checks keep development copies", (
 
 test("the manifest enforces the documented Node floor", () => {
   assert.equal(manifest.engines?.node, ">=22.19.0");
+});
+
+test("Pi development packages enforce the documented compatibility floor", () => {
+  for (const packageName of PI_HOST_PACKAGES) {
+    assert.equal(manifest.devDependencies?.[packageName], "^0.84.3");
+  }
 });
 
 test("pi-intercom stays an explicit opt-in instead of a bundled dependency", () => {


### PR DESCRIPTION
## Problem

OpenPI documents and freezes Pi 0.84.1 even though provider correctness now depends on host contracts first released in Pi 0.84.3. Caret development ranges allow newer patches, but the frozen lock and existing CI lanes do not continuously prove either the intended floor or the newest locked patch.

Closes #328. This is the project-wide compatibility follow-up to #269; that provider PR intentionally keeps `package.json` and `bun.lock` unchanged.

## Value

The repository gains one explicit, reviewable Pi support boundary instead of handling version-sensitive provider behavior case by case. Contributors test against the current compatible patch, while CI prevents accidental use of APIs newer than the documented minimum.

## Approach

- Raise the three Pi development ranges from `^0.84.1` to `^0.84.3` and regenerate `bun.lock`, which currently resolves the compatible Pi family at 0.84.4.
- Keep runtime peer dependencies at `*`; Pi remains the owner of the host packages used by installed OpenPI packages.
- Preserve the existing locked Node 22 and Node 24 check names, and add a Node 22 minimum-version lane.
- In the minimum lane, transiently override and verify all seven resolved Pi packages at exactly 0.84.3, then restore the publishable manifest before running the normal checks, tests, source-install smoke, and packed-package smoke.
- Document the support boundary and its evidence in Decision 0003 and README, and enforce the declared development floor with the package contract test.

## Validation

- `NPM_CONFIG_REGISTRY=https://registry.npmjs.org bun install --frozen-lockfile` — passed with locked Pi 0.84.4.
- `bun run check` — passed on locked Pi 0.84.4 and an isolated exact Pi 0.84.3 family.
- `PI_CODING_AGENT_DIR="$(mktemp -d)" bun run test` — both versions passed 1,115 of 1,116 Node tests with the single Windows-only test skipped, plus 30/30 Vitest tests.
- Source-install package discovery smoke — passed on Pi 0.84.3 and 0.84.4.
- Packed-package loading without optional peers — passed on Pi 0.84.3 and 0.84.4.
- `git diff --check` — passed.

## Impact

Users and contributors must use Pi 0.84.3 or newer for the documented support boundary. No model-visible tools or context, runtime provider behavior, or persisted configuration/data change in this PR. The lockfile moves normal development to Pi 0.84.4 and its compatible transitive dependency graph; CI gains one full minimum-version lane and therefore additional runtime.
