### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tt-a1i/openpi",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "OpenPI — a Pi-native multi-agent workbench with background execution, isolated subagents, replay-safe workflows, goals, tasks, and observable TUI",
   "license": "MIT",
   "author": "tt-a1i",


### PR DESCRIPTION
## Problem

The npm latest release remains 0.5.0 while main contains 24 additional commits, including new providers, structured direct-subagent results, and Web reliability improvements.

## Value

Make the accumulated main changes available as OpenPI 0.6.0 through the existing validated npm release pipeline.

## Approach

Bump package.json from 0.5.0 to 0.6.0. This is a minor release because it adds public capabilities. After required checks pass and this PR is merged, tag the exact merged main commit as v0.6.0 and publish through the tag-triggered Release workflow.

## Validation

- Existing main CI at c1c60cd: passed.
- bun run check: passed.
- Required PR CI: Node 22.19.0, Node 24, and Windows all passed, including full suites and package smoke.
- Local macOS bun run test: default concurrency on Node 26 and Node 24 hit one detached-render settlement timeout (1426 passed, 1 failed, 1 skipped). The focused test and complete 20-test Workflow file passed. The complete discovered suite on Node 24 with --test-concurrency=4 passed: 1427 Node tests passed, 1 skipped; 30 Vitest tests passed. No test or runtime code was changed.
- Local Node 24 bun run check: passed.
- npm pack --dry-run --json --ignore-scripts: passed; 204 files, 760421 bytes compressed, 2357260 bytes unpacked.
- git diff --check: passed.
- Release workflow 34019034153: passed; npm latest is 0.6.0.
- Published npm SHA-512 matches the workflow artifact; provenance resolves to c8f2c13d49f2e6cd3b389dfff72ccc2eaca970c1 at refs/tags/v0.6.0.
- Isolated fresh npm install with Pi 0.85.1: unique OpenPI source, offline RPC extension discovery, Web startup, marked.js, and SIGTERM shutdown all passed. No provider model calls or visual UI acceptance were performed.
- GitHub Release: https://github.com/openpi-dev/openpi/releases/tag/v0.6.0

## Impact

This PR only changes the package version. The release includes user-visible Web features and provider integrations, model-visible structured subagent output, background completion delivery changes, and a persisted Web theme preference. Pi 0.85.1 or newer is required. Cursor OAuth is experimental and chat-only. Workflow acceptance self-attestation is deprecated and no longer determines agent().ok. No new data migration is introduced by this version bump.
