### PR TITLE
fix(web): 合成会话键原样存取，使标记在会话落盘后依然生效

### DIFF
--- a/tests/web/pi-adapter.test.ts
+++ b/tests/web/pi-adapter.test.ts
@@ -4,11 +4,12 @@ import {
   mkdtemp,
   readFile,
   realpath,
+  rename,
   rm,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { basename, join, resolve } from "node:path";
 import test from "node:test";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { PiWebAdapter } from "../../web/adapter/pi-adapter.ts";
@@ -224,9 +225,118 @@ test("first archive mutation preserves previously persisted archive metadata", a
     const persisted = JSON.parse(
       await readFile(join(sessionDirectory, "archived-sessions.json"), "utf8"),
     ) as string[];
-    assert.deepEqual(
-      new Set(persisted),
-      new Set([existing, resolve(currentPath)]),
+    assert.deepEqual(new Set(persisted), new Set([existing, currentPath]));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("removing the current workspace keeps its unpersisted session ungrouped after it persists", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openpi-web-remove-workspace-"));
+  const sessionDirectory = join(root, "sessions");
+  const stash = join(root, "stash");
+  try {
+    await Promise.all([
+      mkdir(sessionDirectory, { recursive: true }),
+      mkdir(stash, { recursive: true }),
+    ]);
+    const persisted = SessionManager.create(root, sessionDirectory);
+    persistSession(persisted, "persisted", 1);
+    const persistedPath = persisted.getSessionFile();
+    assert.ok(persistedPath);
+    const persistedId = persisted.getSessionId();
+    const stashedPath = join(stash, basename(persistedPath));
+    await rename(persistedPath, stashedPath);
+    let currentFile: string | null = null;
+    const current = {
+      getSessionId: () => persistedId,
+      getSessionFile: () => currentFile,
+      getBranch: () => [],
+      getSessionName: () => undefined,
+    } as unknown as SessionManager;
+    const adapter = new PiWebAdapter(
+      runtimeFor(root, sessionDirectory, current),
+    );
+
+    await adapter.removeWorkspace(root);
+
+    const state = JSON.parse(
+      await readFile(join(sessionDirectory, "workspace-state.json"), "utf8"),
+    ) as { ungroupedSessions: string[] };
+    assert.deepEqual(state.ungroupedSessions, [`current:${persistedId}`]);
+    assert.equal(
+      (await adapter.getSnapshot()).sessions.find(
+        (session) => session.id === persistedId,
+      )?.ungrouped,
+      true,
+    );
+
+    await rename(stashedPath, persistedPath);
+    currentFile = persistedPath;
+
+    const snapshot = await adapter.getSnapshot();
+    assert.equal(
+      snapshot.sessions.find((session) => session.id === persistedId)
+        ?.ungrouped,
+      true,
+    );
+    assert.equal(
+      (await adapter.requireSession(persistedPath)).cwd,
+      resolve(root),
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("archiving an unpersisted session preserves the mark after it persists", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openpi-web-archive-persist-"));
+  const sessionDirectory = join(root, "sessions");
+  const stash = join(root, "stash");
+  try {
+    await Promise.all([
+      mkdir(sessionDirectory, { recursive: true }),
+      mkdir(stash, { recursive: true }),
+    ]);
+    const persisted = SessionManager.create(root, sessionDirectory);
+    persistSession(persisted, "persisted", 1);
+    const persistedPath = persisted.getSessionFile();
+    assert.ok(persistedPath);
+    const persistedId = persisted.getSessionId();
+    const stashedPath = join(stash, basename(persistedPath));
+    await rename(persistedPath, stashedPath);
+    let currentFile: string | null = null;
+    const current = {
+      getSessionId: () => persistedId,
+      getSessionFile: () => currentFile,
+      getBranch: () => [],
+      getSessionName: () => undefined,
+    } as unknown as SessionManager;
+    const adapter = new PiWebAdapter(
+      runtimeFor(root, sessionDirectory, current),
+    );
+
+    await adapter.archiveSession(`current:${persistedId}`);
+
+    const marks = JSON.parse(
+      await readFile(join(sessionDirectory, "archived-sessions.json"), "utf8"),
+    ) as string[];
+    assert.deepEqual(marks, [`current:${persistedId}`]);
+    assert.equal(
+      (await adapter.getSnapshot()).sessions.find(
+        (session) => session.id === persistedId,
+      )?.archived,
+      true,
+    );
+
+    await rename(stashedPath, persistedPath);
+    currentFile = persistedPath;
+
+    assert.equal(
+      (await adapter.getSnapshot()).sessions.find(
+        (session) => session.id === persistedId,
+      )?.archived,
+      true,
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -375,7 +485,7 @@ test("archive transactions roll back a failed mutation before the next mutation 
     const persisted = JSON.parse(
       await readFile(join(sessionDirectory, "archived-sessions.json"), "utf8"),
     ) as string[];
-    assert.deepEqual(persisted, [resolve(currentPath)]);
+    assert.deepEqual(persisted, [currentPath]);
     assert.equal(
       (await adapter.getSnapshot()).sessions.find(
         (session) => session.id === current.getSessionId(),

--- a/web/adapter/pi-adapter.ts
+++ b/web/adapter/pi-adapter.ts
@@ -27,6 +27,18 @@ type WorkspaceStateSnapshot = {
   restoreInitialWorkspace: boolean;
 };
 
+// An unpersisted active session is keyed by the synthetic `current:<sessionId>`
+// marker instead of a file path. Synthetic keys must round-trip verbatim:
+// resolving one against the process cwd both pollutes persisted state and
+// breaks lookups once the session gains a real file.
+function isSyntheticSessionKey(path: string) {
+  return path.startsWith("current:");
+}
+
+function sessionKey(path: string) {
+  return isSyntheticSessionKey(path) ? path : resolve(path);
+}
+
 export class PiWebAdapter {
   private readonly runtime: WebRuntimeController;
   private readonly importedWorkspaces = new Set<string>();
@@ -88,7 +100,7 @@ export class PiWebAdapter {
             this.hiddenWorkspaces.add(resolve(path));
           }
           for (const path of state.ungroupedSessions) {
-            this.ungroupedSessions.add(resolve(path));
+            this.ungroupedSessions.add(sessionKey(path));
           }
           for (const [path, name] of Object.entries(state.workspaceNames)) {
             this.workspaceNames.set(resolve(path), name as string);
@@ -144,7 +156,7 @@ export class PiWebAdapter {
           ) {
             throw new Error("Archive metadata must be an array of paths");
           }
-          for (const path of parsed) this.archivedSessions.add(resolve(path));
+          for (const path of parsed) this.archivedSessions.add(sessionKey(path));
         } catch (error) {
           if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
         }
@@ -280,7 +292,7 @@ export class PiWebAdapter {
     await this.ensureArchivesLoaded();
     await this.enqueueArchiveMutation(async (draft) => {
       const session = await this.requireSession(path);
-      draft.add(resolve(session.path));
+      draft.add(sessionKey(session.path));
     });
   }
 
@@ -295,14 +307,14 @@ export class PiWebAdapter {
       const sessions = await SessionManager.listAll(this.runtime.sessionDirectory);
       for (const session of sessions) {
         if (resolve(session.cwd) === canonical) {
-          draft.ungroupedSessions.add(resolve(session.path));
+          draft.ungroupedSessions.add(sessionKey(session.path));
         }
       }
       if (resolve(this.runtime.cwd) === canonical) {
         const currentPath =
           this.runtime.sessionManager.getSessionFile() ??
           `current:${this.runtime.sessionManager.getSessionId()}`;
-        draft.ungroupedSessions.add(resolve(currentPath));
+        draft.ungroupedSessions.add(sessionKey(currentPath));
       }
       draft.importedWorkspaces.delete(canonical);
       draft.workspaceNames.delete(canonical);
@@ -351,8 +363,12 @@ export class PiWebAdapter {
           session.firstMessage,
           WEB_MAX_SESSION_PREVIEW,
         ),
-        ...(this.archivedSessions.has(resolve(session.path)) ? { archived: true } : {}),
-        ...(this.ungroupedSessions.has(resolve(session.path)) ? { ungrouped: true } : {}),
+        ...(this.hasSessionMark(this.archivedSessions, session.path, session.id)
+          ? { archived: true }
+          : {}),
+        ...(this.hasSessionMark(this.ungroupedSessions, session.path, session.id)
+          ? { ungrouped: true }
+          : {}),
       }));
     if (
       this.runtime.workspaceSelected === true &&
@@ -390,10 +406,10 @@ export class PiWebAdapter {
         created: now,
         messageCount,
         firstMessage: boundedText(firstUser, WEB_MAX_SESSION_PREVIEW),
-        ...(this.archivedSessions.has(resolve(currentPath))
+        ...(this.hasSessionMark(this.archivedSessions, currentPath, currentId)
           ? { archived: true }
           : {}),
-        ...(this.ungroupedSessions.has(resolve(currentPath))
+        ...(this.hasSessionMark(this.ungroupedSessions, currentPath, currentId)
           ? { ungrouped: true }
           : {}),
       });
@@ -596,6 +612,18 @@ export class PiWebAdapter {
       snapshot.truncation.modelsOmitted++;
     }
     snapshot.truncation.truncated = true;
+  }
+
+  // Marks recorded while a session was unpersisted are stored under the
+  // synthetic `current:<id>` key; match either the resolved file path (marks
+  // recorded after persistence) or the synthetic key so marks survive the
+  // session gaining a real file.
+  private hasSessionMark(
+    marks: ReadonlySet<string>,
+    path: string,
+    id: string,
+  ) {
+    return marks.has(sessionKey(path)) || marks.has(`current:${id}`);
   }
 
   private captureWorkspaceState(): WorkspaceStateSnapshot {


### PR DESCRIPTION
## Problem

Fixes #351.

当前工作区在活动会话尚未落盘（还没有会话文件）时被移除，`removeWorkspace` 会把合成标记 `current:<sessionId>` 先经 `resolve()` 再写入 `ungroupedSessions`，实际持久化的是 `<cwd>/current:<uuid>` 这样的污染键。该键只有在同一进程内写入与查询两侧 resolve 结果恰好一致时才能匹配投影；一旦会话获得真实文件（发出第一条消息），标记永久丢失：会话从所有侧栏分组中消失，`/api/sessions/select` 被 `requireSession` 以 "Workspace is not available" 拒绝，切走后无法切回。`archiveSession` 存在同样模式，归档标记同样会丢失。

## Value

- 「删除工作区后其对话会移入 Ungrouped」的确认承诺，对尚未落盘的活动对话现在真正成立——此前恰恰在发出第一条消息时就破裂。
- 归档未落盘的会话后，归档标记在落盘后依然保留。
- 不再向 `workspace-state.json` / `archived-sessions.json` 累积假的 `<cwd>\current:<uuid>` 条目。

## Approach

遵循 #351 中建议的最小修复：

- 合成键 `current:<sessionId>` 现在原样往返：共享的 `sessionKey()` 辅助（配合 `isSyntheticSessionKey`）统一用于写入（`removeWorkspace`、`archiveSession`）与加载（`ensureWorkspaceStateLoaded`、`ensureArchivesLoaded`）；真实路径仍照常 `resolve()`。
- 投影查询经新增的 `hasSessionMark()` 辅助，按「resolve 后的真实文件路径」（落盘后记录的标记）或「合成 `current:<id>` 键」（落盘前记录的标记）双查，标记在会话获得真实文件后依然生效，无需任何迁移。
- 旧污染条目（`<cwd>\current:<uuid>`）resolve 幂等、不再匹配任何键——按 #351 的决策保留为惰性孤儿，不做迁移。

## Validation

- `npm run format:check`、`npm run lint`、`npm run typecheck` — 通过。
- `node --test --experimental-strip-types tests/web/pi-adapter.test.ts` — 15/15 通过，含 2 条新回归测试，完整复现 ungrouped 与 archive 两条流程的「未落盘 → 落盘」转换。
- 反向验证：stash 修复还原旧代码后，上述 4 条测试全部失败，证明新测试确实锁定该 bug。
- `tests/web` 纯逻辑套件（protocol、http-dispatcher、observer-registry、terminal-status、web-host-lease）：38 通过 / 0 失败 / 2 平台跳过；`app-render.test.ts`：21/21。
- Windows 上全量 `node scripts/run-tests.mjs` 会命中 #304 已跟踪的背景终端 kill 测试 flake/挂起（进程管理域，与本改动无关），本机无法完整跑完，如实说明。

## Impact

- 用户可见：删除当前工作区后，其未落盘的活动对话在落盘后仍留在 Ungrouped 且可选中；归档未落盘会话后，标记在落盘后保留。
- 持久化数据：新标记以 `current:<id>` 原样存储；旧污染条目保持可读且惰性（按 #351 不迁移），无 schema 变化。
- 模型可见上下文 / 运行时生命周期：无。
- 兼容性：旧代码写入的污染键本来就是失配孤儿，现有状态不会因此回归。
