### PR TITLE
fix(background-terminals): avoid false success after Windows taskkill timeout

### DIFF
--- a/extensions/background-terminals/src/manager.ts
+++ b/extensions/background-terminals/src/manager.ts
@@ -395,8 +395,8 @@ export async function signalWindowsProcessTree(
       : attempt.outcome === "timed_out"
         ? `taskkill timed out after ${attempt.timeoutMs}ms; helper ${attempt.helperClosed ? "closed after SIGKILL" : `did not close within an additional ${attempt.helperCloseTimeoutMs}ms`}`
         : `taskkill exited ${attempt.exitCode ?? "without a code"}${attempt.signal ? ` (${attempt.signal})` : ""}`;
-  // ponytail: a closed helper proves only that taskkill stopped, not that the
-  // target tree was removed; retry or Job Objects can provide stronger proof.
+  // Closing the helper or observing the shell exit does not prove that all
+  // descendants exited. Preserve uncertainty instead of killing only the shell.
   if (attempt.outcome === "timed_out") {
     return { outcome: "unresolved", detail };
   }

--- a/extensions/background-terminals/src/manager.ts
+++ b/extensions/background-terminals/src/manager.ts
@@ -395,11 +395,9 @@ export async function signalWindowsProcessTree(
       : attempt.outcome === "timed_out"
         ? `taskkill timed out after ${attempt.timeoutMs}ms; helper ${attempt.helperClosed ? "closed after SIGKILL" : `did not close within an additional ${attempt.helperCloseTimeoutMs}ms`}`
         : `taskkill exited ${attempt.exitCode ?? "without a code"}${attempt.signal ? ` (${attempt.signal})` : ""}`;
-  if (
-    attempt.outcome === "timed_out" &&
-    !attempt.helperClosed &&
-    !targetExited()
-  ) {
+  // ponytail: a closed helper proves only that taskkill stopped, not that the
+  // target tree was removed; retry or Job Objects can provide stronger proof.
+  if (attempt.outcome === "timed_out") {
     return { outcome: "unresolved", detail };
   }
   // A failed graceful taskkill must leave the shell PID alive for the

--- a/tests/extensions/background-terminals/manager.test.ts
+++ b/tests/extensions/background-terminals/manager.test.ts
@@ -204,6 +204,32 @@ test("Windows taskkill timeout waits for the stopped helper to close", async () 
   });
 });
 
+test("Windows taskkill timeout never falls back to a direct shell signal", async () => {
+  const killer = new EventEmitter() as ChildProcess;
+  killer.kill = () => {
+    queueMicrotask(() => killer.emit("close", null, "SIGKILL"));
+    return true;
+  };
+  const signals: Array<NodeJS.Signals | number | undefined> = [];
+
+  const result = await signalWindowsProcessTree(
+    {
+      pid: 47,
+      kill(signal) {
+        signals.push(signal);
+        return true;
+      },
+    },
+    "SIGKILL",
+    () => false,
+    () => killer,
+  );
+
+  assert.equal(result.outcome, "unresolved");
+  assert.match(result.detail, /helper closed after SIGKILL/);
+  assert.deepEqual(signals, []);
+});
+
 test("Windows taskkill helper close has a second explicit bound", async () => {
   const killer = new EventEmitter() as ChildProcess;
   killer.kill = () => true;

--- a/tests/extensions/background-terminals/manager.test.ts
+++ b/tests/extensions/background-terminals/manager.test.ts
@@ -204,31 +204,37 @@ test("Windows taskkill timeout waits for the stopped helper to close", async () 
   });
 });
 
-test("Windows taskkill timeout never falls back to a direct shell signal", async () => {
-  const killer = new EventEmitter() as ChildProcess;
-  killer.kill = () => {
-    queueMicrotask(() => killer.emit("close", null, "SIGKILL"));
-    return true;
-  };
-  const signals: Array<NodeJS.Signals | number | undefined> = [];
-
-  const result = await signalWindowsProcessTree(
-    {
-      pid: 47,
-      kill(signal) {
-        signals.push(signal);
+for (const signal of ["SIGTERM", "SIGKILL"] as const) {
+  for (const shellExitsDuringTimeout of [false, true]) {
+    test(`Windows ${signal} taskkill timeout stays unresolved when shell exit is ${shellExitsDuringTimeout}`, async () => {
+      let targetExited = false;
+      const killer = new EventEmitter() as ChildProcess;
+      killer.kill = () => {
+        targetExited = shellExitsDuringTimeout;
+        queueMicrotask(() => killer.emit("close", null, "SIGKILL"));
         return true;
-      },
-    },
-    "SIGKILL",
-    () => false,
-    () => killer,
-  );
+      };
+      const signals: Array<NodeJS.Signals | number | undefined> = [];
 
-  assert.equal(result.outcome, "unresolved");
-  assert.match(result.detail, /helper closed after SIGKILL/);
-  assert.deepEqual(signals, []);
-});
+      const result = await signalWindowsProcessTree(
+        {
+          pid: 47,
+          kill(signal) {
+            signals.push(signal);
+            return true;
+          },
+        },
+        signal,
+        () => targetExited,
+        () => killer,
+      );
+
+      assert.equal(result.outcome, "unresolved");
+      assert.match(result.detail, /helper closed after SIGKILL/);
+      assert.deepEqual(signals, []);
+    });
+  }
+}
 
 test("Windows taskkill helper close has a second explicit bound", async () => {
   const killer = new EventEmitter() as ChildProcess;


### PR DESCRIPTION
## Problem

Fixes #408. On Windows, a slow `taskkill /T /F` helper can exceed its bounded wait, get force-closed, and then fall back to `child.kill()`. That only terminates the shell and can orphan descendants while the manager reports successful termination.

## Value

A timed-out tree kill is reported as unresolved instead of claiming that the full process tree was terminated. This keeps background-terminal state truthful and avoids silently leaving servers or descendants holding resources.

## Approach

Treat every Windows `taskkill` timeout as unresolved, including the case where the helper closes after SIGKILL. Keep the existing time bounds, direct fallback behavior for non-timeout cases, and POSIX behavior unchanged. Cover both graceful and force timeouts, with the shell still alive or exiting during timeout. Every case stays unresolved and avoids a direct shell signal.

## Validation

- `bun run check` — passed.
- Node 22 `bun run test` at `a2c23a1` — 1427 passed, 1 skipped; Vitest 30 passed.
- The first local full-suite run hit a 150ms subagent watchdog assertion in `tests/extensions/subagents/manager.test.ts`; its isolated rerun and a second complete suite passed.
- Final-head Node 22, Node 24, and Windows CI must pass before merge.

## Impact

- User-visible behavior: uncertain Windows process-tree termination is surfaced as failure/unresolved rather than success.
- Model-visible context/tools: none.
- Runtime/lifecycle: Windows background-terminal cleanup fails closed on taskkill timeout; POSIX behavior is unchanged.
- Persisted config/data: none.
- Compatibility/risk: a timed-out Windows kill remains unconfirmed and may leave processes running. This change prevents the shell-only timeout fallback; it does not implement a reliable retry or Windows Job Object containment.
