### PR TITLE
feat(web): add Pi-native /web launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ pi install npm:pi-intercom
 
 ### 独立 Web 工作台
 
-Web 工作台不是交互式终端 Session 的 extension。它由独立进程创建自己的 Pi `AgentSessionRuntime`、独立 `~/.pi/agent/web-sessions` 持久化目录和生命周期；浏览器发送消息、新建 Session 或切换工作区，不会写入或切换任何已经运行的终端 Pi Session，Web Session 也不会出现在终端的默认 Session 列表中。在侧栏选择 Session 会把它激活为 Web 进程的当前 Pi Session；Prompt 只会投递到请求时仍匹配的活动 Web Session。独立的只读历史浏览不属于首版范围。
+Web runtime 不嵌入交互式终端 Session。它由独立进程创建自己的 Pi `AgentSessionRuntime`、独立 `~/.pi/agent/web-sessions` 持久化目录和生命周期；浏览器发送消息、新建 Session 或切换工作区，不会写入或切换任何已经运行的终端 Pi Session，Web Session 也不会出现在终端的默认 Session 列表中。在侧栏选择 Session 会把它激活为 Web 进程的当前 Pi Session；Prompt 只会投递到请求时仍匹配的活动 Web Session。独立的只读历史浏览不属于首版范围。
 
 同一 Pi agent 目录一次只允许一个 Web Host 持有该 Session/元数据目录。第二个 `openpi web` 会明确拒绝启动；正常关停会先排空共享目录变更再释放租约，进程崩溃后仅在确认原 owner 的 PID 与进程启动身份不再匹配时恢复。一个 Host 可在侧栏管理多个工作区，因此不需要为每个仓库启动一个进程。
 
@@ -542,6 +542,8 @@ openpi web /path/to/repo      # 指定初始工作区
 
 两处应保持同一 OpenPI 版本。Pi 的 managed package 与全局 CLI 即使位于不同物理路径，同一 Web 进程内也通过带版本的共享 registry 按 Pi `SessionManager` 身份连接 capability 投影；它不保存第二份状态，也不兼容任意混装版本。
 
+已经在 Pi 中安装 OpenPI 时，也可以直接执行 `/web`。它通过 Pi 官方的交互式终端 seam 暂停当前 TUI，运行当前 package 内完全相同的 `openpi web` 子进程，并在 `Ctrl+C` 停止 Web 后恢复原来的终端 Session。运行期间终端只归 Web 子进程使用；父 Pi 不读取按键，也不会把当前 Session id、消息、上下文或工作目录传给浏览器。Web 会恢复它自己的已有 Session 和工作区；没有可用项时，由用户在浏览器中添加或选择，不会把启动 `/web` 时的终端目录自动注册为 Web 工作区。选择前的内部引导态不暴露 Session、不绑定 extension 生命周期，也不接受 Prompt 或模型变更。选择工作区后发送第一条消息会先创建真实 Web Session，再向它投递。
+
 Pi 当前只原生分派 `install`、`remove`、`update`、`list`、`config` 和 `auth` 等固定子命令，package 不能注册新的顶层子命令。因此 Web 入口是独立 CLI 的 `openpi web`，不是会被 Pi 当成初始 Prompt 的 `pi open`。Web 进程仍沿用 Pi 的 Provider、模型、凭据、Settings、Trust、Session 格式和 extension 资源加载，不引入第二套 Provider 或 Session 存储。
 
 ### 命令速查
@@ -549,6 +551,7 @@ Pi 当前只原生分派 `install`、`remove`、`update`、`list`、`config` 和
 | 命令                       | 作用                                           |
 | -------------------------- | ---------------------------------------------- |
 | `/openpi-setup [自然语言]` | 查看或修改 OpenPI 自有配置                     |
+| `/web`                     | 前台运行独立 Web 工作台；`Ctrl+C` 后返回 Pi    |
 | `/ps`                      | 查看、跟踪与终止后台终端                       |
 | `/subagents` / `/btw`      | 管理 Subagent / 在旁路 Context 中提问；仅 TUI  |
 | `/workflows`               | 查看阶段、Agent、Graph 与产物；可停止运行      |

--- a/bin/openpi.js
+++ b/bin/openpi.js
@@ -25,12 +25,14 @@ if (args.includes("--help") || args.includes("-h")) {
 }
 const command = args[0] === "web" ? args.slice(1) : args;
 const noOpen = command.includes("--no-open");
+const noWorkspace = command.includes("--no-workspace");
 const portIndex = command.indexOf("--port");
 const portText = portIndex >= 0 ? command[portIndex + 1] : undefined;
 const workspaceArgs = [];
 for (let index = 0; index < command.length; index++) {
   const value = command[index];
   if (value === "--no-open") continue;
+  if (value === "--no-workspace") continue;
   if (value === "--port") {
     index++;
     continue;
@@ -51,6 +53,10 @@ if (workspaceArgs.length > 1) {
   console.error("Usage: openpi web [workspace]");
   process.exit(1);
 }
+if (noWorkspace && workspaceArgs.length > 0) {
+  console.error("--no-workspace cannot be combined with a workspace");
+  process.exit(1);
+}
 
 let host;
 let runtime;
@@ -62,20 +68,22 @@ const stop = () => {
 
 try {
   const jiti = createJiti(import.meta.url);
-  const [browserModule, hostModule, runtimeModule, traceModule] =
+  const [browserModule, hostModule, runtimeModule, statusModule, traceModule] =
     await Promise.all([
       jiti.import("../web/host/browser-launcher.ts"),
       jiti.import("../web/host/web-host.ts"),
       jiti.import("../web/runtime/pi-runtime.ts"),
+      jiti.import("../web/host/terminal-status.ts"),
       jiti.import("../web/trace.ts"),
     ]);
   const { openBrowser } = browserModule;
   const { WebHost } = hostModule;
   const { PiWebRuntime } = runtimeModule;
+  const { formatWebReadyScreen } = statusModule;
   const { traceWeb } = traceModule;
-  runtime = await PiWebRuntime.create(
-    resolve(workspaceArgs[0] ?? process.cwd()),
-  );
+  runtime = noWorkspace
+    ? await PiWebRuntime.createWithoutWorkspace()
+    : await PiWebRuntime.create(resolve(workspaceArgs[0] ?? process.cwd()));
   host = new WebHost({
     runtime,
     ...(port === undefined ? {} : { port }),
@@ -87,10 +95,18 @@ try {
       : {}),
   });
   await host.start();
-  traceWeb("web_started", { cwd: runtime.cwd, origin: host.origin });
+  traceWeb("web_started", {
+    ...(runtime.workspaceSelected === true ? { cwd: runtime.cwd } : {}),
+    origin: host.origin,
+  });
   const opened = noOpen ? false : await openBrowser(host.url);
-  console.log(`OpenPI Web Workbench is running at ${host.origin}`);
-  if (!opened) console.log(`Open this URL in a browser: ${host.url}`);
+  console.log(
+    formatWebReadyScreen({
+      origin: host.origin,
+      url: host.url,
+      opened,
+    }),
+  );
 
   for (const signal of ["SIGINT", "SIGTERM"]) {
     process.once(signal, () => {

--- a/bin/openpi.js
+++ b/bin/openpi.js
@@ -100,13 +100,18 @@ try {
     origin: host.origin,
   });
   const opened = noOpen ? false : await openBrowser(host.url);
-  console.log(
-    formatWebReadyScreen({
-      origin: host.origin,
-      url: host.url,
-      opened,
-    }),
-  );
+  if (noWorkspace) {
+    console.log(
+      formatWebReadyScreen({
+        origin: host.origin,
+        url: host.url,
+        opened,
+      }),
+    );
+  } else {
+    console.log(`OpenPI Web Workbench is running at ${host.origin}`);
+    if (!opened) console.log(`Open this URL in a browser: ${host.url}`);
+  }
 
   for (const signal of ["SIGINT", "SIGTERM"]) {
     process.once(signal, () => {

--- a/extensions/web/index.ts
+++ b/extensions/web/index.ts
@@ -1,0 +1,234 @@
+import { spawn as nodeSpawn } from "node:child_process";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+} from "@earendil-works/pi-coding-agent";
+
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 5_000;
+
+export interface WebProcess {
+  readonly exitCode: number | null;
+  readonly signalCode: NodeJS.Signals | null;
+  once(event: "error", listener: (error: Error) => void): this;
+  once(
+    event: "close",
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): this;
+  kill(signal?: NodeJS.Signals): boolean;
+}
+
+interface SpawnWebOptions {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  shell: false;
+  stdio: "inherit";
+}
+
+function webProcessEnvironment(cwd: string) {
+  const environment: NodeJS.ProcessEnv = { ...process.env, PWD: cwd };
+  delete environment.OLDPWD;
+  delete environment.INIT_CWD;
+  delete environment.PI_SESSION_ID;
+  delete environment.PI_SESSION_FILE;
+  return environment;
+}
+
+export interface WebCommandDependencies {
+  entrypoint: string;
+  spawn(command: string, args: string[], options: SpawnWebOptions): WebProcess;
+  clearTerminal(): void;
+  holdParentSigint(): () => void;
+  shutdownTimeoutMs: number;
+}
+
+type WebExit =
+  | { kind: "close"; code: number | null; signal: NodeJS.Signals | null }
+  | { kind: "error"; error: Error };
+
+interface ActiveWebProcess {
+  child: WebProcess;
+  closed: Promise<void>;
+}
+
+const defaultDependencies: WebCommandDependencies = {
+  entrypoint: fileURLToPath(new URL("../../bin/openpi.js", import.meta.url)),
+  spawn(command, args, options) {
+    return nodeSpawn(command, args, options);
+  },
+  clearTerminal() {
+    process.stdout.write("\u001b[2J\u001b[H");
+  },
+  holdParentSigint() {
+    const keepPiAlive = () => {};
+    process.on("SIGINT", keepPiAlive);
+    return () => process.removeListener("SIGINT", keepPiAlive);
+  },
+  shutdownTimeoutMs: DEFAULT_SHUTDOWN_TIMEOUT_MS,
+};
+
+function delay(milliseconds: number) {
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, milliseconds);
+    timer.unref();
+  });
+}
+
+async function stopWebProcess(active: ActiveWebProcess, timeoutMs: number) {
+  if (active.child.exitCode !== null || active.child.signalCode !== null)
+    return;
+  active.child.kill("SIGTERM");
+  const timedOut = await Promise.race([
+    active.closed.then(() => false),
+    delay(timeoutMs).then(() => true),
+  ]);
+  if (!timedOut) return;
+  if (active.child.exitCode === null && active.child.signalCode === null) {
+    active.child.kill("SIGKILL");
+    await Promise.race([active.closed, delay(timeoutMs)]);
+  }
+}
+
+function runWebInForeground(
+  ctx: ExtensionCommandContext,
+  dependencies: WebCommandDependencies,
+  setActive: (active: ActiveWebProcess | undefined) => void,
+  isShuttingDown: () => boolean,
+) {
+  return ctx.ui.custom<WebExit>((tui, _theme, _keybindings, done) => {
+    let finished = false;
+    let tuiStopped = false;
+    let resolveClosed = () => {};
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+    const releaseParentSigint = dependencies.holdParentSigint();
+
+    const finish = (result: WebExit) => {
+      if (finished) return;
+      finished = true;
+      releaseParentSigint();
+      setActive(undefined);
+      resolveClosed();
+      if (tuiStopped && !isShuttingDown()) {
+        tui.start();
+        tui.requestRender(true);
+      }
+      done(result);
+    };
+
+    try {
+      tui.stop();
+      tuiStopped = true;
+      dependencies.clearTerminal();
+      const childCwd = dirname(dependencies.entrypoint);
+      const child = dependencies.spawn(
+        process.execPath,
+        [dependencies.entrypoint, "web", "--no-workspace"],
+        {
+          cwd: childCwd,
+          env: webProcessEnvironment(childCwd),
+          shell: false,
+          stdio: "inherit",
+        },
+      );
+      setActive({ child, closed });
+      child.once("error", (error) => finish({ kind: "error", error }));
+      child.once("close", (code, signal) =>
+        finish({ kind: "close", code, signal }),
+      );
+    } catch (error) {
+      finish({
+        kind: "error",
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+    }
+
+    return { render: () => [], invalidate: () => {} };
+  });
+}
+
+export default function web(
+  pi: ExtensionAPI,
+  dependencies: WebCommandDependencies = defaultDependencies,
+) {
+  let active: ActiveWebProcess | undefined;
+  let running = false;
+  let shuttingDown = false;
+
+  pi.on("session_start", () => {
+    shuttingDown = false;
+  });
+
+  pi.on("session_shutdown", async () => {
+    shuttingDown = true;
+    if (active) {
+      await stopWebProcess(active, dependencies.shutdownTimeoutMs);
+    }
+  });
+
+  pi.registerCommand("web", {
+    description:
+      "Open the separate OpenPI Web Workbench in this terminal until Ctrl+C",
+    handler: async (args, ctx) => {
+      if (args.trim()) {
+        ctx.ui.notify("Usage: /web", "warning");
+        return;
+      }
+      if (ctx.mode !== "tui") {
+        ctx.ui.notify("/web requires the interactive TUI.", "warning");
+        return;
+      }
+      if (!ctx.isIdle() || ctx.hasPendingMessages()) {
+        ctx.ui.notify(
+          "Wait until the current Pi Session is idle before starting /web.",
+          "warning",
+        );
+        return;
+      }
+      if (running) {
+        ctx.ui.notify("OpenPI Web Workbench is already running.", "warning");
+        return;
+      }
+
+      running = true;
+      try {
+        const result = await runWebInForeground(
+          ctx,
+          dependencies,
+          (next) => {
+            active = next;
+          },
+          () => shuttingDown,
+        );
+        if (shuttingDown) return;
+        if (result.kind === "error") {
+          ctx.ui.notify(
+            `Failed to start OpenPI Web Workbench: ${result.error.message}`,
+            "error",
+          );
+          return;
+        }
+        if (result.signal !== null) {
+          ctx.ui.notify(
+            `OpenPI Web Workbench was terminated by ${result.signal}.`,
+            "error",
+          );
+          return;
+        }
+        if (result.code !== 0) {
+          ctx.ui.notify(
+            `OpenPI Web Workbench exited with code ${result.code ?? "unknown"}.`,
+            "error",
+          );
+          return;
+        }
+        ctx.ui.notify("OpenPI Web Workbench stopped.", "info");
+      } finally {
+        active = undefined;
+        running = false;
+      }
+    },
+  });
+}

--- a/tests/extensions/web/index.test.ts
+++ b/tests/extensions/web/index.test.ts
@@ -1,0 +1,301 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+} from "@earendil-works/pi-coding-agent";
+import web, {
+  type WebCommandDependencies,
+  type WebProcess,
+} from "../../../extensions/web/index.ts";
+
+type CommandHandler = (
+  args: string,
+  ctx: ExtensionCommandContext,
+) => Promise<void>;
+type CustomFactory = (
+  tui: {
+    stop(): void;
+    start(): void;
+    requestRender(force?: boolean): void;
+  },
+  theme: unknown,
+  keybindings: unknown,
+  done: (value: unknown) => void,
+) => unknown;
+
+class FakeWebProcess extends EventEmitter implements WebProcess {
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  readonly kills: NodeJS.Signals[] = [];
+
+  kill(signal: NodeJS.Signals = "SIGTERM") {
+    this.kills.push(signal);
+    return true;
+  }
+
+  close(code: number | null, signal: NodeJS.Signals | null = null) {
+    this.exitCode = code;
+    this.signalCode = signal;
+    this.emit("close", code, signal);
+  }
+}
+
+function harness(
+  options: { mode?: "tui" | "print"; idle?: boolean; stopError?: Error } = {},
+) {
+  const hooks = new Map<string, Array<(event: unknown) => unknown>>();
+  let command: CommandHandler | undefined;
+  let customCalls = 0;
+  let stopped = 0;
+  let started = 0;
+  let rendered = 0;
+  let spawnCalls = 0;
+  let activeSigint = 0;
+  let clearCalls = 0;
+  const notifications: Array<{ message: string; level?: string }> = [];
+  const children: FakeWebProcess[] = [];
+  const cwd = "/workspace/current";
+  const pi = {
+    registerCommand(name: string, definition: { handler: CommandHandler }) {
+      assert.equal(name, "web");
+      command = definition.handler;
+    },
+    on(event: string, handler: (event: unknown) => unknown) {
+      hooks.set(event, [...(hooks.get(event) ?? []), handler]);
+    },
+  } as unknown as ExtensionAPI;
+
+  const dependencies: WebCommandDependencies = {
+    entrypoint: "/package/bin/openpi.js",
+    spawn(commandName, args, spawnOptions) {
+      spawnCalls++;
+      assert.equal(commandName, process.execPath);
+      assert.deepEqual(args, [
+        "/package/bin/openpi.js",
+        "web",
+        "--no-workspace",
+      ]);
+      assert.equal(spawnOptions.cwd, "/package/bin");
+      assert.equal(spawnOptions.env.PWD, "/package/bin");
+      assert.equal(spawnOptions.env.OLDPWD, undefined);
+      assert.equal(spawnOptions.env.INIT_CWD, undefined);
+      assert.equal(spawnOptions.env.PI_SESSION_ID, undefined);
+      assert.equal(spawnOptions.env.PI_SESSION_FILE, undefined);
+      assert.equal(spawnOptions.env.PATH, process.env.PATH);
+      assert.equal(spawnOptions.shell, false);
+      assert.equal(spawnOptions.stdio, "inherit");
+      const child = new FakeWebProcess();
+      children.push(child);
+      return child;
+    },
+    clearTerminal() {
+      clearCalls++;
+    },
+    holdParentSigint() {
+      activeSigint++;
+      return () => {
+        activeSigint--;
+      };
+    },
+    shutdownTimeoutMs: 20,
+  };
+
+  const ctx = {
+    cwd,
+    mode: options.mode ?? "tui",
+    isIdle: () => options.idle ?? true,
+    hasPendingMessages: () => false,
+    ui: {
+      notify(message: string, level?: string) {
+        notifications.push({ message, level });
+      },
+      custom(factory: CustomFactory) {
+        customCalls++;
+        return new Promise((resolve) => {
+          factory(
+            {
+              stop() {
+                if (options.stopError) throw options.stopError;
+                stopped++;
+              },
+              start() {
+                started++;
+              },
+              requestRender(force?: boolean) {
+                assert.equal(force, true);
+                rendered++;
+              },
+            },
+            {},
+            {},
+            resolve,
+          );
+        });
+      },
+    },
+  } as unknown as ExtensionCommandContext;
+
+  web(pi, dependencies);
+
+  const run = (args = "") => {
+    assert.ok(command);
+    return command(args, ctx);
+  };
+  const emit = async (event: string, payload: unknown = {}) => {
+    for (const handler of hooks.get(event) ?? []) await handler(payload);
+  };
+
+  return {
+    run,
+    emit,
+    children,
+    notifications,
+    customCalls: () => customCalls,
+    stopped: () => stopped,
+    started: () => started,
+    rendered: () => rendered,
+    spawnCalls: () => spawnCalls,
+    activeSigint: () => activeSigint,
+    clearCalls: () => clearCalls,
+  };
+}
+
+test("/web hands the terminal to the exact packaged Web CLI and restores Pi", async () => {
+  const previousSessionId = process.env.PI_SESSION_ID;
+  const previousSessionFile = process.env.PI_SESSION_FILE;
+  process.env.PI_SESSION_ID = "terminal-session";
+  process.env.PI_SESSION_FILE = "/tmp/terminal-session.jsonl";
+  const h = harness();
+  try {
+    const running = h.run();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(h.spawnCalls(), 1);
+    assert.equal(h.stopped(), 1);
+    assert.equal(h.clearCalls(), 1);
+    assert.equal(h.activeSigint(), 1);
+    assert.equal(h.started(), 0);
+
+    h.children[0]!.close(0);
+    await running;
+
+    assert.equal(h.activeSigint(), 0);
+    assert.equal(h.started(), 1);
+    assert.equal(h.rendered(), 1);
+    assert.deepEqual(h.notifications.at(-1), {
+      message: "OpenPI Web Workbench stopped.",
+      level: "info",
+    });
+  } finally {
+    if (previousSessionId === undefined) delete process.env.PI_SESSION_ID;
+    else process.env.PI_SESSION_ID = previousSessionId;
+    if (previousSessionFile === undefined) delete process.env.PI_SESSION_FILE;
+    else process.env.PI_SESSION_FILE = previousSessionFile;
+  }
+});
+
+test("/web rejects unsupported modes, arguments, busy sessions, and duplicates", async () => {
+  const print = harness({ mode: "print" });
+  await print.run();
+  assert.equal(print.spawnCalls(), 0);
+  assert.match(print.notifications.at(-1)?.message ?? "", /interactive TUI/u);
+
+  const args = harness();
+  await args.run("/tmp/other");
+  assert.equal(args.spawnCalls(), 0);
+  assert.match(args.notifications.at(-1)?.message ?? "", /Usage: \/web/u);
+
+  const busy = harness({ idle: false });
+  await busy.run();
+  assert.equal(busy.spawnCalls(), 0);
+  assert.match(busy.notifications.at(-1)?.message ?? "", /idle/u);
+
+  const duplicate = harness();
+  const running = duplicate.run();
+  await new Promise((resolve) => setImmediate(resolve));
+  await duplicate.run();
+  assert.equal(duplicate.spawnCalls(), 1);
+  assert.match(
+    duplicate.notifications.at(-1)?.message ?? "",
+    /already running/u,
+  );
+  duplicate.children[0]!.close(0);
+  await running;
+});
+
+test("/web restores the TUI and reports startup or process failures", async () => {
+  const h = harness();
+  const running = h.run();
+  await new Promise((resolve) => setImmediate(resolve));
+  h.children[0]!.emit("error", new Error("spawn failed"));
+  await running;
+
+  assert.equal(h.activeSigint(), 0);
+  assert.equal(h.started(), 1);
+  assert.equal(h.rendered(), 1);
+  assert.match(h.notifications.at(-1)?.message ?? "", /spawn failed/u);
+
+  const nonzero = harness();
+  const failed = nonzero.run();
+  await new Promise((resolve) => setImmediate(resolve));
+  nonzero.children[0]!.close(2);
+  await failed;
+  assert.match(nonzero.notifications.at(-1)?.message ?? "", /code 2/u);
+
+  const signalled = harness();
+  const terminated = signalled.run();
+  await new Promise((resolve) => setImmediate(resolve));
+  signalled.children[0]!.close(null, "SIGKILL");
+  await terminated;
+  assert.deepEqual(signalled.notifications.at(-1), {
+    message: "OpenPI Web Workbench was terminated by SIGKILL.",
+    level: "error",
+  });
+
+  const stopFailure = harness({ stopError: new Error("terminal unavailable") });
+  await stopFailure.run();
+  assert.equal(stopFailure.activeSigint(), 0);
+  assert.equal(stopFailure.started(), 0);
+  assert.match(
+    stopFailure.notifications.at(-1)?.message ?? "",
+    /terminal unavailable/u,
+  );
+});
+
+test("session shutdown terminates the foreground Web process without repainting stale TUI", async () => {
+  const h = harness();
+  const running = h.run();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const shutdown = h.emit("session_shutdown", {
+    type: "session_shutdown",
+    reason: "quit",
+  });
+  assert.deepEqual(h.children[0]!.kills, ["SIGTERM"]);
+  h.children[0]!.close(0, "SIGTERM");
+  await Promise.all([running, shutdown]);
+
+  assert.equal(h.activeSigint(), 0);
+  assert.equal(h.started(), 0);
+  assert.equal(h.rendered(), 0);
+});
+
+test("session shutdown force-kills a Web child that misses its graceful deadline", async () => {
+  const h = harness();
+  const running = h.run();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const shutdown = h.emit("session_shutdown", {
+    type: "session_shutdown",
+    reason: "quit",
+  });
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  assert.deepEqual(h.children[0]!.kills, ["SIGTERM", "SIGKILL"]);
+  h.children[0]!.close(null, "SIGKILL");
+  await Promise.all([running, shutdown]);
+
+  assert.equal(h.activeSigint(), 0);
+  assert.equal(h.started(), 0);
+});

--- a/tests/web/app-render.test.ts
+++ b/tests/web/app-render.test.ts
@@ -21,6 +21,10 @@ interface ElementStub {
 }
 
 function makeElement(id: string): ElementStub {
+  const listeners = new Map<
+    string,
+    Array<(event: Record<string, unknown>) => void>
+  >();
   return {
     id,
     innerHTML: "",
@@ -36,7 +40,15 @@ function makeElement(id: string): ElementStub {
     classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
     setAttribute() {},
     getAttribute: () => null,
-    addEventListener() {},
+    addEventListener(
+      type: string,
+      listener: (event: Record<string, unknown>) => void,
+    ) {
+      listeners.set(type, [...(listeners.get(type) ?? []), listener]);
+    },
+    dispatch(type: string, event: Record<string, unknown> = {}) {
+      for (const listener of listeners.get(type) ?? []) listener(event);
+    },
     querySelector: () => null,
     querySelectorAll: () => [],
     closest: () => null,
@@ -243,10 +255,18 @@ const SNAPSHOT = {
   },
 };
 
+type SnapshotFixture = Omit<
+  typeof SNAPSHOT,
+  "currentSessionId" | "selectedSession"
+> & {
+  currentSessionId?: string;
+  selectedSession?: typeof SNAPSHOT.selectedSession;
+};
+
 async function renderApp(
   options: {
     eventRecords?: string[];
-    snapshot?: typeof SNAPSHOT;
+    snapshot?: SnapshotFixture;
     storageValues?: Record<string, string>;
   } = {},
 ) {
@@ -370,6 +390,10 @@ async function renderApp(
     createSession: vm.runInContext("createSession", context as vm.Context) as (
       workspacePath: string,
     ) => Promise<void>,
+    chooseWorkspace: vm.runInContext(
+      "chooseWorkspace",
+      context as vm.Context,
+    ) as () => Promise<void>,
     selectModel: vm.runInContext("selectModel", context as vm.Context) as (
       value: string,
     ) => Promise<void>,
@@ -887,6 +911,76 @@ test("app.js renders the landing state for an empty selection", async () => {
   const conversation = elements.get("conversation");
   assert.ok(conversation);
   assert.ok(conversation.innerHTML.length > 0);
+});
+
+test("app.js accepts an unbound snapshot and preserves a chosen workspace through Session creation", async () => {
+  const unbound = structuredClone(SNAPSHOT) as SnapshotFixture;
+  delete unbound.currentSessionId;
+  delete unbound.selectedSession;
+  unbound.workspaces = [];
+  unbound.sessions = [];
+  const app = await renderApp({ snapshot: unbound });
+
+  assert.equal(app.state.selectedWorkspace, null);
+  assert.equal(app.state.selectedPath, null);
+  assert.equal(app.elements.get("prompt-input")?.readOnly, true);
+
+  const chosenPath = "/tmp/chosen-workspace";
+  const chosen = structuredClone(unbound);
+  chosen.workspaces = [{ path: chosenPath, name: "chosen", current: false }];
+  const activated = structuredClone(SNAPSHOT);
+  activated.workspaces[0] = {
+    path: chosenPath,
+    name: "chosen",
+    current: true,
+  };
+  activated.sessions[0].cwd = chosenPath;
+  activated.selectedSession.cwd = chosenPath;
+  let currentSnapshot: SnapshotFixture = chosen;
+  let sessionCreations = 0;
+  const prompts: Array<{ sessionId: string; content: string }> = [];
+  app.context.fetch = async (url: unknown, options?: { body?: string }) => {
+    if (String(url) === "/api/workspaces/select") {
+      return response({ cancelled: false, path: chosenPath });
+    }
+    if (String(url) === "/api/sessions") {
+      sessionCreations++;
+      currentSnapshot = activated;
+      return response({ cancelled: false, sessionPath: "/tmp/s1.jsonl" });
+    }
+    if (String(url) === "/api/prompt") {
+      prompts.push(JSON.parse(options?.body || "{}"));
+      return response({ id: "first-prompt", accepted: true });
+    }
+    if (String(url).startsWith("/api/snapshot")) {
+      return response(currentSnapshot);
+    }
+    throw new Error(`unexpected request: ${String(url)}`);
+  };
+
+  await app.chooseWorkspace();
+  assert.equal(app.state.selectedWorkspace, chosenPath);
+  assert.equal(app.elements.get("prompt-input")?.readOnly, false);
+  assert.equal(app.elements.get("prompt-input")?.disabled, false);
+  assert.equal(app.elements.get("send-prompt")?.disabled, false);
+
+  const input = app.elements.get("prompt-input");
+  assert.ok(input);
+  input.value = "first task";
+  const composer = app.elements.get("composer");
+  assert.ok(composer);
+  (composer.dispatch as (type: string, event: Record<string, unknown>) => void)(
+    "submit",
+    { preventDefault() {} },
+  );
+  while (prompts.length === 0) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  assert.equal(sessionCreations, 1);
+  assert.deepEqual(prompts, [{ sessionId: "s1", content: "first task" }]);
+  assert.equal(app.state.selectedWorkspace, chosenPath);
+  assert.equal(app.state.selectedPath, "/tmp/s1.jsonl");
+  assert.equal(input.value, "");
 });
 
 test("snapshot archive state remains authoritative over legacy browser storage", async () => {

--- a/tests/web/cli.test.ts
+++ b/tests/web/cli.test.ts
@@ -116,7 +116,14 @@ export class PiWebRuntime {
       temporaryRoot,
       "--no-open",
     ]);
-    assert.match(stdout, /ready http:\/\/127\.0\.0\.1:12345/u);
+    assert.match(
+      stdout,
+      /^OpenPI Web Workbench is running at http:\/\/127\.0\.0\.1:12345$/mu,
+    );
+    assert.match(
+      stdout,
+      /^Open this URL in a browser: http:\/\/127\.0\.0\.1:12345\/#token=test$/mu,
+    );
 
     const noWorkspaceMarker = join(temporaryRoot, "no-workspace");
     await execFileAsync(
@@ -197,7 +204,11 @@ export class PiWebRuntime {
         5_000,
       );
       const waitForReady = () => {
-        if (signalOutput.includes("ready http://127.0.0.1:12345")) {
+        if (
+          signalOutput.includes(
+            "OpenPI Web Workbench is running at http://127.0.0.1:12345",
+          )
+        ) {
           clearTimeout(timeout);
           resolve();
           return;

--- a/tests/web/cli.test.ts
+++ b/tests/web/cli.test.ts
@@ -55,6 +55,10 @@ test("installed CLI loads TypeScript Web modules through its package loader", as
       "export async function openBrowser(): Promise<boolean> { return false; }\n",
     );
     await writeFile(
+      join(packageRoot, "web", "host", "terminal-status.ts"),
+      "export function formatWebReadyScreen(options: { origin: string; url: string }): string { return `ready ${options.origin} ${options.url}`; }\n",
+    );
+    await writeFile(
       join(packageRoot, "web", "host", "web-host.ts"),
       `import { readFile } from "node:fs/promises";
 import { MARKED_BROWSER_URL } from "./static-assets.ts";
@@ -85,6 +89,11 @@ export class WebHost {
       `import { writeFile } from "node:fs/promises";
 
 export class PiWebRuntime {
+  static async createWithoutWorkspace(): Promise<{ cwd: string; dispose(): Promise<void> }> {
+    const marker = process.env.OPENPI_CLI_NO_WORKSPACE_MARKER;
+    if (marker) await writeFile(marker, "unbound");
+    return PiWebRuntime.create("/web-owned-bootstrap");
+  }
   static async create(cwd: string): Promise<{ cwd: string; dispose(): Promise<void> }> {
     return {
       cwd,
@@ -107,7 +116,25 @@ export class PiWebRuntime {
       temporaryRoot,
       "--no-open",
     ]);
-    assert.match(stdout, /running at http:\/\/127\.0\.0\.1:12345/u);
+    assert.match(stdout, /ready http:\/\/127\.0\.0\.1:12345/u);
+
+    const noWorkspaceMarker = join(temporaryRoot, "no-workspace");
+    await execFileAsync(
+      process.execPath,
+      [
+        join(packageRoot, "bin", "openpi.js"),
+        "web",
+        "--no-workspace",
+        "--no-open",
+      ],
+      {
+        env: {
+          ...process.env,
+          OPENPI_CLI_NO_WORKSPACE_MARKER: noWorkspaceMarker,
+        },
+      },
+    );
+    assert.equal(await readFile(noWorkspaceMarker, "utf8"), "unbound");
 
     const disposeMarker = join(temporaryRoot, "runtime-disposed");
     await assert.rejects(
@@ -170,7 +197,7 @@ export class PiWebRuntime {
         5_000,
       );
       const waitForReady = () => {
-        if (signalOutput.includes("running at http://127.0.0.1:12345")) {
+        if (signalOutput.includes("ready http://127.0.0.1:12345")) {
           clearTimeout(timeout);
           resolve();
           return;

--- a/tests/web/pi-adapter.test.ts
+++ b/tests/web/pi-adapter.test.ts
@@ -1,5 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
@@ -18,6 +25,7 @@ function runtimeFor(
 ): WebRuntimeController {
   return {
     cwd,
+    workspaceSelected: true,
     sessionDirectory,
     sessionManager,
     isIdle: () => true,
@@ -108,6 +116,49 @@ test("snapshot pins current and selected sessions while bounding the projection"
     assert.equal(snapshot.truncation.sessionsOmitted, 5);
     assert.equal(snapshot.truncation.truncated, true);
     assert.ok(snapshot.truncation.bytes <= WEB_MAX_SNAPSHOT_BYTES);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("an unbound Web runtime never projects its bootstrap cwd as a workspace or Session", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openpi-web-unbound-"));
+  const bootstrap = join(root, ".bootstrap-workspace");
+  const imported = join(root, "chosen-workspace");
+  const sessionDirectory = join(root, "sessions");
+  try {
+    await Promise.all([
+      mkdir(bootstrap, { recursive: true }),
+      mkdir(imported, { recursive: true }),
+      mkdir(sessionDirectory, { recursive: true }),
+    ]);
+    const current = SessionManager.inMemory(bootstrap);
+    const runtime = Object.assign(
+      runtimeFor(bootstrap, sessionDirectory, current),
+      { workspaceSelected: false as const },
+    );
+    const adapter = new PiWebAdapter(runtime);
+
+    const initial = await adapter.getSnapshot();
+    assert.deepEqual(initial.workspaces, []);
+    assert.deepEqual(initial.sessions, []);
+    assert.equal(initial.currentSessionId, undefined);
+    assert.equal(initial.selectedSession, undefined);
+
+    await adapter.importWorkspace(imported);
+    const afterImport = await adapter.getSnapshot();
+    const canonicalImported = await realpath(imported);
+    const canonicalBootstrap = await realpath(bootstrap);
+    assert.deepEqual(
+      afterImport.workspaces.map((workspace) => workspace.path),
+      [canonicalImported],
+    );
+    assert.equal(
+      afterImport.workspaces.some(
+        (workspace) => workspace.path === canonicalBootstrap,
+      ),
+      false,
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/tests/web/pi-runtime.test.ts
+++ b/tests/web/pi-runtime.test.ts
@@ -85,6 +85,7 @@ type PromptRuntimeHarness = {
   promptAdmission: Promise<void>;
   pendingPromptTraces: Trace[];
   disposed: boolean;
+  hasSelectedWorkspace: boolean;
   dispatcherLease: { release: () => Promise<void> };
   webHostLease: { release: () => Promise<void> };
   sendPrompt: PiWebRuntime["sendPrompt"];
@@ -205,6 +206,21 @@ function lifecycleHarness(runtime: LifecycleRuntime) {
   return harness;
 }
 
+test("an unbound runtime rejects prompts before touching its bootstrap Session", async () => {
+  const session = promptSession("bootstrap-session");
+  const runtime = promptHarness(session);
+  runtime.hasSelectedWorkspace = false;
+
+  await assert.rejects(
+    runtime.sendPrompt("must not run"),
+    (error: unknown) =>
+      error instanceof WebRuntimeRequestError &&
+      error.code === "WORKSPACE_REQUIRED" &&
+      error.statusCode === 409,
+  );
+  assert.equal(session.calls.length, 0);
+});
+
 function promptHarness(session: ReturnType<typeof promptSession>) {
   const harness = Object.create(
     PiWebRuntime.prototype,
@@ -222,6 +238,7 @@ function promptHarness(session: ReturnType<typeof promptSession>) {
   harness.promptAdmission = Promise.resolve();
   harness.pendingPromptTraces = [];
   harness.disposed = false;
+  harness.hasSelectedWorkspace = true;
   harness.dispatcherLease = { release: async () => undefined };
   harness.webHostLease = { release: async () => undefined };
   return harness;
@@ -367,6 +384,7 @@ test("model selection and Session activation are serialized", async () => {
     runtimeDisposalPromises: WeakMap<typeof runtimeA, Promise<void>>;
     controllerMutation: Promise<void>;
     disposed: boolean;
+    hasSelectedWorkspace: boolean;
     setModel: PiWebRuntime["setModel"];
     switchSession: PiWebRuntime["switchSession"];
     switchActiveSession: (path: string) => Promise<{ cancelled: false }>;
@@ -381,6 +399,7 @@ test("model selection and Session activation are serialized", async () => {
   harness.runtimeDisposalPromises = new WeakMap();
   harness.controllerMutation = Promise.resolve();
   harness.disposed = false;
+  harness.hasSelectedWorkspace = true;
   harness.switchActiveSession = async () => {
     harness.runtime = runtimeB;
     return { cancelled: false };
@@ -447,6 +466,7 @@ test("a delayed model selection cannot target a newly activated Session", async 
     runtimeOperations: Set<Promise<void>>;
     controllerMutation: Promise<void>;
     disposed: boolean;
+    hasSelectedWorkspace: boolean;
     setModel: PiWebRuntime["setModel"];
     switchSession: PiWebRuntime["switchSession"];
     switchActiveSession: (path: string) => Promise<{ cancelled: false }>;
@@ -455,6 +475,7 @@ test("a delayed model selection cannot target a newly activated Session", async 
   harness.runtimeOperations = new Set();
   harness.controllerMutation = Promise.resolve();
   harness.disposed = false;
+  harness.hasSelectedWorkspace = true;
   harness.switchActiveSession = async () => {
     switchStarted.resolve();
     await allowSwitch.promise;

--- a/tests/web/terminal-status.test.ts
+++ b/tests/web/terminal-status.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatWebReadyScreen } from "../../web/host/terminal-status.ts";
+
+const origin = "http://127.0.0.1:43210";
+const url = `${origin}/#token=${"a".repeat(64)}`;
+
+test("ready screen explains the independent Web boundary without binding to terminal cwd", () => {
+  const output = formatWebReadyScreen({
+    origin,
+    url,
+    opened: true,
+    color: false,
+  });
+
+  assert.match(output, /OpenPI Web Workbench/u);
+  assert.match(output, /ready/u);
+  assert.match(output, new RegExp(origin.replaceAll(".", "\\."), "u"));
+  assert.match(output, /choose and switch in the browser/u);
+  assert.match(output, /separate from terminal Pi/u);
+  assert.match(output, /Ctrl\+C\s+stop/u);
+  assert.doesNotMatch(output, /token=/u);
+  assert.doesNotMatch(output, /workspace\/current/u);
+  assert.doesNotMatch(output, /\u001b\[/u);
+});
+
+test("ready screen exposes the authenticated URL only when browser opening fails", () => {
+  const output = formatWebReadyScreen({
+    origin,
+    url,
+    opened: false,
+    color: false,
+  });
+
+  assert.match(output, new RegExp(url.replaceAll(".", "\\."), "u"));
+  assert.match(output, /Browser\s+not opened/u);
+});

--- a/tests/web/web-host.test.ts
+++ b/tests/web/web-host.test.ts
@@ -40,6 +40,7 @@ test("serves workspaces through a runtime isolated from terminal sessions", asyn
   let disposed = false;
   const listeners = new Set<(event: WebRuntimeEvent) => void>();
   const runtime: WebRuntimeController = {
+    workspaceSelected: true,
     sessionDirectory: cwd,
     get cwd() {
       return runtimeCwd;
@@ -513,6 +514,88 @@ test("serves workspaces through a runtime isolated from terminal sessions", asyn
   }
 });
 
+test("an unbound Host exposes no bootstrap Session and rejects prompt bypasses", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openpi-web-unbound-host-"));
+  const bootstrap = join(root, ".bootstrap-workspace");
+  const sessionManager = SessionManager.inMemory(bootstrap);
+  let prompts = 0;
+  let disposed = false;
+  const events: Array<{ type: string; detail?: Record<string, unknown> }> = [];
+  const runtime: WebRuntimeController = {
+    cwd: bootstrap,
+    workspaceSelected: false,
+    sessionDirectory: root,
+    sessionManager,
+    isIdle: () => true,
+    sendPrompt: async () => {
+      prompts++;
+    },
+    newSession: async () => ({ cancelled: false }),
+    switchSession: async () => ({ cancelled: false }),
+    listModels: () => [],
+    setModel: async () => {
+      throw new Error("workspace required");
+    },
+    subscribe: () => () => {},
+    dispose: async () => {
+      disposed = true;
+    },
+  };
+  const host = new WebHost({
+    runtime,
+    onEvent: (type, detail) => events.push({ type, detail }),
+  });
+
+  try {
+    await host.start();
+    const launched = new URL(host.url);
+    const token = new URLSearchParams(launched.hash.slice(1)).get("token");
+    assert.ok(token);
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    };
+
+    const snapshotResponse = await fetch(`${launched.origin}/api/snapshot`, {
+      headers,
+    });
+    assert.equal(snapshotResponse.status, 200);
+    const snapshot = (await snapshotResponse.json()) as {
+      currentSessionId?: string;
+      selectedSession?: unknown;
+      workspaces: unknown[];
+      sessions: unknown[];
+    };
+    assert.equal(snapshot.currentSessionId, undefined);
+    assert.equal(snapshot.selectedSession, undefined);
+    assert.deepEqual(snapshot.workspaces, []);
+    assert.deepEqual(snapshot.sessions, []);
+
+    const prompt = await fetch(`${launched.origin}/api/prompt`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        sessionId: sessionManager.getSessionId(),
+        content: "must not run",
+      }),
+    });
+    assert.equal(prompt.status, 409);
+    assert.deepEqual(await prompt.json(), {
+      code: "WORKSPACE_REQUIRED",
+      error: "Choose a workspace before using the Web runtime",
+    });
+    assert.equal(prompts, 0);
+
+    const started = events.find((event) => event.type === "web_host_started");
+    assert.ok(started);
+    assert.equal("cwd" in (started.detail ?? {}), false);
+  } finally {
+    await host.stop();
+    assert.equal(disposed, true);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("returns accepted only after Pi admits the prompt", async () => {
   const cwd = await mkdtemp(join(tmpdir(), "openpi-web-prompt-"));
   const sessionManager = SessionManager.inMemory(cwd);
@@ -523,6 +606,7 @@ test("returns accepted only after Pi admits the prompt", async () => {
   let promptStarted = false;
   let disposed = false;
   const runtime: WebRuntimeController = {
+    workspaceSelected: true,
     sessionDirectory: cwd,
     cwd,
     sessionManager,
@@ -585,6 +669,7 @@ function testRuntime(
 ) {
   const sessionManager = SessionManager.inMemory(cwd);
   const runtime: WebRuntimeController = {
+    workspaceSelected: true,
     sessionDirectory: cwd,
     cwd,
     sessionManager,

--- a/web/adapter/pi-adapter.ts
+++ b/web/adapter/pi-adapter.ts
@@ -53,7 +53,9 @@ export class PiWebAdapter {
       "workspace-state.json",
     );
     this.archiveFile = join(runtime.sessionDirectory, "archived-sessions.json");
-    this.importedWorkspaces.add(resolve(runtime.cwd));
+    if (runtime.workspaceSelected === true) {
+      this.importedWorkspaces.add(resolve(runtime.cwd));
+    }
   }
 
   private async ensureWorkspaceStateLoaded() {
@@ -94,9 +96,9 @@ export class PiWebAdapter {
         } catch (error) {
           if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
         }
-        this.restoreInitialWorkspace = this.hiddenWorkspaces.has(
-          resolve(this.runtime.cwd),
-        );
+        this.restoreInitialWorkspace =
+          this.runtime.workspaceSelected === true &&
+          this.hiddenWorkspaces.has(resolve(this.runtime.cwd));
         this.workspaceStateLoaded = true;
       })();
     }
@@ -352,7 +354,10 @@ export class PiWebAdapter {
         ...(this.archivedSessions.has(resolve(session.path)) ? { archived: true } : {}),
         ...(this.ungroupedSessions.has(resolve(session.path)) ? { ungrouped: true } : {}),
       }));
-    if (!projected.some((session) => session.id === currentId)) {
+    if (
+      this.runtime.workspaceSelected === true &&
+      !projected.some((session) => session.id === currentId)
+    ) {
       const entries = this.runtime.sessionManager.getBranch();
       let firstUser = "";
       let messageCount = 0;
@@ -409,7 +414,10 @@ export class PiWebAdapter {
       omitted: Math.max(
         0,
         allSessions.length +
-          (allSessions.some((session) => session.id === currentId) ? 0 : 1) -
+          (allSessions.some((session) => session.id === currentId) ||
+          this.runtime.workspaceSelected !== true
+            ? 0
+            : 1) -
           projected.length,
       ),
     };
@@ -438,7 +446,8 @@ export class PiWebAdapter {
       .map((path) => ({
         path,
         name: (this.workspaceNames.get(path) ?? basename(path)) || path,
-        current: path === currentCwd,
+        current:
+          this.runtime.workspaceSelected === true && path === currentCwd,
       }))
       .sort((left, right) =>
         left.current === right.current
@@ -470,7 +479,9 @@ export class PiWebAdapter {
       label: boundedText(model.label, WEB_MAX_SESSION_PREVIEW),
     }));
     const snapshot = {
-      currentSessionId: this.runtime.sessionManager.getSessionId(),
+      ...(this.runtime.workspaceSelected === true
+        ? { currentSessionId: this.runtime.sessionManager.getSessionId() }
+        : {}),
       workspaces,
       sessions,
       models,
@@ -500,7 +511,7 @@ export class PiWebAdapter {
   }
 
   private fitSnapshot(snapshot: {
-    currentSessionId: string;
+    currentSessionId?: string;
     workspaces: WebWorkspaceSummary[];
     sessions: WebSessionSummary[];
     selectedSession?: WebSessionProjection;
@@ -619,7 +630,9 @@ export class PiWebAdapter {
   ) {
     const sessions = knownSessions ?? (await this.listSessions());
     return new Set([
-      resolve(this.runtime.cwd),
+      ...(this.runtime.workspaceSelected === true
+        ? [resolve(this.runtime.cwd)]
+        : []),
       ...(workspaceState?.importedWorkspaces ?? this.importedWorkspaces),
       ...sessions.map((session) => session.cwd),
     ]);

--- a/web/host/terminal-status.ts
+++ b/web/host/terminal-status.ts
@@ -1,0 +1,38 @@
+interface WebReadyScreenOptions {
+  origin: string;
+  url: string;
+  opened: boolean;
+  color?: boolean;
+}
+
+const ANSI = {
+  accent: "\u001b[36m",
+  bold: "\u001b[1m",
+  dim: "\u001b[2m",
+  green: "\u001b[32m",
+  reset: "\u001b[0m",
+};
+
+export function formatWebReadyScreen(options: WebReadyScreenOptions) {
+  const color =
+    options.color ?? (process.stdout.isTTY === true && !("NO_COLOR" in process.env));
+  const paint = (codes: string, text: string) =>
+    color ? `${codes}${text}${ANSI.reset}` : text;
+  const label = (text: string) => paint(ANSI.dim, text.padEnd(12));
+  const rows = [
+    "",
+    `${paint(`${ANSI.bold}${ANSI.accent}`, "OpenPI Web Workbench")}  ${paint(ANSI.green, "ready")}`,
+    paint(
+      ANSI.dim,
+      "Local, authenticated, and isolated from the terminal Pi Session.",
+    ),
+    "",
+    `${label("Local")} ${options.origin}`,
+    `${label("Workspaces")} choose and switch in the browser`,
+    `${label("Sessions")} separate from terminal Pi`,
+    `${label("Browser")} ${options.opened ? "opened" : "not opened"}`,
+  ];
+  if (!options.opened) rows.push(`${label("Open")} ${options.url}`);
+  rows.push("", `${paint(ANSI.bold, "Ctrl+C")}  stop`, "");
+  return rows.join("\n");
+}

--- a/web/host/web-host.ts
+++ b/web/host/web-host.ts
@@ -141,7 +141,9 @@ export class WebHost {
     this.port = address.port;
     this.publish("web_host_started", {
       port: this.port,
-      cwd: this.runtime.cwd,
+      ...(this.runtime.workspaceSelected === true
+        ? { cwd: this.runtime.cwd }
+        : {}),
       mode: "local-workbench",
     });
   }
@@ -447,6 +449,12 @@ export class WebHost {
           error: "provider, modelId, and sessionId are required",
         });
       }
+      if (this.runtime.workspaceSelected !== true) {
+        return this.json(response, 409, {
+          code: "WORKSPACE_REQUIRED",
+          error: "Choose a workspace before using the Web runtime",
+        });
+      }
       try {
         const model = await this.runtime.setModel(body.provider, body.modelId, {
           expectedSessionId: body.sessionId,
@@ -476,6 +484,12 @@ export class WebHost {
       if (!content || content.length > 12_000) {
         return this.json(response, 400, {
           error: "prompt must be 1-12000 characters",
+        });
+      }
+      if (this.runtime.workspaceSelected !== true) {
+        return this.json(response, 409, {
+          code: "WORKSPACE_REQUIRED",
+          error: "Choose a workspace before using the Web runtime",
         });
       }
       if (

--- a/web/protocol/types.ts
+++ b/web/protocol/types.ts
@@ -105,7 +105,8 @@ export interface WebSnapshot {
   protocolVersion: typeof WEB_PROTOCOL_VERSION;
   generatedAt: string;
   cursor: number;
-  currentSessionId: string;
+  /** Absent until the browser selects or creates a real Web Session. */
+  currentSessionId?: string;
   workspaces: WebWorkspaceSummary[];
   sessions: WebSessionSummary[];
   selectedSession?: WebSessionProjection;

--- a/web/runtime/pi-runtime.ts
+++ b/web/runtime/pi-runtime.ts
@@ -1,4 +1,4 @@
-import { realpath, stat } from "node:fs/promises";
+import { mkdir, realpath, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import {
   type AgentSession,
@@ -35,6 +35,7 @@ import {
 } from "./web-host-lease.ts";
 
 const STARTUP_TIMEOUT_MS = 15_000;
+const BOOTSTRAP_WORKSPACE_DIRECTORY = ".bootstrap-workspace";
 
 type PromptTrace = {
   commandId: string;
@@ -83,36 +84,61 @@ export class PiWebRuntime implements WebRuntimeController {
   private readonly webHostLease: WebHostLease;
   private disposed = false;
   private disposePromise?: Promise<void>;
+  private hasSelectedWorkspace: boolean;
 
   private constructor(
     runtime: AgentSessionRuntime,
     webSessionDirectory: string,
     dispatcherLease: HttpDispatcherLease,
     webHostLease: WebHostLease,
+    workspaceSelected: boolean,
   ) {
     this.runtime = runtime;
     this.webSessionDirectory = webSessionDirectory;
     this.dispatcherLease = dispatcherLease;
     this.webHostLease = webHostLease;
+    this.hasSelectedWorkspace = workspaceSelected;
   }
 
   static async create(cwd: string) {
     const canonicalCwd = await canonicalDirectory(cwd);
+    return PiWebRuntime.createForWorkspace(canonicalCwd, true);
+  }
+
+  static async createWithoutWorkspace() {
+    const webSessionDirectory = join(getAgentDir(), "web-sessions");
+    await mkdir(webSessionDirectory, { recursive: true, mode: 0o700 });
+    const bootstrapDirectory = join(
+      webSessionDirectory,
+      BOOTSTRAP_WORKSPACE_DIRECTORY,
+    );
+    await mkdir(bootstrapDirectory, { recursive: true, mode: 0o700 });
+    const canonicalCwd = await canonicalDirectory(bootstrapDirectory);
+    return PiWebRuntime.createForWorkspace(canonicalCwd, false);
+  }
+
+  private static async createForWorkspace(
+    canonicalCwd: string,
+    workspaceSelected: boolean,
+  ) {
     const webSessionDirectory = join(getAgentDir(), "web-sessions");
     const webHostLease = await acquireWebHostLease(webSessionDirectory);
     let runtime: PiWebRuntime | undefined;
     try {
       const created = await PiWebRuntime.createRuntime(
         canonicalCwd,
-        SessionManager.create(canonicalCwd, webSessionDirectory),
+        workspaceSelected
+          ? SessionManager.create(canonicalCwd, webSessionDirectory)
+          : SessionManager.inMemory(canonicalCwd),
       );
       runtime = new PiWebRuntime(
         created.runtime,
         webSessionDirectory,
         created.dispatcherLease,
         webHostLease,
+        workspaceSelected,
       );
-      await runtime.startRuntimeSession();
+      if (workspaceSelected) await runtime.startRuntimeSession();
       return runtime;
     } catch (error) {
       try {
@@ -130,6 +156,10 @@ export class PiWebRuntime implements WebRuntimeController {
 
   get cwd() {
     return this.runtime.cwd;
+  }
+
+  get workspaceSelected() {
+    return this.hasSelectedWorkspace;
   }
 
   get sessionDirectory() {
@@ -180,6 +210,7 @@ export class PiWebRuntime implements WebRuntimeController {
     options?: WebModelSelectionOptions,
   ) {
     this.assertActive();
+    this.assertWorkspaceSelected();
     const agentRuntime = this.runtime;
     if (
       options?.expectedSessionId !== undefined &&
@@ -236,6 +267,7 @@ export class PiWebRuntime implements WebRuntimeController {
 
   async sendPrompt(content: string, options?: WebPromptOptions) {
     this.assertActive();
+    this.assertWorkspaceSelected();
     const agentRuntime = this.runtime;
     const session = agentRuntime.session;
     const sessionId = session.sessionManager.getSessionId();
@@ -440,6 +472,7 @@ export class PiWebRuntime implements WebRuntimeController {
       this.dispatcherLease,
     );
     await this.activateCandidate(replacement.runtime);
+    this.hasSelectedWorkspace = true;
     const sessionPath = this.runtime.session.sessionManager.getSessionFile();
     this.emit("session_switched", {
       ...(options?.commandId ? { commandId: options.commandId } : {}),
@@ -468,6 +501,7 @@ export class PiWebRuntime implements WebRuntimeController {
     );
     if (retained) {
       await this.promoteRetainedRuntime(retained);
+      this.hasSelectedWorkspace = true;
       this.emit("session_switched", { sessionPath });
       return { cancelled: false };
     }
@@ -483,6 +517,7 @@ export class PiWebRuntime implements WebRuntimeController {
       this.dispatcherLease,
     );
     await this.activateCandidate(replacement.runtime);
+    this.hasSelectedWorkspace = true;
     this.emit("session_switched", { sessionPath });
     return { cancelled: false };
   }
@@ -930,6 +965,15 @@ export class PiWebRuntime implements WebRuntimeController {
 
   private assertActive() {
     if (this.disposed) throw new Error("Web runtime is stopped");
+  }
+
+  private assertWorkspaceSelected() {
+    if (this.hasSelectedWorkspace) return;
+    throw new WebRuntimeRequestError(
+      "Choose a workspace before using the Web runtime",
+      "WORKSPACE_REQUIRED",
+      409,
+    );
   }
 
   private assertActiveRuntime(runtime: AgentSessionRuntime) {

--- a/web/runtime/types.ts
+++ b/web/runtime/types.ts
@@ -9,7 +9,8 @@ export interface WebRuntimeEvent {
 export type WebRuntimeRequestErrorCode =
   | "MODEL_NOT_AVAILABLE"
   | "SESSION_CONFLICT"
-  | "PROMPT_REJECTED";
+  | "PROMPT_REJECTED"
+  | "WORKSPACE_REQUIRED";
 
 export class WebRuntimeRequestError extends Error {
   readonly code: WebRuntimeRequestErrorCode;
@@ -48,6 +49,8 @@ export interface WebSessionCreationResult {
 
 export interface WebRuntimeController {
   readonly cwd: string;
+  /** Runtime authority: false until a real Web workspace and Session are active. */
+  readonly workspaceSelected: boolean;
   readonly sessionDirectory: string;
   readonly sessionManager: SessionManager;
   isIdle(): boolean;

--- a/web/ui/app.js
+++ b/web/ui/app.js
@@ -477,11 +477,16 @@ function renderConversation() {
 function updateComposer() {
   const selected = state.snapshot?.selectedSession;
   const active = selected?.id === state.snapshot?.currentSessionId;
+  const newSessionDraft =
+    Boolean(state.selectedWorkspace) &&
+    !selected &&
+    !state.snapshot?.currentSessionId;
+  const canCompose = active || newSessionDraft;
   $("prompt-input").disabled =
-    state.sessionSwitching || (!active && Boolean(state.selectedWorkspace));
+    state.sessionSwitching || (!canCompose && Boolean(state.selectedWorkspace));
   $("send-prompt").disabled =
     state.sessionSwitching ||
-    !active ||
+    !canCompose ||
     !state.selectedWorkspace ||
     state.promptAdmissionPending;
   const modelPicker = $("model-picker");
@@ -522,7 +527,7 @@ function updateComposer() {
       : active
         ? t("promptMessage")
         : t("promptReadonly");
-  $("composer-hint").textContent = active
+  $("composer-hint").textContent = canCompose
     ? state.snapshot.runtime.status === "running" || state.liveRunning
       ? t("queuedHint")
       : t("enterHint")
@@ -574,11 +579,15 @@ async function refreshSnapshot({
       epoch !== state.sessionEpoch ||
       generation !== state.snapshotGeneration
     ) return false;
-    const current = snapshot.sessions.find(
-      (session) => session.id === snapshot.currentSessionId,
-    );
-    const selectedIsCurrent =
-      snapshot.selectedSession?.id === snapshot.currentSessionId;
+    const hasCurrentSession = typeof snapshot.currentSessionId === "string";
+    const current = hasCurrentSession
+      ? snapshot.sessions.find(
+          (session) => session.id === snapshot.currentSessionId,
+        )
+      : undefined;
+    const selectedIsCurrent = hasCurrentSession
+      ? snapshot.selectedSession?.id === snapshot.currentSessionId
+      : snapshot.selectedSession === undefined;
     const requestedExists =
       !requestedPath ||
       snapshot.sessions.some((session) => session.path === requestedPath);
@@ -611,9 +620,14 @@ async function refreshSnapshot({
     const availableWorkspaces = state.snapshot.workspaces;
     const selectedSessionWorkspace = state.snapshot.selectedSession?.cwd;
     const activeWorkspace = availableWorkspaces.find((workspace) => workspace.current)?.path;
+    const retainedWorkspace = availableWorkspaces.some(
+      (workspace) => workspace.path === state.selectedWorkspace,
+    )
+      ? state.selectedWorkspace
+      : undefined;
     const readyWorkspace = availableWorkspaces.some((workspace) => workspace.path === selectedSessionWorkspace)
       ? selectedSessionWorkspace
-      : activeWorkspace;
+      : activeWorkspace ?? retainedWorkspace;
     setWorkspaceReady(readyWorkspace);
     state.selectedPath = current?.path || snapshot.selectedSession?.path || null;
     renderWorkspaces();
@@ -702,16 +716,19 @@ function scheduleSnapshotRefresh(delay = 160) {
 async function sendPrompt() {
   if (!state.selectedWorkspace) {
     await chooseWorkspace();
-    return;
   }
   const content = $("prompt-input").value.trim();
-  const sessionId = state.snapshot?.selectedSession?.id;
   if (
     !content ||
-    !sessionId ||
+    !state.selectedWorkspace ||
     state.sessionSwitching ||
     state.promptAdmissionPending
   ) return;
+  if (!state.snapshot?.selectedSession?.id) {
+    await createSession(state.selectedWorkspace);
+  }
+  const sessionId = state.snapshot?.selectedSession?.id;
+  if (!sessionId || state.sessionSwitching || state.promptAdmissionPending) return;
   const epoch = state.sessionEpoch;
   const admissionToken = ++state.promptAdmissionSequence;
   const optimisticKey = `optimistic-${Date.now()}`;


### PR DESCRIPTION
## Problem

OpenPI Web can only be started from the standalone CLI today. An interactive Pi user has no native `/web` handoff, and launching Web from a terminal risks accidentally treating the terminal Session or current directory as Web authority.

## Value

`/web` becomes a lightweight entrance to the existing local OpenPI Web Workbench while keeping the browser workspace independent:

- no terminal Session, history, context, Session provenance, or current workspace is transferred;
- the browser chooses or restores its own workspace;
- the first prompt in a selected empty workspace creates the first Web Session;
- Ctrl+C stops Web and restores the same Pi TUI.

This advances the vertical slice in #76 without adding a second runtime or control plane.

## Method

- Register a Pi-native `/web` extension that yields the terminal to the packaged `openpi web --no-workspace` process.
- Start the Web runtime unbound with an in-memory bootstrap Session that is never projected, persisted, or extension-bound.
- Require an explicit `workspaceSelected` authority bit at runtime, adapter, host, and UI boundaries.
- Strip terminal cwd and Pi Session provenance from the child environment.
- Render a compact ready screen and use bounded shutdown/cleanup before restoring Pi.

## Impact

- Ordinary Pi/OpenPI behavior is unchanged until `/web` is invoked.
- Existing explicit `openpi web [workspace]` CLI behavior remains available.
- `/web` accepts no workspace argument by design; workspace selection belongs to the browser.
- Unbound prompt/model requests fail closed with `WORKSPACE_REQUIRED`.

## Verification

- `bun run check`
- focused `/web` + Web runtime/host/adapter/UI suite: 82 passed
- full Node suite: 1235 passed, 1 skipped, 0 failed
- Vitest: 30 passed
- `git diff --check`
- `npm pack --dry-run --json --ignore-scripts` includes the launcher and terminal status modules
- manual PTY smoke: `/web` opens Web, creates no terminal-cwd workspace or Session while unbound, Ctrl+C restores Pi
- independent final correctness review: no findings
- independent final Standards/Pi-native review: no findings
