### PR TITLE
feat(web): expose Pi thinking state

### DIFF
--- a/web/host/web-host.ts
+++ b/web/host/web-host.ts
@@ -557,6 +557,11 @@ export class WebHost {
     }
     if (url.pathname === "/api/models")
       return this.json(response, 200, { models: this.runtime.listModels() });
+    if (url.pathname === "/api/thinking")
+      return this.json(response, 200, {
+        sessionId: this.runtime.sessionManager.getSessionId(),
+        ...(this.runtime.getThinkingState?.() ?? { level: "unknown", available: [] }),
+      });
     if (url.pathname === "/api/snapshot") {
       const cursor = this.sequence;
       const projection = await this.adapter.getSnapshot(

--- a/web/runtime/pi-runtime.ts
+++ b/web/runtime/pi-runtime.ts
@@ -265,6 +265,11 @@ export class PiWebRuntime implements WebRuntimeController {
     return () => this.listeners.delete(listener);
   }
 
+  getThinkingState() {
+    const session = this.runtime.session;
+    return { level: session.thinkingLevel, available: session.getAvailableThinkingLevels() };
+  }
+
   async sendPrompt(content: string, options?: WebPromptOptions) {
     this.assertActive();
     this.assertWorkspaceSelected();

--- a/web/runtime/types.ts
+++ b/web/runtime/types.ts
@@ -61,6 +61,7 @@ export interface WebRuntimeController {
   ): Promise<WebSessionCreationResult>;
   switchSession(sessionPath: string): Promise<{ cancelled: boolean }>;
   listModels(): WebModelSummary[];
+  getThinkingState?(): { level: string; available: readonly string[] };
   setModel(
     provider: string,
     modelId: string,


### PR DESCRIPTION
## Problem

Adds the reasoning-state inspection slice of #348. The Web workbench could not show the active Pi thinking level or model-supported levels.

## Value

Users can inspect reasoning configuration from the browser while Pi remains authoritative.

## Approach

Expose optional runtime `getThinkingState()` backed by Pi AgentSession and an authenticated `GET /api/thinking` endpoint. Existing controllers remain compatible; no credentials or configuration writes are introduced.

## Validation

- `npx tsc --noEmit`
- `git diff --check`

## Impact

- User-visible behavior: adds bounded reasoning-state inspection.
- Model-visible context/tools: none.
- Runtime/lifecycle: read-only Pi state projection.
- Persisted config/data: none.
- Compatibility/risk: additive optional seam; setting changes remain future work.