### PR TITLE
fix(ui): 修复 Windows Home 路径缩写

### DIFF
--- a/extensions/ui-customization/footer.ts
+++ b/extensions/ui-customization/footer.ts
@@ -1,5 +1,4 @@
 import { homedir } from "node:os";
-import { relative } from "node:path";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import {
   getCapabilities,
@@ -117,10 +116,14 @@ export function formatTokens(tokens: number) {
   return `${(tokens / 1_000_000).toFixed(1)}m`;
 }
 
-export function formatDirectory(cwd: string) {
-  const home = homedir();
+export function formatDirectory(cwd: string, home = homedir()) {
   if (cwd === home) return "~";
-  const display = cwd.startsWith(`${home}/`) ? `~/${relative(home, cwd)}` : cwd;
+  const separator = cwd.startsWith(home) ? cwd[home.length] : undefined;
+  const child = separator === "/" || separator === "\\";
+  const relativePath = child ? cwd.slice(home.length + 1) : "";
+  const display = child
+    ? `~/${separator === "\\" ? relativePath.replaceAll("\\", "/") : relativePath}`
+    : cwd;
   return sanitizeTerminalLabel(display);
 }
 

--- a/extensions/ui-customization/footer.ts
+++ b/extensions/ui-customization/footer.ts
@@ -1,4 +1,5 @@
 import { homedir } from "node:os";
+import { posix, win32 } from "node:path";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import {
   getCapabilities,
@@ -116,14 +117,21 @@ export function formatTokens(tokens: number) {
   return `${(tokens / 1_000_000).toFixed(1)}m`;
 }
 
-export function formatDirectory(cwd: string, home = homedir()) {
-  if (cwd === home) return "~";
-  const separator = cwd.startsWith(home) ? cwd[home.length] : undefined;
-  const child = separator === "/" || separator === "\\";
-  const relativePath = child ? cwd.slice(home.length + 1) : "";
-  const display = child
-    ? `~/${separator === "\\" ? relativePath.replaceAll("\\", "/") : relativePath}`
-    : cwd;
+export function formatDirectory(
+  cwd: string,
+  home = homedir(),
+  pathModule = process.platform === "win32" ? win32 : posix,
+) {
+  const relativePath = pathModule.relative(home, cwd);
+  const outsideHome =
+    relativePath === ".." ||
+    relativePath.startsWith(`..${pathModule.sep}`) ||
+    pathModule.isAbsolute(relativePath);
+  const display = outsideHome
+    ? cwd
+    : relativePath
+      ? `~/${relativePath.replaceAll(pathModule.sep, "/")}`
+      : "~";
   return sanitizeTerminalLabel(display);
 }
 

--- a/tests/extensions/ui-customization/footer.test.ts
+++ b/tests/extensions/ui-customization/footer.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   buildSegmentCatalog,
   fitSegmentsToWidth,
+  formatDirectory,
   renderFooter,
   resolveLineSegments,
   type FooterSegment,
@@ -42,6 +43,22 @@ const gitInfo: GitInfoState = {
   changedFiles: 7,
   pullRequest: { number: 42, url: "https://example.com/pr/42", isDraft: false },
 };
+
+test("formatDirectory shortens Windows Home paths", () => {
+  assert.equal(
+    formatDirectory("C:\\Users\\Adam\\project", "C:\\Users\\Adam"),
+    "~/project",
+  );
+  assert.equal(formatDirectory("C:\\Users\\Adam", "C:\\Users\\Adam"), "~");
+  assert.equal(
+    formatDirectory("C:\\Users\\Adam2\\project", "C:\\Users\\Adam"),
+    "C:\\Users\\Adam2\\project",
+  );
+  assert.equal(
+    formatDirectory("/Users/adam/project", "/Users/adam"),
+    "~/project",
+  );
+});
 
 test("default one-line layout leads with model context and ends with cwd", () => {
   const lines = renderFooter({

--- a/tests/extensions/ui-customization/footer.test.ts
+++ b/tests/extensions/ui-customization/footer.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { posix, win32 } from "node:path";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import {
   DEFAULT_FOOTER_LINES,
@@ -56,6 +57,20 @@ test("formatDirectory shortens Windows Home paths", () => {
   );
   assert.equal(
     formatDirectory("/Users/adam/project", "/Users/adam"),
+    "~/project",
+  );
+});
+
+test("formatDirectory respects POSIX backslashes as filename characters", () => {
+  assert.equal(
+    formatDirectory("/Users/adam\\project", "/Users/adam", posix),
+    "/Users/adam\\project",
+  );
+});
+
+test("formatDirectory compares Windows paths case-insensitively", () => {
+  assert.equal(
+    formatDirectory("c:\\users\\adam\\project", "C:\\Users\\Adam", win32),
     "~/project",
   );
 });

--- a/tests/extensions/ui-customization/footer.test.ts
+++ b/tests/extensions/ui-customization/footer.test.ts
@@ -47,12 +47,15 @@ const gitInfo: GitInfoState = {
 
 test("formatDirectory shortens Windows Home paths", () => {
   assert.equal(
-    formatDirectory("C:\\Users\\Adam\\project", "C:\\Users\\Adam"),
+    formatDirectory("C:\\Users\\Adam\\project", "C:\\Users\\Adam", win32),
     "~/project",
   );
-  assert.equal(formatDirectory("C:\\Users\\Adam", "C:\\Users\\Adam"), "~");
   assert.equal(
-    formatDirectory("C:\\Users\\Adam2\\project", "C:\\Users\\Adam"),
+    formatDirectory("C:\\Users\\Adam", "C:\\Users\\Adam", win32),
+    "~",
+  );
+  assert.equal(
+    formatDirectory("C:\\Users\\Adam2\\project", "C:\\Users\\Adam", win32),
     "C:\\Users\\Adam2\\project",
   );
   assert.equal(


### PR DESCRIPTION
## Problem

在 Windows 上，`homedir()` 和当前工作目录使用反斜杠（`\`），而 `formatDirectory` 只检查 `${home}/`。因此 Home 目录下的工作目录无法缩写为 `~/...`，页脚会显示完整绝对路径。

关联 Issue：#335。

## Value

修复 Windows 页脚当前目录显示，减少无用的绝对路径占用，同时保持 POSIX 路径、Home 根目录和 Home 外路径的现有行为。

## Approach

- 让 Home 子路径判断同时支持 `/` 和 `\\` 分隔符。
- 将 Windows 子路径转换为页脚统一使用的 `/` 展示格式。
- 保留 Home 根目录显示为 `~`，并避免把 `C:\\Users\\Adam2` 等相邻路径误判为 Home 子路径。
- 增加 POSIX、Windows、Home 根目录及 Home 外路径的回归测试。

## Validation

- `node --test tests/extensions/ui-customization/footer.test.ts`：14/14 通过。
- `bun run check`：通过（配置契约、纪律检查、Web 语法、格式、Lint、TypeScript）。
- `git diff --check`：通过。
- `bun run test`：Windows 本地完整套件仍遇到已有的 `background-terminals` 进程测试失败并挂起；相关问题与本 PR 修改的页脚文件无关。

## Impact

- 用户可见行为：Windows Home 目录下的页脚 cwd 改为 `~/...`，其他路径行为不变。
- 模型可见工具：无变化。
- 运行时与生命周期：无变化。
- 持久化配置或数据：无变化。
- 兼容性与风险：低；仅调整目录显示格式。

Fixes #335