### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tt-a1i/openpi",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "OpenPI — a Pi-native multi-agent workbench with background execution, isolated subagents, replay-safe workflows, goals, tasks, and observable TUI",
   "license": "MIT",
   "author": "tt-a1i",


### PR DESCRIPTION
## Summary

- bump `@tt-a1i/openpi` from `0.4.0` to `0.5.0`
- release the Pi-native OpenPI Web Workbench and interactive `/web` launcher
- include the accumulated Session, Subagent, Workflow, TUI, setup, safety, performance, and repository-governance improvements on current `main`
- preserve the existing standalone `openpi web <workspace>` CLI contract while `/web` starts an independent browser-owned workspace

This is a minor release because the public feature surface has expanded since 0.4.0; it is not only a patch set.

## Release gates

- current `main` CI at `51b85ad`: passed
- `bun run check`: passed
- `bun run test`: 1235 Node tests passed, 1 skipped; 30 Vitest tests passed
- `npm pack --dry-run --json --ignore-scripts`: `@tt-a1i/openpi@0.5.0`, 176 files, 686,335 bytes compressed, 2,049,622 bytes unpacked
- `git diff --check`: passed

## Publication plan

After merge, create `v0.5.0` at the exact merged `main` commit. The tag-triggered Release workflow will re-run validation, build a single npm artifact, and publish it through the protected `npm` environment with OIDC. Publication is not complete until the workflow, npm dist-tag/provenance, GitHub Release, and clean install smoke are verified.
