### PR TITLE
fix(test): give stalled Antigravity body failover a 500ms budget

### DIFF
--- a/tests/extensions/ai-providers/antigravity.test.ts
+++ b/tests/extensions/ai-providers/antigravity.test.ts
@@ -940,6 +940,8 @@ test("streamAntigravity fails over to the sandbox endpoint on 5xx", async () => 
 });
 
 test("streamAntigravity bounds a stalled non-2xx body and fails over", async () => {
+  const stalledBodyTimeoutMs = 500;
+  const stalledBodyOuterMs = 2 * stalledBodyTimeoutMs + 500;
   let requests = 0;
   const server = http.createServer((_request, response) => {
     requests++;
@@ -966,7 +968,7 @@ test("streamAntigravity bounds a stalled non-2xx body and fails over", async () 
     events = await collectEvents(
       streamAntigravity(GEMINI_MODEL, SIMPLE_CONTEXT, {
         apiKey: API_KEY,
-        timeoutMs: 50,
+        timeoutMs: stalledBodyTimeoutMs,
         fetch: (_input, init) => originalFetch(localUrl, init),
       }),
     );
@@ -974,7 +976,7 @@ test("streamAntigravity bounds a stalled non-2xx body and fails over", async () 
     server.closeAllConnections();
     await new Promise<void>((resolve) => server.close(() => resolve()));
   }
-  assert.ok(Date.now() - startedAt < 1_000);
+  assert.ok(Date.now() - startedAt < stalledBodyOuterMs);
   assert.equal(requests, 2);
   const done = events.find((event) => event.type === "done");
   assert.ok(done && done.type === "done" && done.reason === "stop");


### PR DESCRIPTION
## Summary

Only the stalled non-2xx Antigravity body failover test.

- `timeoutMs` 50 → 500
- Outer bound `2 * 500 + 500` (1500ms)
- First 503 body still stalls (`write` partial, no `end`)
- Still expects `requests === 2` and `done.reason === "stop"`

Production `streamAntigravity` is unchanged. This does not claim local reproduction of CI Node 26 / Windows `requests 1 !== 2`.

## Test plan

- [x] Delivery head: `bun run check`; focused case ×8 8/0; `antigravity.test.ts` ×3 37/37
- [x] `bun run test`: this case passed (~508ms); the local suite later hung on `workflows/execute.e2e.test.ts` and was killed. Vitest was not reached via `run-tests.mjs`.
- [x] Separate Vitest: `tests/extensions/file-search/index.spec.ts` 30/30
- [ ] CI Node 22 / 24 on Ubuntu
- [ ] Windows CI job (this is the missing proof for the original Windows flake)

Node 26 is not in the current CI matrix and is not claimed here.
