### PR TITLE
fix(workflows): use portable artifact identities

### DIFF
--- a/extensions/workflows/artifacts.test.ts
+++ b/extensions/workflows/artifacts.test.ts
@@ -128,6 +128,7 @@ test("agent result artifacts are complete or fail without leaving a file", () =>
       output: "complete",
       structured: { verdict: "accepted", emoji: "你好🙂" },
     });
+    assert.equal(artifact, "agent-results/agent-0001.json");
     assert.deepEqual(
       JSON.parse(readFileSync(join(directory, artifact), "utf8")),
       {

--- a/extensions/workflows/artifacts.ts
+++ b/extensions/workflows/artifacts.ts
@@ -109,7 +109,7 @@ export function persistWorkflowAgentResult(
   index: number,
   result: { output: string; structured?: unknown },
 ) {
-  const artifact = path.join(
+  const artifact = path.posix.join(
     "agent-results",
     `agent-${String(index).padStart(4, "0")}.json`,
   );


### PR DESCRIPTION
## Problem

Closes #284. Workflow agent result artifact identities used platform-specific path separators, so Windows handoff validation rejected successful child results.

## Fix

Use `path.posix.join` for persisted run-relative artifact identities while retaining platform-native paths for filesystem access. Add a regression assertion for the canonical slash-separated identity.

## Validation

- `node --experimental-strip-types --test extensions/workflows/artifacts.test.ts extensions/workflows/handoff.test.ts`
- 21 passed, 0 failed
- `git diff --check`
