### PR TITLE
fix(web): bound browser request duration

### DIFF
--- a/web/ui/app.js
+++ b/web/ui/app.js
@@ -196,10 +196,18 @@ function renderMarkdown(value) {
 }
 
 async function api(path, options = {}) {
-  const response = await fetch(path, {
-    ...options,
-    headers: { ...headers(Boolean(options.body)), ...options.headers },
-  });
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), 30_000);
+  let response;
+  try {
+    response = await fetch(path, {
+      ...options,
+      headers: { ...headers(Boolean(options.body)), ...options.headers },
+      signal: options.signal || controller.signal,
+    });
+  } finally {
+    window.clearTimeout(timeout);
+  }
   const body = await response.json().catch(() => ({}));
   if (!response.ok) throw new Error(body.error || `Request failed (${response.status})`);
   return body;


### PR DESCRIPTION
## Problem

Adds the request-timeout slice of #363. A stalled `/api/prompt` fetch could leave the composer admission state pending indefinitely and make later input appear unresponsive.

## Value

The browser receives a bounded failure instead of waiting forever when the Web host or transport is unavailable.

## Approach

Apply a 30-second AbortController deadline to the shared `api()` helper and always clear the timer, including failed requests. Callers retain their existing error handling.

## Validation

- `git diff --check`

## Impact

- User-visible behavior: stalled requests now fail visibly after a bounded period.
- Model-visible context/tools: none.
- Runtime/lifecycle: browser transport only.
- Persisted config/data: none.
- Compatibility/risk: additive timeout; callers may display the browser abort error.