### PR TITLE
feat(web): project Pi trust state in snapshots

### DIFF
--- a/web/adapter/pi-adapter.ts
+++ b/web/adapter/pi-adapter.ts
@@ -490,6 +490,7 @@ export class PiWebAdapter {
         status: this.runtime.isIdle()
           ? ("idle" as const)
           : ("running" as const),
+        trust: this.runtime.projectTrustState ?? "unknown",
         capabilities: webCapabilitySnapshot(this.runtime.sessionManager),
       },
       truncation: {

--- a/web/protocol/types.ts
+++ b/web/protocol/types.ts
@@ -113,6 +113,7 @@ export interface WebSnapshot {
   models: WebModelSummary[];
   runtime: {
     status: "idle" | "running" | "unknown";
+    trust: "trusted" | "untrusted" | "unknown";
     capabilities: WebCapabilitySnapshot;
   };
   truncation: WebSnapshotTruncation;

--- a/web/runtime/pi-runtime.ts
+++ b/web/runtime/pi-runtime.ts
@@ -86,6 +86,17 @@ export class PiWebRuntime implements WebRuntimeController {
   private disposePromise?: Promise<void>;
   private hasSelectedWorkspace: boolean;
 
+  get projectTrustState() {
+    if (!this.hasSelectedWorkspace) return "unknown" as const;
+    try {
+      return this.runtime.session.settingsManager.isProjectTrusted()
+        ? ("trusted" as const)
+        : ("untrusted" as const);
+    } catch {
+      return "unknown" as const;
+    }
+  }
+
   private constructor(
     runtime: AgentSessionRuntime,
     webSessionDirectory: string,

--- a/web/runtime/types.ts
+++ b/web/runtime/types.ts
@@ -53,6 +53,7 @@ export interface WebRuntimeController {
   readonly workspaceSelected: boolean;
   readonly sessionDirectory: string;
   readonly sessionManager: SessionManager;
+  readonly projectTrustState?: "trusted" | "untrusted" | "unknown";
   isIdle(): boolean;
   sendPrompt(content: string, options?: WebPromptOptions): Promise<void>;
   newSession(


### PR DESCRIPTION
## Problem

Implements the snapshot portion of #343. Web clients could not distinguish the active workspace trust state before invoking operations.

## Value

The browser can show whether the current workspace is trusted without owning or persisting a second permission policy.

## Approach

Read Pi SettingsManager trust state through the Web runtime, map it to bounded `trusted`/`untrusted`/`unknown` values, and include it in the existing runtime snapshot projection. Unbound or unreadable state fails closed to `unknown`.

## Validation

- `npx tsc --noEmit`
- `node --test --experimental-strip-types tests/web/protocol.test.ts tests/web/pi-adapter.test.ts tests/web/pi-runtime.test.ts` (44 passed)
- `git diff --check`

## Impact

- User-visible behavior: snapshot consumers receive trust status for display.
- Model-visible context/tools: none.
- Runtime/lifecycle: reads Pi-owned trust state only.
- Persisted config/data: none.
- Compatibility/risk: optional controller field preserves existing test doubles; approval actions remain a separate follow-up.