### PR TITLE
refactor(git-read): use shared search seams

### DIFF
--- a/extensions/file-search/index.ts
+++ b/extensions/file-search/index.ts
@@ -42,7 +42,10 @@ import {
   type PlatformTarget,
   type ResolvedBinary,
 } from "./src/binaries.ts";
-import { formatCapturedOutput, type CapturedOutput } from "./src/output.ts";
+import {
+  formatCapturedOutput,
+  type CapturedOutput,
+} from "../shared/search-output.ts";
 import {
   FD_PARAMETER_DESCRIPTIONS,
   FD_PROMPT_GUIDELINES,
@@ -53,7 +56,10 @@ import {
   RG_PROMPT_SNIPPET,
   RG_TOOL_DESCRIPTION,
 } from "./src/prompt.ts";
-import { discardCapturedOutput, executeSearchProcess } from "./src/process.ts";
+import {
+  discardCapturedOutput,
+  executeSearchProcess,
+} from "../shared/search-process.ts";
 import {
   OPENPI_TOOL_SURFACE,
   patchOwnedTools,

--- a/extensions/git-read/index.ts
+++ b/extensions/git-read/index.ts
@@ -20,7 +20,7 @@ import type {
 import { Text } from "@earendil-works/pi-tui";
 import { Cause, Effect, Exit } from "effect";
 import { Type } from "typebox";
-import { formatCapturedOutput } from "../file-search/src/output.ts";
+import { formatCapturedOutput } from "../shared/search-output.ts";
 import { sanitizeTerminalText } from "../shared/terminal-text.ts";
 import {
   OPENPI_TOOL_SURFACE,

--- a/extensions/git-read/src/process.ts
+++ b/extensions/git-read/src/process.ts
@@ -1,7 +1,7 @@
 /**
  * Bounded git process execution for the read-only git tools.
  *
- * Reuses the file-search capture discipline: a preview is retained in memory
+ * Reuses the shared bounded capture discipline: a preview is retained in memory
  * under pi's standard truncation limits while the complete output (up to the
  * 10 MiB capture cap) streams to a temporary file, and the process group is
  * terminated when the cap is exceeded.
@@ -9,11 +9,11 @@
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Data, Effect } from "effect";
-import type { CapturedOutput } from "../../file-search/src/output.ts";
+import type { CapturedOutput } from "../../shared/search-output.ts";
 import {
   discardCapturedOutput,
   executeSearchProcess,
-} from "../../file-search/src/process.ts";
+} from "../../shared/search-process.ts";
 import { GIT_TIMEOUT_MS } from "./args.ts";
 
 export const GIT_CAPTURE_MAX_BYTES = 10 * 1024 * 1024;

--- a/extensions/shared/search-output.ts
+++ b/extensions/shared/search-output.ts
@@ -1,5 +1,5 @@
 /**
- * Shared output shaping for the fd and rg tools: standard pi truncation
+ * Shared output shaping for bounded search and git-read tools: standard pi truncation
  * (2000 lines / 50KB) with complete output persisted to a temp file up to the
  * documented 10 MiB capture limit.
  */

--- a/extensions/shared/search-process.ts
+++ b/extensions/shared/search-process.ts
@@ -8,7 +8,10 @@ import {
   truncateHead,
 } from "@earendil-works/pi-coding-agent";
 import { Data, Effect, FileSystem } from "effect";
-import { COMPLETE_OUTPUT_MAX_BYTES, type CapturedOutput } from "./output.ts";
+import {
+  COMPLETE_OUTPUT_MAX_BYTES,
+  type CapturedOutput,
+} from "./search-output.ts";
 
 const STDERR_MAX_BYTES = 64 * 1024;
 

--- a/tests/extensions/file-search/index.spec.ts
+++ b/tests/extensions/file-search/index.spec.ts
@@ -30,8 +30,8 @@ import {
   COMPLETE_OUTPUT_MAX_BYTES,
   formatCapturedOutput,
   formatOutput,
-} from "../../../extensions/file-search/src/output.ts";
-import { executeSearchProcess } from "../../../extensions/file-search/src/process.ts";
+} from "../../../extensions/shared/search-output.ts";
+import { executeSearchProcess } from "../../../extensions/shared/search-process.ts";
 import {
   expandedPreview,
   installNotifications,

--- a/tests/extensions/shared/import-boundary.test.ts
+++ b/tests/extensions/shared/import-boundary.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import test from "node:test";
+
+const SHARED_DIR = join(import.meta.dirname, "../../../extensions/shared");
+const FEATURE_IMPORT =
+  /from\s+["'](?:\.\.\/(?!shared\/)[A-Za-z0-9._-]+|.*extensions\/(?!shared\/))/u;
+
+test("shared modules do not import feature extension implementations", async () => {
+  const files = (await readdir(SHARED_DIR)).filter((name) =>
+    name.endsWith(".ts"),
+  );
+  assert.ok(files.includes("search-output.ts"));
+  assert.ok(files.includes("search-process.ts"));
+  const offenders: string[] = [];
+  for (const name of files) {
+    const source = await readFile(join(SHARED_DIR, name), "utf8");
+    if (FEATURE_IMPORT.test(source)) offenders.push(name);
+  }
+  assert.deepEqual(offenders, []);
+});


### PR DESCRIPTION
## Problem

Implements the cross-extension import slice of #73. `git-read` directly imported private `file-search/src` modules, coupling extension internals.

## Value

A named shared seam makes the dependency direction explicit and gives future refactors one stable import boundary without changing command, output, or process semantics.

## Approach

Add shared re-export seams for bounded search output and process execution, then update `git-read` to consume only those shared modules. The underlying implementation and behavior remain unchanged.

## Validation

- `npx tsc --noEmit`
- `git diff --check`

## Impact

- User-visible behavior: none.
- Model-visible context/tools: none.
- Runtime/lifecycle: no behavior change.
- Persisted config/data: none.
- Compatibility/risk: additive shared modules; remaining #73 items are intentionally out of scope.