### PR TITLE
feat(web): integrate provider authentication diagnostics

### DIFF
--- a/tests/web/pi-runtime.test.ts
+++ b/tests/web/pi-runtime.test.ts
@@ -474,6 +474,51 @@ test("stale expected Session fails before prompt dispatch", async () => {
   assert.equal(session.calls.length, 0);
 });
 
+test("provider auth projection is bounded and never serializes credentials", () => {
+  const secret = "sk-must-never-reach-web";
+  const providers = Array.from({ length: 252 }, (_, index) => ({
+    id: index === 0 ? "invalid\u0000provider" : `provider-${index}`,
+    name: index === 1 ? "n".repeat(500) : `Provider ${index}`,
+    auth: {
+      apiKey: { secret },
+      ...(index % 2 === 0 ? { oauth: { token: secret } } : {}),
+    },
+  }));
+  const modelRuntime = {
+    getProviders: () => providers,
+    getProviderAuthStatus: () => ({
+      configured: true,
+      source: "stored" as const,
+      label: secret,
+    }),
+    isUsingSubscription: (id: string) => id === "provider-2",
+  };
+  const runtime = Object.create(PiWebRuntime.prototype) as {
+    runtime: { services: { modelRuntime: typeof modelRuntime } };
+    listProviderAuth: PiWebRuntime["listProviderAuth"];
+  };
+  runtime.runtime = { services: { modelRuntime } };
+
+  const projection = runtime.listProviderAuth();
+  assert.equal(projection.providers.length, 250);
+  assert.equal(projection.truncation.providersOmitted, 2);
+  assert.equal(projection.truncation.namesTruncated, 1);
+  assert.equal(projection.truncation.truncated, true);
+  assert.deepEqual(projection.providers[0], {
+    id: "provider-1",
+    name: `${"n".repeat(159)}…`,
+    authMethods: ["api_key"],
+    configured: true,
+    source: "stored",
+    subscription: false,
+    nameTruncated: true,
+  });
+  assert.deepEqual(projection.providers[1]?.authMethods, ["api_key", "oauth"]);
+  assert.equal(projection.providers[1]?.subscription, true);
+  assert.doesNotMatch(JSON.stringify(projection), /sk-must-never-reach-web/u);
+  assert.doesNotMatch(JSON.stringify(projection), /label|token|secret/u);
+});
+
 test("model selection and Session activation are serialized", async () => {
   const applied = deferred();
   const model = { provider: "fixture", id: "model-a", name: "Model A" };

--- a/tests/web/web-host.test.ts
+++ b/tests/web/web-host.test.ts
@@ -93,6 +93,25 @@ test("serves workspaces through a runtime isolated from terminal sessions", asyn
       sessionTrusted: false,
       refreshRequired: false,
     }),
+    listProviderAuth: () => ({
+      providers: [
+        {
+          id: "fixture",
+          name: "Fixture",
+          authMethods: ["api_key"],
+          configured: true,
+          source: "environment",
+          subscription: false,
+          nameTruncated: false,
+        },
+      ],
+      truncation: {
+        truncated: false,
+        providersOmitted: 0,
+        namesTruncated: 0,
+        maxProviders: 250,
+      },
+    }),
     setModel: async () => {
       throw new WebRuntimeRequestError(
         "Model is not available",
@@ -252,6 +271,30 @@ test("serves workspaces through a runtime isolated from terminal sessions", asyn
       projectResources: true,
       sessionTrusted: false,
       refreshRequired: false,
+    });
+    const providerAuthResponse = await fetch(
+      `${launched.origin}/api/providers/auth-status`,
+      { headers: authorized },
+    );
+    assert.equal(providerAuthResponse.status, 200);
+    assert.deepEqual(await providerAuthResponse.json(), {
+      providers: [
+        {
+          id: "fixture",
+          name: "Fixture",
+          authMethods: ["api_key"],
+          configured: true,
+          source: "environment",
+          subscription: false,
+          nameTruncated: false,
+        },
+      ],
+      truncation: {
+        truncated: false,
+        providersOmitted: 0,
+        namesTruncated: 0,
+        maxProviders: 250,
+      },
     });
     const unavailableModel = await fetch(`${launched.origin}/api/model`, {
       method: "POST",

--- a/web/host/web-host.ts
+++ b/web/host/web-host.ts
@@ -705,6 +705,15 @@ export class WebHost {
         workspaceSelected: this.runtime.workspaceSelected,
         models: this.runtime.listModels().filter((model) => model.current),
       });
+    if (url.pathname === "/api/providers/auth-status") {
+      if (!this.runtime.listProviderAuth) {
+        return this.json(response, 501, {
+          code: "PROVIDER_AUTH_STATUS_UNAVAILABLE",
+          error: "provider authentication status is unavailable",
+        });
+      }
+      return this.json(response, 200, this.runtime.listProviderAuth());
+    }
     if (url.pathname === "/api/snapshot") {
       const cursor = this.sequence;
       const projection = await this.adapter.getSnapshot(

--- a/web/runtime/pi-runtime.ts
+++ b/web/runtime/pi-runtime.ts
@@ -19,6 +19,8 @@ import {
   type WebModelSelectionOptions,
   type WebPromptOptions,
   type WebPromptAdmissionReceipt,
+  type WebProviderAuthProjection,
+  type WebProviderAuthSource,
   type WebRuntimeController,
   type WebRuntimeEvent,
   type WebSessionCreationOptions,
@@ -44,6 +46,18 @@ import {
 const STARTUP_TIMEOUT_MS = 15_000;
 const TURN_CANCELLATION_SETTLEMENT_TIMEOUT_MS = 10_000;
 const BOOTSTRAP_WORKSPACE_DIRECTORY = ".bootstrap-workspace";
+const WEB_MAX_PROVIDER_AUTH_ITEMS = 250;
+const WEB_MAX_PROVIDER_AUTH_SCANNED = 1_024;
+const WEB_MAX_PROVIDER_ID_LENGTH = 160;
+const WEB_MAX_PROVIDER_NAME_LENGTH = 160;
+const WEB_PROVIDER_AUTH_SOURCES = new Set<WebProviderAuthSource>([
+  "stored",
+  "runtime",
+  "environment",
+  "fallback",
+  "models_json_key",
+  "models_json_command",
+]);
 
 type PromptTrace = {
   commandId: string;
@@ -62,6 +76,24 @@ type TurnSettlement = WebActiveTurn & {
 
 function errorText(error: unknown) {
   return error instanceof Error ? error.message : String(error);
+}
+
+function safeProviderId(value: string) {
+  return value.length > 0 &&
+    value.length <= WEB_MAX_PROVIDER_ID_LENGTH &&
+    !/[\u0000-\u001f\u007f]/u.test(value)
+    ? value
+    : undefined;
+}
+
+function boundedProviderName(value: string) {
+  const sanitized = value.replace(/[\u0000-\u001f\u007f]/gu, " ");
+  return sanitized.length <= WEB_MAX_PROVIDER_NAME_LENGTH
+    ? { value: sanitized, truncated: false }
+    : {
+        value: `${sanitized.slice(0, WEB_MAX_PROVIDER_NAME_LENGTH - 1)}…`,
+        truncated: true,
+      };
 }
 
 async function canonicalDirectory(path: string) {
@@ -336,6 +368,61 @@ export class PiWebRuntime implements WebRuntimeController {
       label: model.name || `${model.provider}/${model.id}`,
       current: current?.provider === model.provider && current.id === model.id,
     }));
+  }
+
+  listProviderAuth(): WebProviderAuthProjection {
+    const modelRuntime = this.runtime.services.modelRuntime;
+    const allProviders = modelRuntime.getProviders();
+    const providers = allProviders.slice(0, WEB_MAX_PROVIDER_AUTH_SCANNED);
+    const projection: WebProviderAuthProjection["providers"][number][] = [];
+    let omitted = Math.max(
+      0,
+      allProviders.length - WEB_MAX_PROVIDER_AUTH_SCANNED,
+    );
+    let namesTruncated = 0;
+    for (const provider of providers) {
+      if (projection.length >= WEB_MAX_PROVIDER_AUTH_ITEMS) {
+        omitted++;
+        continue;
+      }
+      try {
+        const id = safeProviderId(provider.id);
+        if (!id) {
+          omitted++;
+          continue;
+        }
+        const name = boundedProviderName(provider.name || id);
+        if (name.truncated) namesTruncated++;
+        const status = modelRuntime.getProviderAuthStatus(id);
+        const source =
+          status.source && WEB_PROVIDER_AUTH_SOURCES.has(status.source)
+            ? status.source
+            : undefined;
+        projection.push({
+          id,
+          name: name.value,
+          authMethods: [
+            ...(provider.auth.apiKey ? (["api_key"] as const) : []),
+            ...(provider.auth.oauth ? (["oauth"] as const) : []),
+          ],
+          configured: status.configured,
+          ...(source ? { source } : {}),
+          subscription: modelRuntime.isUsingSubscription(id),
+          nameTruncated: name.truncated,
+        });
+      } catch {
+        omitted++;
+      }
+    }
+    return {
+      providers: projection,
+      truncation: {
+        truncated: omitted > 0 || namesTruncated > 0,
+        providersOmitted: omitted,
+        namesTruncated,
+        maxProviders: WEB_MAX_PROVIDER_AUTH_ITEMS,
+      },
+    };
   }
 
   setModel(

--- a/web/runtime/types.ts
+++ b/web/runtime/types.ts
@@ -2,6 +2,34 @@ import type { SessionManager } from "@earendil-works/pi-coding-agent";
 import type { WebModelSummary } from "../protocol/types.ts";
 import type { WebProjectTrustStatus } from "./trust-status.ts";
 
+export type WebProviderAuthSource =
+  | "stored"
+  | "runtime"
+  | "environment"
+  | "fallback"
+  | "models_json_key"
+  | "models_json_command";
+
+export interface WebProviderAuthSummary {
+  readonly id: string;
+  readonly name: string;
+  readonly authMethods: readonly ("api_key" | "oauth")[];
+  readonly configured: boolean;
+  readonly source?: WebProviderAuthSource;
+  readonly subscription: boolean;
+  readonly nameTruncated: boolean;
+}
+
+export interface WebProviderAuthProjection {
+  readonly providers: readonly WebProviderAuthSummary[];
+  readonly truncation: {
+    readonly truncated: boolean;
+    readonly providersOmitted: number;
+    readonly namesTruncated: number;
+    readonly maxProviders: number;
+  };
+}
+
 export interface WebRuntimeEvent {
   type: string;
   detail?: Record<string, unknown>;
@@ -94,6 +122,7 @@ export interface WebRuntimeController {
   ): Promise<WebSessionCreationResult>;
   switchSession(sessionPath: string): Promise<{ cancelled: boolean }>;
   listModels(): WebModelSummary[];
+  listProviderAuth?(): WebProviderAuthProjection;
   setModel(
     provider: string,
     modelId: string,


### PR DESCRIPTION
## Problem and value

Integrate #390's useful Provider authentication diagnostics onto current main while preserving the contributor's implementation. Authenticated GET /api/providers/auth-status reports which Pi providers support API keys or OAuth, whether they are configured, and a bounded non-secret source category. It does not return credentials, labels, commands or tokens.

The original branch conflicts with newer main changes. This integration preserves both its additions and the existing trust, capability, diagnostics and cancellation behavior. No feature fixes or policy changes are added on behalf of the author; there is no new UI or authentication write path.

## Attribution

Original contribution: #390, authored by testikun <320479488+testikun@users.noreply.github.com>. The cherry-picked commit preserves that author identity; the squash merge must retain the same contributor as a co-author.

## Validation

- Base: d1f283e1d43f54b7a233939af07b313d2ef8a41d.
- Exact original-head runtime/host tests:57 passed.
- Integrated `bun run check`: passed.
- Integrated `bun run test`:1,453 Node tests passed,1 skipped;92 Vitest tests passed.
- Two independent source and integration reviews found no P2-or-higher issues.
- No installed runtime or live-provider acceptance claimed. CI must pass on this integration head before merge.

Refs #348. Integrates #390, which will be closed with the merge receipt afterward.
