### PR TITLE
docs: simplify README credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,17 +728,6 @@ npm 仍用于发布包的 `pack` / clean-install 验证，因为用户通过 npm
 
 ---
 
-## 来源、许可与致谢
+## 许可与致谢
 
-本项目最初基于 [davis7dotsh/my-pi-setup](https://github.com/davis7dotsh/my-pi-setup) 演进，现作为独立发行版维护。感谢原作者提供起点。
-
-`extensions/ai-providers/` 的部分协议实现改编自 [oh-my-pi](https://github.com/can1357/oh-my-pi)；`extensions/sessions/` 改编自 [jayshah5696/pi-agent-extensions](https://github.com/jayshah5696/pi-agent-extensions)。独立可选的顶层 Session 通信 package 见 [pi-intercom](https://github.com/nicobailon/pi-intercom)。完整第三方说明见 [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md)。
-
-Web workbench 的贡献包括：
-
-- [@testikun](https://github.com/testikun)：[#398](https://github.com/openpi-dev/openpi/pull/398) 的 Web 会话来源信息和 [#392](https://github.com/openpi-dev/openpi/pull/392) 的 Pi 项目信任诊断。来源字段只描述当前 Web 运行时，信任诊断区分已保存的决定和当前会话权限；这些是只读 API，目前没有新增界面入口。
-
-- [QuinnWan (@somewan820)](https://github.com/somewan820)：[#352](https://github.com/openpi-dev/openpi/pull/352) 提供界面恢复基线及复制回退；界面主体由 [#384](https://github.com/openpi-dev/openpi/pull/384) 迁移至 React，复制回退继续沿用并补充失败反馈。
-- [@seekskyworld](https://github.com/seekskyworld)：[#377](https://github.com/openpi-dev/openpi/pull/377) 提出浏览器请求超时保护，[#358](https://github.com/openpi-dev/openpi/pull/358) 提出 Pi 原生取消能力。当前 React 请求层和精确轮次取消协议已覆盖这些目标；保留当前实现，并补充响应体停滞和超时清理的回归覆盖。
-
-本项目以 MIT 许可证发布（见 [`LICENSE`](LICENSE)）；`THIRD_PARTY_NOTICES.md` 记录第三方来源与各自许可。
+[MIT License](LICENSE) · [第三方来源与致谢](THIRD_PARTY_NOTICES.md) · [所有贡献者](https://github.com/openpi-dev/openpi/graphs/contributors)

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,5 +1,17 @@
 # Third-Party Notices
 
+## Project origins and acknowledgments
+
+OpenPI originated from [davis7dotsh/my-pi-setup](https://github.com/davis7dotsh/my-pi-setup) and is maintained as an independent distribution. Thanks to the original author for the starting point.
+
+Web workbench contributions include:
+
+- [@testikun](https://github.com/testikun): Web runtime source information ([#398](https://github.com/openpi-dev/openpi/pull/398)) and Pi project trust diagnostics ([#392](https://github.com/openpi-dev/openpi/pull/392)).
+- [QuinnWan (@somewan820)](https://github.com/somewan820): UI restoration baseline and clipboard fallback ([#352](https://github.com/openpi-dev/openpi/pull/352)), carried forward through the React migration ([#384](https://github.com/openpi-dev/openpi/pull/384)).
+- [@seekskyworld](https://github.com/seekskyworld): request timeout protection ([#377](https://github.com/openpi-dev/openpi/pull/377)) and native cancellation proposals ([#358](https://github.com/openpi-dev/openpi/pull/358)), whose goals were integrated with the existing React transport and cancellation implementation, including additional regression coverage.
+
+The optional top-level Session communication package is [pi-intercom](https://github.com/nicobailon/pi-intercom).
+
 ## OAuth model providers
 
 `extensions/ai-providers/` adapts protocol and OAuth details from


### PR DESCRIPTION
README 的致谢段落混入了 PR 集成历史与实现细节，影响产品介绍的阅读。这次将其缩为许可证、第三方说明、所有贡献者三个链接。

项目来源及具名贡献记录移至 THIRD_PARTY_NOTICES.md，并精简成贡献摘要；已有第三方许可和版权声明保留。

验证：文档差异与链接目标已检查；`bun run check` 与 `bun run test` 通过（Node 1461 passed / 1 skipped，Vitest 113 passed）。
