### PR TITLE
chore(release): prepare OpenPI 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tt-a1i/openpi",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "OpenPI — a Pi-native multi-agent workbench with background execution, isolated subagents, replay-safe workflows, goals, tasks, and observable TUI",
   "license": "MIT",
   "author": "tt-a1i",


### PR DESCRIPTION
## Problem

The tested main includes the React workbench, historical Markdown reuse, Workflow artifact recovery, headless shell preservation and Cursor transport/cache fixes, but the published package remains 0.6.1.

## Value

Prepare OpenPI 0.7.0 so the reviewed changes can be distributed through the existing tagged release workflow.

## Approach

Bump only package.json from 0.6.1 to 0.7.0. The lockfile does not store a root package version. Keep source, dependencies and committed Web assets unchanged. After merge, create v0.7.0 on the verified merge commit; the existing Release workflow validates and publishes the npm artifact.

## Validation

Local `bun run check` passed; `bun run test` passed with 1,442 Node tests, one platform skip and 82 Vitest tests. Product main `2d3f68b` already has green Node 22/24/26, Windows, browser and package/source-install checks. Final PR head `1574ff58ac26ad85b77bbdf5dddd2cfa2c72a47e` passed Node 22/24/26, Windows and browser CI, including package/source install smokes: https://github.com/openpi-dev/openpi/actions/runs/34083185443. Tagged release validation remains a separate gate.

## Impact

Package version metadata only. No runtime, tool/context, permission, configuration or persisted-data change. Release publication does not update the user's installed runtime.
