### PR TITLE
fix(web): show readiness before bounded browser launch

### DIFF
--- a/bin/openpi.js
+++ b/bin/openpi.js
@@ -61,12 +61,15 @@ if (noWorkspace && workspaceArgs.length > 0) {
 let host;
 let runtime;
 let stopping;
+const browserAbort = new AbortController();
 const stop = () => {
+  browserAbort.abort();
   stopping ??= host?.stop() ?? runtime?.dispose() ?? Promise.resolve();
   return stopping;
 };
 
 try {
+  console.error("Starting OpenPI Web Workbench…");
   const bootstrap = createJiti(import.meta.url);
   const { missingPiCodingAgentDiagnostic, resolveStandaloneJitiAliases } =
     await bootstrap.import("../web/host/pi-coding-agent-entry.ts");
@@ -123,18 +126,27 @@ try {
     ...(runtime.workspaceSelected === true ? { cwd: runtime.cwd } : {}),
     origin: host.origin,
   });
-  const opened = noOpen ? false : await openBrowser(host.url);
   if (noWorkspace) {
     console.log(
       formatWebReadyScreen({
         origin: host.origin,
         url: host.url,
-        opened,
+        opened: noOpen ? false : "pending",
       }),
     );
   } else {
     console.log(`OpenPI Web Workbench is running at ${host.origin}`);
-    if (!opened) console.log(`Open this URL in a browser: ${host.url}`);
+    if (noOpen) console.log(`Open this URL in a browser: ${host.url}`);
+  }
+  if (!noOpen) {
+    const opened = await openBrowser(host.url, browserAbort.signal);
+    if (!browserAbort.signal.aborted) {
+      console.log(
+        opened
+          ? "Browser open requested."
+          : `Browser did not open. Open this URL: ${host.url}`,
+      );
+    }
   }
 } catch (error) {
   let cleanupError;

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -8,6 +8,8 @@ Research records preserve sourced investigation and distinguish observations, in
 
 ## Validated investigations
 
+- [`WEB_STARTUP_2026-09-07.md`](WEB_STARTUP_2026-09-07.md) — terminal startup feedback, browser-launch waiting, and exploratory timing limits ([#450](https://github.com/openpi-dev/openpi/issues/450)).
+
 - [`WEB_STREAMING_MARKDOWN_2026-09-07.md`](WEB_STREAMING_MARKDOWN_2026-09-07.md) — unchanged historical Markdown parsing during streaming, bounded React component reuse and deterministic regression evidence ([#434](https://github.com/openpi-dev/openpi/issues/434)).
 
 - [`ISSUE_419_SHELL_PATH_RETROSPECTIVE_2026-09-07.md`](ISSUE_419_SHELL_PATH_RETROSPECTIVE_2026-09-07.md) — headless 子 Session 被展示扩展覆盖 bash 定义、shellPath 丢失的根因与回归证据 ([#419](https://github.com/openpi-dev/openpi/issues/419), [PR #423](https://github.com/openpi-dev/openpi/pull/423))。

--- a/docs/research/WEB_STARTUP_2026-09-07.md
+++ b/docs/research/WEB_STARTUP_2026-09-07.md
@@ -1,0 +1,21 @@
+# Web startup feedback and browser waiting
+
+- Status: validated for the source observations below; timings are exploratory.
+- Created and verified: 2026-09-07.
+- Source boundary: OpenPI main `5dac5ba7fe16285947907920c1450ccd487067cf`, local macOS, Pi 0.85.1, source-installed OpenPI.
+- Tracking: [Issue #450](https://github.com/openpi-dev/openpi/issues/450).
+- Supersedes: none.
+
+## Observations
+
+`extensions/web/index.ts` stopped the TUI and cleared the terminal before spawning the Web CLI, without writing progress. `bin/openpi.js` printed ready only after awaiting `openBrowser`, although the Host was already listening. The browser launcher used `execFile` without a deadline. These are distinct from runtime initialization cost.
+
+Four alternating local probes used fresh temporary agent directories and Jiti filesystem-cache directories per run, an empty workspace, a real Host on port zero, and explicit cleanup. Existing loading reached ready in 1273 and 1004 ms; a candidate native SDK import bound through Jiti virtual modules reached ready in 1016 and 995 ms. The native candidate asserted exported SessionManager identity and runtime instance identity. An earlier existing-loader sample took 10015 ms; that difference was not reproduced in the alternating runs.
+
+These exploratory observations do not establish a cold-start speedup: operating-system caches and machine load were not controlled, only one machine was sampled, and user provider/extension configuration was not exercised. No formal Benchmark or general latency claim is made. SDK loading remains unchanged.
+
+## Repair and verification boundary
+
+The terminal handoff now writes progress immediately. Host readiness and the usable address are printed before invoking the browser opener. The native `execFile` operation has a three-second deadline and accepts cancellation during Host shutdown. An opener exit is described as an open request, not proof that a browser page loaded. Timeout stops only the owned launcher process; this does not promise cleanup of arbitrary descendants created by operating-system launch services.
+
+`tests/web/startup.test.ts` uses an isolated real CLI and a deliberately stalled opener on POSIX to verify that the address appears and serves HTTP before the opener completes, that timeout preserves the serving Host, and that shutdown cancels the pending launch. The process test is explicitly skipped on Windows; pre-cancelled launch and ready-screen tests are portable. Extension tests check progress before spawn. Browser rendering performance and fully cold user-configured startup remain separate investigation scopes.

--- a/extensions/web/index.ts
+++ b/extensions/web/index.ts
@@ -195,6 +195,9 @@ function runWebInForeground(
       tui.stop();
       tuiStopped = true;
       dependencies.clearTerminal();
+      dependencies.writeStderr(
+        "Starting OpenPI Web Workbench… Ctrl+C to stop.\n",
+      );
       const childCwd = dirname(dependencies.entrypoint);
       const child = dependencies.spawn(
         process.execPath,

--- a/tests/extensions/web/index.test.ts
+++ b/tests/extensions/web/index.test.ts
@@ -84,6 +84,8 @@ function harness(
   const dependencies: WebCommandDependencies = {
     entrypoint: "/package/bin/openpi.js",
     spawn(commandName, args, spawnOptions) {
+      assert.equal(clearCalls, 1);
+      assert.match(forwardedStderr, /Starting OpenPI Web Workbench/u);
       spawnCalls++;
       spawnEnvs.push(spawnOptions.env);
       assert.equal(commandName, process.execPath);

--- a/tests/web/startup.test.ts
+++ b/tests/web/startup.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { get } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { openBrowser } from "../../web/host/browser-launcher.ts";
+import { formatWebReadyScreen } from "../../web/host/terminal-status.ts";
+
+const status = (url: string) =>
+  new Promise<number | undefined>((resolve, reject) => {
+    get(
+      url,
+      {
+        headers: {
+          "Sec-Fetch-Site": "none",
+          "Sec-Fetch-Mode": "navigate",
+          "Sec-Fetch-Dest": "document",
+        },
+      },
+      (response) => {
+        response.resume();
+        resolve(response.statusCode);
+      },
+    ).on("error", reject);
+  });
+
+const unix = process.platform !== "win32";
+
+test("ready screen can expose the address before browser launch completes", () => {
+  const output = formatWebReadyScreen({
+    origin: "http://127.0.0.1:1234",
+    url: "http://127.0.0.1:1234/#token=secret",
+    opened: "pending",
+    color: false,
+  });
+  assert.match(output, /ready/u);
+  assert.match(output, /http:\/\/127.0.0.1:1234/u);
+  assert.match(output, /opening/u);
+  assert.doesNotMatch(output, /secret|open requested/u);
+});
+
+test("browser launch accepts cancellation", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  assert.equal(
+    await openBrowser("http://127.0.0.1:1", controller.signal),
+    false,
+  );
+});
+
+for (const outcome of ["timeout", "cancel"] as const) {
+  test(`CLI serves before a stalled browser opener finishes: ${outcome}`, {
+    skip: !unix,
+    timeout: 60000,
+  }, async () => {
+    const root = await mkdtemp(join(tmpdir(), "openpi-startup-test-"));
+    const bin = join(root, "bin");
+    await mkdir(bin);
+    // exec keeps the stalled process owned by execFile, with no descendant to leak.
+    await writeFile(
+      join(bin, process.platform === "darwin" ? "open" : "xdg-open"),
+      `#!/bin/sh\nexec '${process.execPath.replaceAll("'", "'\\''")}' -e 'setInterval(() => {}, 1000)'\n`,
+      { mode: 0o755 },
+    );
+    const child = spawn(
+      process.execPath,
+      [
+        fileURLToPath(new URL("../../bin/openpi.js", import.meta.url)),
+        "web",
+        "--no-workspace",
+        "--port",
+        "0",
+      ],
+      {
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH ?? ""}`,
+          PI_CODING_AGENT_DIR: join(root, "agent"),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    const closed = once(child, "close");
+    let output = "";
+    child.stdout.on("data", (chunk) => {
+      output += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      output += String(chunk);
+    });
+    const waitFor = async (pattern: RegExp, timeout: number) => {
+      const start = Date.now();
+      while (!pattern.test(output)) {
+        assert.equal(
+          child.exitCode,
+          null,
+          "CLI exited before expected startup state",
+        );
+        assert.ok(
+          Date.now() - start < timeout,
+          "startup state deadline exceeded",
+        );
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+    };
+    try {
+      await waitFor(/Starting OpenPI Web Workbench/u, 5000);
+      await waitFor(/Local\s+(http:\/\/127.0.0.1:\d+)/u, 45000);
+      assert.doesNotMatch(output, /Browser did not open/u);
+      const origin = /Local\s+(http:\/\/127.0.0.1:\d+)/u.exec(output)?.[1];
+      assert.ok(origin);
+      assert.equal(await status(origin), 200);
+      if (outcome === "cancel") {
+        child.kill("SIGTERM");
+        const [code] = await closed;
+        assert.equal(code, 0);
+        assert.doesNotMatch(output, /Browser did not open/u);
+        return;
+      }
+      await waitFor(/Browser did not open/u, 7000);
+      assert.equal(await status(origin), 200);
+    } finally {
+      child.kill("SIGTERM");
+      const kill = setTimeout(() => child.kill("SIGKILL"), 5000);
+      await closed;
+      clearTimeout(kill);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+}

--- a/web/host/browser-launcher.ts
+++ b/web/host/browser-launcher.ts
@@ -3,7 +3,8 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
-export async function openBrowser(url: string) {
+export async function openBrowser(url: string, signal?: AbortSignal) {
+  if (signal?.aborted) return false;
   const command =
     process.platform === "darwin"
       ? "open"
@@ -12,7 +13,11 @@ export async function openBrowser(url: string) {
         : "xdg-open";
   const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
   try {
-    await execFileAsync(command, args);
+    await execFileAsync(command, args, {
+      timeout: 3000,
+      killSignal: "SIGKILL",
+      signal,
+    });
     return true;
   } catch {
     return false;

--- a/web/host/terminal-status.ts
+++ b/web/host/terminal-status.ts
@@ -1,7 +1,7 @@
 interface WebReadyScreenOptions {
   origin: string;
   url: string;
-  opened: boolean;
+  opened: boolean | "pending";
   color?: boolean;
 }
 
@@ -30,7 +30,13 @@ export function formatWebReadyScreen(options: WebReadyScreenOptions) {
     `${label("Local")} ${options.origin}`,
     `${label("Workspaces")} choose and switch in the browser`,
     `${label("Sessions")} separate from terminal Pi`,
-    `${label("Browser")} ${options.opened ? "opened" : "not opened"}`,
+    `${label("Browser")} ${
+      options.opened === "pending"
+        ? "opening…"
+        : options.opened
+          ? "open requested"
+          : "not opened"
+    }`,
   ];
   if (!options.opened) rows.push(`${label("Open")} ${options.url}`);
   rows.push("", `${paint(ANSI.bold, "Ctrl+C")}  stop`, "");


### PR DESCRIPTION
## Problem and behavior

`/web` cleared the terminal without feedback, and the CLI withheld its ready address until the system browser launcher returned. A slow or stalled opener made an already-serving Web Host look stuck.

Write progress at terminal handoff, print ready immediately after listen, and bound the owned browser launcher to three seconds with shutdown cancellation. Already-cancelled launches return without spawning. Browser output describes an open request rather than claiming the page loaded. Pi SDK resolution, loading, runtime ownership, and configuration remain unchanged.

Closes #450.

## Validation

- `bun run check` and `bun run test` (1,461 Node passed, one platform skip; 106 Vitest passed).
- Real isolated CLI with a deliberately stalled opener: address printed and HTTP responds before timeout; Host survives timeout; shutdown cancels pending launch. POSIX integration only, explicitly skipped on Windows; portable pre-cancel and formatting tests remain enabled.
- Two independent implementation reviews.
- Exploratory alternating loader probes did not establish a startup speedup; no SDK loading optimization is included. [Investigation and limitations](docs/research/WEB_STARTUP_2026-09-07.md).
