### PR TITLE
chore(release): publish OpenPI 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tt-a1i/openpi",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "OpenPI — a Pi-native multi-agent workbench with background execution, isolated subagents, replay-safe workflows, goals, tasks, and observable TUI",
   "license": "MIT",
   "author": "tt-a1i",


### PR DESCRIPTION
## Problem

The Workflow and child-session repairs merged since v0.6.0 are not yet available from npm.

## Value

Publish the validated fixes as @tt-a1i/openpi 0.6.1.

## Approach

Bump only package.json from 0.6.0 to 0.6.1. After merge, tag the exact main commit and use the existing release workflow.

## Validation

Repository checks and full tests run for this version change; release CI revalidates the tagged source and package before npm publication.

## Impact

Version metadata only. Release includes #422, #426 and #429. Existing custom role allowlists are preserved; built-in roles inherit parent child-eligible tools. No local runtime is reloaded.
