### PR TITLE
feat(web): expose bounded capability snapshot endpoint

### DIFF
--- a/web/host/web-host.ts
+++ b/web/host/web-host.ts
@@ -9,7 +9,10 @@ import {
 } from "node:http";
 import { URL } from "node:url";
 import { promisify } from "node:util";
-import { subscribeWebCapabilities } from "../../extensions/shared/web-observer-registry.ts";
+import {
+  subscribeWebCapabilities,
+  webCapabilitySnapshot,
+} from "../../extensions/shared/web-observer-registry.ts";
 import { PiWebAdapter } from "../adapter/pi-adapter.ts";
 import {
   jsonByteLength,
@@ -557,6 +560,11 @@ export class WebHost {
     }
     if (url.pathname === "/api/models")
       return this.json(response, 200, { models: this.runtime.listModels() });
+    if (url.pathname === "/api/capabilities")
+      return this.json(response, 200, {
+        sessionId: this.runtime.sessionManager.getSessionId(),
+        capabilities: webCapabilitySnapshot(this.runtime.sessionManager),
+      });
     if (url.pathname === "/api/snapshot") {
       const cursor = this.sequence;
       const projection = await this.adapter.getSnapshot(


### PR DESCRIPTION
## Problem

Implements the read-only protocol slice of #346. The Web workbench had capability data only inside the full snapshot, with no focused endpoint for capability panels and reconnect refreshes.

## Value

Operators can request the existing bounded Subagent/Workflow/Terminal projections directly without the browser reconstructing lifecycle state.

## Approach

Expose authenticated `GET /api/capabilities`, using the existing `webCapabilitySnapshot` projection and active Session identity. No new registry or control path is introduced.

## Validation

- `npx tsc --noEmit`
- `git diff --check`

## Impact

- User-visible behavior: enables focused capability-panel refreshes.
- Model-visible context/tools: none.
- Runtime/lifecycle: read-only projection only.
- Persisted config/data: none.
- Compatibility/risk: additive endpoint; lifecycle controls remain owner-specific follow-ups.