### PR TITLE
fix(cursor): bound frame copying and preserve context boundaries

### DIFF
--- a/docs/research/CURSOR_CONTEXT_AND_TRANSPORT_2026-09-07.md
+++ b/docs/research/CURSOR_CONTEXT_AND_TRANSPORT_2026-09-07.md
@@ -1,0 +1,37 @@
+# Cursor context and transport follow-up
+
+- Status: validated source investigation and deterministic reproductions; PR validation is recorded in the linked Issue
+- Created / verified: 2026-09-07
+- Source boundary: `69a7e5f19b4db3e32b7ad6abc81884edf767b2e3` (v0.6.1)
+- Issue: [#431](https://github.com/openpi-dev/openpi/issues/431)
+- Supersedes: none
+
+## Scope and runtime identity
+
+The isolated repair checkout is `openpi-context-transport-performance`. The user's `pi list` still reports one OpenPI source, `openpi-main-runtime`, at `c8f2c13d49f2e6cd3b389dfff72ccc2eaca970c1`. Source tests do not imply that the running Pi has loaded these fixes. No role, auth, settings or user runtime files were changed.
+
+## Context: preserve the two protocol projections
+
+A local request probe with a 115,000-byte historical user message found that payload in two blobs, totaling approximately 230,565 stored bytes with surrounding metadata. This is a local representation cost, not proof of doubled model context or billed input.
+
+The primary upstream [history repair #737](https://github.com/can1357/oh-my-pi/pull/737) identifies the JSON root history as model input and the protobuf turns as Cursor UI state. It records actual history loss when only turns were populated. OpenPI builds both from current Pi messages. Removing either without a protocol acceptance test would be a semantic change, not a safe allocation optimization. Request-context rules similarly remain unchanged; server-side deduplication and exact tokenization have not been measured here.
+
+Cursor's generated-token deltas do not contain complete input/cache usage. Keep usage unknown rather than reporting generated tokens as total context. Current Pi skips all-zero usage when selecting a context anchor and estimates message history for compaction; the existing real AgentSession regression exercises an 800,000-character prompt with generated-only token updates. This is a heuristic, not an exact tokenizer or provider billing receipt. The repair adds request-history regressions, including rebuilding from a compacted context without reviving omitted history. It does not replace Pi compaction or introduce a second usage ledger.
+
+## Transport: repeated frame copying
+
+The previous receive loop concatenated the entire incomplete frame for each network chunk. A deterministic 1 MiB payload split into 1 KiB chunks copied 538,442,757 bytes for 1,048,581 wire bytes. The regression counts byte-copy operations rather than enforcing a machine-dependent timing threshold.
+
+The repair accumulates the five-byte header, rejects oversized frames before body allocation, and copies a fragmented payload into one bounded buffer. Contiguous payloads use a synchronous borrowed slice. Each body byte is copied at most once; header copying is constant per frame. The existing 16 MiB frame limit is unchanged. A fragmented frame now reserves its declared bounded body size once the complete header arrives, even before its whole body arrives; this trades repeated incremental allocations for one bounded reservation.
+
+Tests cover all split positions, empty/coalesced frames, retained-buffer stability, exact-limit acceptance, oversized headers, linear copy bounds and production EOF errors. Existing production transport tests cover text/thinking, tool pairing, trailers, permission denial, timeout and cancellation. A complete header awaiting its body still delays tool handoff; a partial header retains the existing behavior. This is an allocation repair, not a throughput claim for live Cursor or eight concurrent model calls.
+
+## Transcript: confirmed cache error, viewport priority narrowed
+
+On the fixed base, reusing the same transcript items after changing cwd could retain a path formatted relative to the old directory. A warm renderer showed `Read file.ts` where a fresh renderer showed the original absolute path. Adding cwd to the bounded per-item cache key fixes that operator-visible error. It does not change model context or native tool execution.
+
+The separate [viewport PR #327](https://github.com/openpi-dev/openpi/pull/327), inspected at `9691b006a9a96c786a9ed4cd6d5fd00ae8499e9f`, reports approximately 0.1 ms warm repaint at the 512-item ceiling and explicitly excludes cold-open improvement. That evidence does not establish severe present-day lag. Its larger layout/revision rewrite needs separate validation of renderer identity and invalidation before adoption. This batch therefore repairs the reproduced stale path, rather than importing an overlapping renderer rewrite. Full-history iteration remains a scaling opportunity, not a newly validated severe defect.
+
+## Acceptance limits
+
+No paid provider calls were needed or made for these deterministic tests. Local SDK/transport tests establish the client behavior; upstream protocol evidence is separately attributed. Local `bun run check` passed. The default full test attempt was interrupted during host scheduling delay; the complete discovered suite then passed at Node file concurrency 2 (1455 passed, one platform skip; Vitest 30/30). Two independent reviews found no actionable defects. Remote CI receipts are recorded in the PR. This investigation is not a formal end-to-end performance Benchmark.

--- a/docs/research/CURSOR_CONTEXT_AND_TRANSPORT_2026-09-07.md
+++ b/docs/research/CURSOR_CONTEXT_AND_TRANSPORT_2026-09-07.md
@@ -4,6 +4,7 @@
 - Created / verified: 2026-09-07
 - Source boundary: `69a7e5f19b4db3e32b7ad6abc81884edf767b2e3` (v0.6.1)
 - Issue: [#431](https://github.com/openpi-dev/openpi/issues/431)
+- Repair PR: [#432](https://github.com/openpi-dev/openpi/pull/432)
 - Supersedes: none
 
 ## Scope and runtime identity

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -4,6 +4,8 @@ Research records preserve sourced investigation and distinguish observations, in
 
 ## Validated investigations
 
+- [`CURSOR_CONTEXT_AND_TRANSPORT_2026-09-07.md`](CURSOR_CONTEXT_AND_TRANSPORT_2026-09-07.md) — Cursor protocol context boundaries, linear frame accumulation and cwd-sensitive transcript caching ([#431](https://github.com/openpi-dev/openpi/issues/431)).
+
 - [`CHILD_ACQUISITION_AND_PROGRESS_2026-09-07.md`](CHILD_ACQUISITION_AND_PROGRESS_2026-09-07.md) — cancelled child/worktree acquisitions and stale progress evidence under output pressure ([#428](https://github.com/openpi-dev/openpi/issues/428)).
 
 - [`WORKFLOW_CHILD_FAILURES_2026-09-07.md`](WORKFLOW_CHILD_FAILURES_2026-09-07.md) — child tool transport, cwd and timeout failure mechanisms, intended capability inheritance, and acceptance limits ([#424](https://github.com/openpi-dev/openpi/issues/424)).

--- a/extensions/ai-providers/cursor/connect-frame-reader.ts
+++ b/extensions/ai-providers/cursor/connect-frame-reader.ts
@@ -1,0 +1,76 @@
+/** Incremental Cursor Connect framing; callbacks consume complete frames synchronously. */
+export class ConnectFrameReader {
+  private readonly maxBytes: number;
+  private readonly header = Buffer.alloc(5);
+  private headerBytes = 0;
+  private payload: Buffer | undefined;
+  private payloadBytes = 0;
+
+  constructor(maxBytes: number) {
+    this.maxBytes = maxBytes;
+  }
+
+  get incomplete() {
+    return this.headerBytes !== 0;
+  }
+
+  get awaitingPayload() {
+    return this.payload !== undefined;
+  }
+
+  push(chunk: Buffer, onFrame: (flags: number, data: Buffer) => void) {
+    let offset = 0;
+    while (offset < chunk.length) {
+      if (this.payload) {
+        const copied = chunk.copy(
+          this.payload,
+          this.payloadBytes,
+          offset,
+          offset +
+            Math.min(
+              chunk.length - offset,
+              this.payload.length - this.payloadBytes,
+            ),
+        );
+        offset += copied;
+        this.payloadBytes += copied;
+      } else {
+        if (this.headerBytes < 5) {
+          const copied = chunk.copy(
+            this.header,
+            this.headerBytes,
+            offset,
+            offset + Math.min(5 - this.headerBytes, chunk.length - offset),
+          );
+          offset += copied;
+          this.headerBytes += copied;
+          if (this.headerBytes < 5) return;
+        }
+        const size = this.header.readUInt32BE(1);
+        if (size > this.maxBytes)
+          throw new Error(
+            `Cursor Connect frame exceeds ${this.maxBytes} bytes`,
+          );
+        if (chunk.length - offset >= size) {
+          const data = chunk.subarray(offset, offset + size);
+          const flags = this.header[0]!;
+          offset += size;
+          this.headerBytes = 0;
+          onFrame(flags, data);
+          continue;
+        }
+        this.payload = Buffer.allocUnsafe(size);
+        this.payloadBytes = 0;
+        continue;
+      }
+      if (this.payloadBytes === this.payload.length) {
+        const data = this.payload;
+        const flags = this.header[0]!;
+        this.payload = undefined;
+        this.payloadBytes = 0;
+        this.headerBytes = 0;
+        onFrame(flags, data);
+      }
+    }
+  }
+}

--- a/extensions/ai-providers/cursor/provider.ts
+++ b/extensions/ai-providers/cursor/provider.ts
@@ -14,6 +14,7 @@ import type {
 } from "@earendil-works/pi-ai/compat";
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai/compat";
 import { emptyUsage } from "../usage.ts";
+import { ConnectFrameReader } from "./connect-frame-reader.ts";
 import {
   CURSOR_API_URL,
   CURSOR_CLIENT_VERSION,
@@ -833,7 +834,7 @@ export function streamCursor(
           h2Request?.close(http2.constants.NGHTTP2_CANCEL);
         }, requestTimeoutMs);
       };
-      let frameBuffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+      const frames = new ConnectFrameReader(MAX_CONNECT_FRAME_BYTES);
       const processFrame = (flags: number, bytes: Uint8Array) => {
         if (handingOffTools) return;
         if ((flags & CONNECT_COMPRESSED_FLAG) !== 0) {
@@ -1033,23 +1034,9 @@ export function streamCursor(
         );
       };
       const processData = (chunk: Buffer) => {
-        frameBuffer =
-          frameBuffer.length === 0
-            ? chunk
-            : Buffer.concat([frameBuffer, chunk]);
-        while (frameBuffer.length >= 5) {
-          const size = frameBuffer.readUInt32BE(1);
-          if (size > MAX_CONNECT_FRAME_BYTES) {
-            throw new Error(
-              `Cursor Connect frame exceeds ${MAX_CONNECT_FRAME_BYTES} bytes`,
-            );
-          }
-          if (frameBuffer.length < size + 5) return;
-          const flags = frameBuffer[0]!;
-          const data = frameBuffer.subarray(5, size + 5);
-          frameBuffer = frameBuffer.subarray(size + 5);
-          processFrame(flags, data);
-        }
+        frames.push(chunk, processFrame);
+        // Preserve tool batching while a complete header awaits its body.
+        if (frames.awaitingPayload) return;
         if (pendingCalls.size > 0 && !handingOffTools) {
           if (terminalError) throw terminalError;
           if (options?.signal?.aborted)
@@ -1158,7 +1145,7 @@ export function streamCursor(
           .then(() => {
             if (!responseSeen)
               throw new Error("Cursor response headers were not received");
-            if (frameBuffer.length !== 0)
+            if (frames.incomplete)
               throw new Error("Incomplete Cursor Connect frame");
             settle();
           })

--- a/extensions/shared/agent-transcript.ts
+++ b/extensions/shared/agent-transcript.ts
@@ -409,7 +409,7 @@ function findResult(
 }
 
 /**
- * Caches finalized transcript items by identity and width. Live state remains
+ * Caches finalized transcript items by identity, width, and cwd. Live state remains
  * uncached because it changes on every stream tick; callers clear this cache
  * from their component's invalidate() when Pi changes theme.
  */
@@ -434,7 +434,8 @@ export class AgentTranscriptRenderer {
     for (let index = 0; index < document.items.length; index++) {
       const item = document.items[index];
       const context = itemContext(document.items, index, liveIds, pairing);
-      const key = `${width}|${context.token}`;
+      // Fallback tool rows relativize paths against the document's cwd.
+      const key = JSON.stringify([width, context.token, document.cwd]);
       const cacheable = !document.toolRenderer || !itemHasTool(item);
       const cached = cacheable ? this.itemCache.get(item)?.get(key) : undefined;
       const lines =

--- a/tests/extensions/ai-providers/connect-frame-reader.test.ts
+++ b/tests/extensions/ai-providers/connect-frame-reader.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { ConnectFrameReader } from "../../../extensions/ai-providers/cursor/connect-frame-reader.ts";
+
+function frame(text: string, flags = 0) {
+  const body = Buffer.from(text);
+  const header = Buffer.alloc(5);
+  header[0] = flags;
+  header.writeUInt32BE(body.length, 1);
+  return Buffer.concat([header, body]);
+}
+
+test("Connect framing preserves every split, empty frames and coalesced boundaries", () => {
+  const bytes = Buffer.concat([frame("hello", 1), frame(""), frame("世界", 2)]);
+  for (let split = 0; split <= bytes.length; split++) {
+    const reader = new ConnectFrameReader(100);
+    const seen: Array<[number, string]> = [];
+    const receive = (flags: number, data: Buffer) =>
+      seen.push([flags, data.toString()]);
+    reader.push(bytes.subarray(0, split), receive);
+    reader.push(bytes.subarray(split), receive);
+    assert.deepEqual(seen, [
+      [1, "hello"],
+      [0, ""],
+      [2, "世界"],
+    ]);
+    assert.equal(reader.incomplete, false);
+  }
+});
+
+test("Connect reader distinguishes partial headers and payloads and rejects oversized headers", () => {
+  const reader = new ConnectFrameReader(5);
+  const bytes = frame("hello");
+  const seen: string[] = [];
+  const receive = (_flags: number, data: Buffer) => seen.push(data.toString());
+  reader.push(bytes.subarray(0, 4), receive);
+  assert.equal(reader.incomplete, true);
+  assert.equal(reader.awaitingPayload, false);
+  reader.push(bytes.subarray(4, 7), receive);
+  assert.equal(reader.awaitingPayload, true);
+  reader.push(bytes.subarray(7), receive);
+  assert.deepEqual(seen, ["hello"]);
+  assert.equal(reader.incomplete, false);
+  const tooBig = frame("123456");
+  assert.throws(
+    () => reader.push(tooBig.subarray(0, 5), receive),
+    /exceeds 5 bytes/,
+  );
+});
+
+test("fragmented Connect payload copying is linear in wire bytes", () => {
+  const bytes = frame("x".repeat(1024 * 1024));
+  const reader = new ConnectFrameReader(bytes.length);
+  const originalConcat = Buffer.concat;
+  const originalCopy = Buffer.prototype.copy;
+  let copied = 0;
+  let delivered = 0;
+  Buffer.concat = (list, length) => {
+    copied += length ?? list.reduce((sum, item) => sum + item.length, 0);
+    return originalConcat(list, length);
+  };
+  Buffer.prototype.copy = function (...args: Parameters<Buffer["copy"]>) {
+    const count = originalCopy.apply(this, args);
+    copied += count;
+    return count;
+  };
+  try {
+    for (let i = 0; i < bytes.length; i += 1024) {
+      reader.push(bytes.subarray(i, i + 1024), (_flags, data) => {
+        assert.equal(data.length, 1024 * 1024);
+        delivered++;
+      });
+    }
+  } finally {
+    Buffer.concat = originalConcat;
+    Buffer.prototype.copy = originalCopy;
+  }
+  assert.equal(delivered, 1);
+  assert.ok(
+    copied <= bytes.length * 2,
+    `${copied} copied bytes for ${bytes.length} wire bytes`,
+  );
+});
+
+test("completed payload buffers are not reused by later frames", () => {
+  const reader = new ConnectFrameReader(100);
+  const retained: Buffer[] = [];
+  for (const text of ["first", "second"]) {
+    const bytes = frame(text);
+    for (const byte of bytes)
+      reader.push(Buffer.from([byte]), (_flags, data) => retained.push(data));
+  }
+  assert.deepEqual(
+    retained.map((data) => data.toString()),
+    ["first", "second"],
+  );
+  assert.equal(reader.incomplete, false);
+});

--- a/tests/extensions/ai-providers/cursor-context.test.ts
+++ b/tests/extensions/ai-providers/cursor-context.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { AssistantMessage, Message } from "@earendil-works/pi-ai/compat";
+import {
+  estimateTokens,
+  getLastAssistantUsage,
+  shouldCompact,
+} from "@earendil-works/pi-coding-agent";
+import { CURSOR_MODELS } from "../../../extensions/ai-providers/cursor/models.ts";
+import {
+  ConversationStepSchema,
+  ConversationTurnStructureSchema,
+  UserMessageSchema,
+} from "../../../extensions/ai-providers/cursor/proto.ts";
+import { fromBinary } from "../../../extensions/ai-providers/cursor/protobuf.ts";
+import { buildCursorRequest } from "../../../extensions/ai-providers/cursor/provider.ts";
+import { emptyUsage } from "../../../extensions/ai-providers/usage.ts";
+
+const model = CURSOR_MODELS[0]!;
+function assistant(content: AssistantMessage["content"]): AssistantMessage {
+  return {
+    role: "assistant",
+    content,
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: emptyUsage(),
+    stopReason: "stop",
+    timestamp: 1,
+  };
+}
+function blob(
+  built: Awaited<ReturnType<typeof buildCursorRequest>>,
+  id: Uint8Array,
+) {
+  const bytes = built.blobStore.get(Buffer.from(id).toString("hex"));
+  assert.ok(bytes, "every referenced history blob must be available");
+  return bytes;
+}
+
+// These are separate protocol projections, not evidence of doubled model input.
+// Upstream history-loss reproduction: https://github.com/can1357/oh-my-pi/pull/737
+// Root JSON is model history; native turns also have to remain replayable.
+test("Cursor preserves paired history in both projections and sends the active user only as action", async () => {
+  const messages: Message[] = [
+    { role: "user", content: "earlier question", timestamp: 0 },
+    assistant([
+      { type: "thinking", thinking: "hidden reasoning" },
+      { type: "text", text: "checking" },
+      {
+        type: "toolCall",
+        id: "read-1",
+        name: "read",
+        arguments: { path: "a" },
+      },
+    ]),
+    {
+      role: "toolResult",
+      toolCallId: "read-1",
+      toolName: "read",
+      content: [{ type: "text", text: "missing file" }],
+      isError: true,
+      timestamp: 2,
+    },
+    {
+      role: "toolResult",
+      toolCallId: "orphan",
+      toolName: "read",
+      content: [{ type: "text", text: "orphan data" }],
+      isError: false,
+      timestamp: 2,
+    },
+    { role: "user", content: "current question", timestamp: 3 },
+  ];
+  const built = await buildCursorRequest(model, { messages });
+  const root = built.conversationState.rootPromptMessagesJson.map((id) =>
+    JSON.parse(Buffer.from(blob(built, id)).toString()),
+  );
+  assert.deepEqual(
+    root
+      .filter((message) => message.role === "user")
+      .map((message) => message.content),
+    [[{ type: "text", text: "earlier question" }]],
+  );
+  assert.equal(root.filter((message) => message.role === "tool").length, 1);
+  assert.deepEqual(
+    root.find((message) => message.role === "assistant").content,
+    [
+      { type: "text", text: "checking" },
+      {
+        type: "tool-call",
+        toolCallId: "read-1",
+        toolName: "read",
+        args: { path: "a" },
+      },
+    ],
+  );
+  assert.deepEqual(root.find((message) => message.role === "tool").content, [
+    {
+      type: "tool-result",
+      toolCallId: "read-1",
+      toolName: "read",
+      result: "missing file",
+      isError: true,
+    },
+  ]);
+  const action = built.request.action?.action;
+  assert.equal(action?.case, "userMessageAction");
+  if (action?.case === "userMessageAction")
+    assert.equal(action.value.userMessage?.text, "current question");
+  assert.equal(built.conversationState.turns.length, 1);
+  const turn = fromBinary(
+    ConversationTurnStructureSchema,
+    blob(built, built.conversationState.turns[0]!),
+  ).turn;
+  assert.equal(turn.case, "agentConversationTurn");
+  if (turn.case !== "agentConversationTurn")
+    throw new Error("missing native turn");
+  assert.equal(
+    fromBinary(UserMessageSchema, blob(built, turn.value.userMessage)).text,
+    "earlier question",
+  );
+  const steps = turn.value.steps.map(
+    (id) => fromBinary(ConversationStepSchema, blob(built, id)).message,
+  );
+  assert.deepEqual(
+    steps.map((step) => step.case),
+    ["assistantMessage", "toolCall"],
+  );
+  const call = steps[1];
+  assert.ok(
+    call?.case === "toolCall" && call.value.tool.case === "mcpToolCall",
+  );
+  assert.equal(call.value.toolCallId, "read-1");
+  const result = call.value.tool.value.result?.result;
+  assert.ok(result?.case === "success");
+  assert.equal(result.value.isError, true);
+  const stored = [...built.blobStore.values()]
+    .map((value) => Buffer.from(value).toString())
+    .join("\n");
+  assert.doesNotMatch(stored, /hidden reasoning|orphan data|current question/);
+});
+
+test("Cursor rebuild after compaction does not resurrect removed history under the same session ID", async () => {
+  const options = { sessionId: "same-conversation" };
+  const before = await buildCursorRequest(
+    model,
+    {
+      messages: [
+        { role: "user", content: "discarded-private-detail", timestamp: 0 },
+        assistant([{ type: "text", text: "old-answer" }]),
+        { role: "user", content: "next", timestamp: 2 },
+      ],
+    },
+    options,
+  );
+  const after = await buildCursorRequest(
+    model,
+    {
+      messages: [
+        { role: "user", content: "retained-summary", timestamp: 3 },
+        assistant([{ type: "text", text: "summary acknowledged" }]),
+      ],
+    },
+    options,
+  );
+  assert.equal(before.request.conversationId, after.request.conversationId);
+  assert.equal(after.request.action?.action.case, "resumeAction");
+  const stored = [...after.blobStore.values()]
+    .map((value) => Buffer.from(value).toString())
+    .join("\n");
+  assert.match(stored, /retained-summary/);
+  assert.doesNotMatch(stored, /discarded-private-detail|old-answer/);
+});
+
+test("Pi public estimation remains available when Cursor has no provider usage", () => {
+  const response = assistant([{ type: "text", text: "OK" }]);
+  assert.equal(
+    getLastAssistantUsage([
+      {
+        type: "message",
+        id: "response",
+        parentId: null,
+        timestamp: new Date(1).toISOString(),
+        message: response,
+      },
+    ]),
+    undefined,
+  );
+  const small: Message[] = [
+    { role: "user", content: "short", timestamp: 0 },
+    response,
+  ];
+  const large: Message[] = [
+    { role: "user", content: "x".repeat(80_000), timestamp: 0 },
+    response,
+  ];
+  const estimate = (messages: Message[]) =>
+    messages.reduce((total, message) => total + estimateTokens(message), 0);
+  const settings = {
+    enabled: true,
+    reserveTokens: 1_000,
+    keepRecentTokens: 500,
+  };
+  assert.ok(estimate(large) > estimate(small));
+  assert.equal(shouldCompact(estimate(small), 16_000, settings), false);
+  assert.equal(shouldCompact(estimate(large), 16_000, settings), true);
+});

--- a/tests/extensions/ai-providers/cursor.test.ts
+++ b/tests/extensions/ai-providers/cursor.test.ts
@@ -1680,3 +1680,27 @@ test("Cursor bridge preserves nested special JSON keys and rejects replayed invo
     false,
   );
 });
+
+test("Cursor transport rejects EOF in partial headers and payloads", async () => {
+  const complete = frameConnectMessage(Buffer.from("payload"));
+  for (const length of [1, 4, 5, complete.length - 1]) {
+    const server = await startServer((peer) => {
+      peer.respond({ ":status": 200 });
+      receiveClient(peer, (message) => {
+        if (message.case === "runRequest")
+          peer.end(complete.subarray(0, length));
+      });
+    });
+    servers.push(server);
+    const events = await collectEvents(
+      streamCursor(localModel(server.baseUrl), CONTEXT, { apiKey: "token" }),
+    );
+    const last = events.at(-1);
+    assert.equal(last?.type, "error");
+    if (last?.type === "error")
+      assert.match(
+        last.error.errorMessage ?? "",
+        /Incomplete Cursor Connect frame/,
+      );
+  }
+});

--- a/tests/extensions/shared/agent-transcript.test.ts
+++ b/tests/extensions/shared/agent-transcript.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { resolve } from "node:path";
 import test from "node:test";
 
 import { AgentTranscriptRenderer } from "../../../extensions/shared/agent-transcript.ts";
@@ -173,4 +174,35 @@ test("neighbour changes alter output (context.token participates in the cache ke
   assert.match(pending, /Reading/);
   assert.match(completed, COMPLETED);
   assert.notEqual(pending, completed, "cache must not serve a stale phase");
+});
+
+test("cached tool paths follow the document working directory", () => {
+  const childCwd = resolve("child-a");
+  const otherCwd = resolve("child-b");
+  const items: AgentTranscriptItem[] = [
+    {
+      kind: "assistant",
+      parts: [
+        {
+          type: "toolCall",
+          toolId: "path",
+          name: "read",
+          argsPreview: JSON.stringify({ path: resolve(childCwd, "file.ts") }),
+        },
+      ],
+    },
+    result("path"),
+  ];
+  const renderer = new AgentTranscriptRenderer();
+  const initial = renderer.render({ items, cwd: childCwd }, 160, theme);
+  for (const cwd of [otherCwd, undefined, childCwd]) {
+    const warm = renderer.render({ items, cwd }, 160, theme);
+    const cold = new AgentTranscriptRenderer().render(
+      { items, cwd },
+      160,
+      theme,
+    );
+    assert.deepEqual(warm, cold, "cached paths must match the current cwd");
+    if (cwd === otherCwd) assert.notDeepEqual(warm, initial);
+  }
 });


### PR DESCRIPTION
## Problem

Cursor concatenated the entire incomplete Connect frame for every network fragment: a deterministic 1 MiB/1 KiB-chunk regression copied 538 MB. Separately, transcript rows cached relative paths across cwd changes. The follow-up audit also needed to distinguish duplicate protocol representations from actual duplicated model context. Fixes #431.

## Value

Large fragmented responses incur linear copying, and switching child working directories cannot show stale relative paths. Context regression coverage prevents a misleading optimization from deleting required history or substituting generated-token counts for context usage.

## Approach

Use a five-byte header plus one bounded payload buffer for fragmented frames, borrowing contiguous payload slices for synchronous decode. Preserve the 16 MiB limit, EOF errors and existing MCP handoff boundaries. Include cwd in the bounded transcript cache key. Verify both Cursor history trees, compacted-context rebuilding and Pi's zero-usage estimation boundary without changing the protocol or usage policy.

## Validation

`bun run check` passed. The default `bun run test` attempt was interrupted during severe host scheduling delay; its log is retained. The complete repository-discovered suite then passed at Node file concurrency 2: 1455 passed, one platform skip; Vitest 30/30. Final-head [CI](https://github.com/openpi-dev/openpi/actions/runs/34073141470) passed on `84cc307e9af5c8fac0824619ab00814c19d7af5c`: Node 22.19.0, Node 24 and Windows, including standard repository checks/tests and package smoke coverage. Two independent code reviews found no actionable issues. Deterministic regressions cover byte-copy growth, all split positions, empty/coalesced frames, retained buffers, frame limits, production truncated EOF, cwd warm/cold equivalence, history pairing and compacted rebuilds. No paid provider calls or user runtime changes.

## Impact

No model tools, permissions, settings or persisted schema change. A fragmented frame now reserves its declared payload size (up to the existing 16 MiB cap) once its validated header arrives, instead of repeated incremental allocations. Model history and token accounting remain unchanged: upstream evidence identifies JSON root history as model input and native turns as UI state; local duplication is not proof of doubled model context. The separate viewport rewrite #327 remains outside this batch because its existing 512-item measurement does not establish severe lag and its invalidation contract needs separate review.

[Investigation](https://github.com/openpi-dev/openpi/blob/codex/context-transport-performance/docs/research/CURSOR_CONTEXT_AND_TRANSPORT_2026-09-07.md). Fixed base: `69a7e5f19b4db3e32b7ad6abc81884edf767b2e3`.
