### PR TITLE
docs: 调研 70 个 Pi 社区候选并记录采用取舍

### DIFF
--- a/docs/research/PI_COMMUNITY_ECOSYSTEM_2026-09-08.candidates.json
+++ b/docs/research/PI_COMMUNITY_ECOSYSTEM_2026-09-08.candidates.json
@@ -1871,5 +1871,126 @@
         "compatibility": "Node >=22.19; Pi peers *; not runtime-tested"
       }
     }
+  ],
+  "relatedPullRequest": "https://github.com/openpi-dev/openpi/pull/479",
+  "publicationReceipts": [
+    {
+      "kind": "issue",
+      "verified": true,
+      "url": "https://github.com/openpi-dev/openpi/issues/472",
+      "number": 472,
+      "title": "bug(worktree): 自动回收会删除被 index flags 隐藏的未提交修改 [P1]"
+    },
+    {
+      "kind": "issue",
+      "verified": true,
+      "url": "https://github.com/openpi-dev/openpi/issues/473",
+      "number": 473,
+      "title": "feat(web): 支持从回答选区生成带来源和内容版本的反馈草稿"
+    },
+    {
+      "kind": "discussion",
+      "verified": true,
+      "number": 474,
+      "title": "可恢复的工具结果折叠：怎样验证它比原生 compaction 更有价值？",
+      "url": "https://github.com/openpi-dev/openpi/discussions/474"
+    },
+    {
+      "kind": "discussion",
+      "verified": true,
+      "number": 475,
+      "title": "社区包风险收据：只读评估应由独立插件、Skill 还是 OpenPI 承担？",
+      "url": "https://github.com/openpi-dev/openpi/discussions/475"
+    },
+    {
+      "kind": "discussion",
+      "verified": true,
+      "number": 476,
+      "title": "长任务离开屏幕后：通知与保持唤醒应绑定哪个执行事实？",
+      "url": "https://github.com/openpi-dev/openpi/discussions/476"
+    },
+    {
+      "kind": "discussion",
+      "verified": true,
+      "number": 477,
+      "title": "Web 侧问：怎样呈现已有 Pi-native /btw 而不污染主上下文？",
+      "url": "https://github.com/openpi-dev/openpi/discussions/477"
+    },
+    {
+      "kind": "discussion",
+      "verified": true,
+      "number": 478,
+      "title": "外部检索的来源展示：何时值得增加可回查原文的证据入口？",
+      "url": "https://github.com/openpi-dev/openpi/discussions/478"
+    },
+    {
+      "kind": "issue-comment",
+      "verified": true,
+      "url": "https://github.com/openpi-dev/openpi/issues/343#issuecomment-5577485330",
+      "number": 343,
+      "targetState": "open"
+    },
+    {
+      "kind": "issue-comment",
+      "verified": true,
+      "url": "https://github.com/openpi-dev/openpi/issues/345#issuecomment-5577485973",
+      "number": 345,
+      "targetState": "open"
+    },
+    {
+      "kind": "issue-comment",
+      "verified": true,
+      "url": "https://github.com/openpi-dev/openpi/issues/169#issuecomment-5577486546",
+      "number": 169,
+      "targetState": "open"
+    },
+    {
+      "kind": "issue-comment",
+      "verified": true,
+      "url": "https://github.com/openpi-dev/openpi/issues/163#issuecomment-5577486898",
+      "number": 163,
+      "targetState": "open"
+    },
+    {
+      "kind": "issue-comment",
+      "verified": true,
+      "url": "https://github.com/openpi-dev/openpi/issues/168#issuecomment-5577487575",
+      "number": 168,
+      "targetState": "open"
+    },
+    {
+      "kind": "issue-comment",
+      "verified": true,
+      "url": "https://github.com/openpi-dev/openpi/issues/349#issuecomment-5577488155",
+      "number": 349,
+      "targetState": "open"
+    },
+    {
+      "kind": "issue-comment",
+      "verified": true,
+      "url": "https://github.com/openpi-dev/openpi/issues/156#issuecomment-5577488531",
+      "number": 156,
+      "targetState": "open"
+    },
+    {
+      "kind": "issue-comment",
+      "verified": true,
+      "url": "https://github.com/openpi-dev/openpi/issues/167#issuecomment-5577488981",
+      "number": 167,
+      "targetState": "open"
+    },
+    {
+      "kind": "issue-comment",
+      "verified": true,
+      "url": "https://github.com/openpi-dev/openpi/issues/160#issuecomment-5577489557",
+      "number": 160,
+      "targetState": "closed"
+    },
+    {
+      "kind": "discussion-comment",
+      "verified": true,
+      "url": "https://github.com/openpi-dev/openpi/discussions/381#discussioncomment-18339579",
+      "number": 381
+    }
   ]
 }

--- a/docs/research/PI_COMMUNITY_ECOSYSTEM_2026-09-08.candidates.json
+++ b/docs/research/PI_COMMUNITY_ECOSYSTEM_2026-09-08.candidates.json
@@ -1,0 +1,1875 @@
+{
+  "status": "validated-source-observations; adoption undecided",
+  "created": "2026-09-08",
+  "lastVerified": "2026-09-08",
+  "openpiRevision": "ed9dbc1018f890fd54375f5371990ddfee8af5df",
+  "piBaseline": "0.85.1",
+  "counts": {
+    "discoveryEntries": 146,
+    "researchObservations": 74,
+    "distinctPackageOrExtensionCandidates": 70,
+    "candidatesWithImplementationSourceRead": 49
+  },
+  "countingRule": "Identical package names are merged across areas; mitsupi notify/review and pi-ext review remain facets of their parent collection. Standalone extensions in a collection can be separate candidates. A source read may be targeted; none is whole-package runtime certification.",
+  "runtimeBoundary": "No third-party plugin installed or executed. Only separate synthetic Git/OpenPI reclaim fixtures were run. Source manifest versions, npm published versions and Github HEAD are not interchangeable.",
+  "observations": [
+    {
+      "candidate": "pi-studio",
+      "researchArea": "web",
+      "evidenceTier": "source",
+      "observation": {
+        "repo": "omaclaren/pi-studio",
+        "sha": "e04fc7aa3275b0f3f69cbbc0cbc7393a58b9f4bd",
+        "description": "Extension for pi that opens local two-pane browser workspace for working with prompts, responses, Markdown/LaTeX/HTML documents, code files, and other common file types. Comment on and annotate responses and files, write, edit, and run prompts, browse prompt and response history, request critiques, and use live preview for code, Markdown/LaTeX/HTML",
+        "license": null,
+        "updated_at": "2026-09-07T00:26:03Z",
+        "pushed_at": "2026-09-07T00:25:59Z",
+        "archived": false,
+        "default_branch": "main",
+        "name": "pi-studio",
+        "sourceURLs": [
+          "https://github.com/omaclaren/pi-studio/tree/e04fc7aa3275b0f3f69cbbc0cbc7393a58b9f4bd",
+          "https://github.com/omaclaren/pi-studio/blob/e04fc7aa3275b0f3f69cbbc0cbc7393a58b9f4bd/README.md",
+          "https://github.com/omaclaren/pi-studio/blob/e04fc7aa3275b0f3f69cbbc0cbc7393a58b9f4bd/package.json"
+        ],
+        "evidenceLevel": "source-inspected",
+        "disposition": "comment:#345;issue:anchored-feedback",
+        "mechanism": "Bounded local-resource grants, disk revisions, followed preview; do not adopt whole runtime",
+        "manifestVersion": "0.9.60",
+        "manifestLicense": "MIT",
+        "peerDependencies": {
+          "@earendil-works/pi-coding-agent": ">=0.84.3"
+        },
+        "runtimeValidated": false
+      }
+    },
+    {
+      "candidate": "@plannotator/pi-extension",
+      "researchArea": "web",
+      "evidenceTier": "source",
+      "observation": {
+        "repo": "backnotprop/plannotator",
+        "sha": "9c85310151feb335cb8a8e74beae79349873382d",
+        "description": "Annotate and review coding agent plans and code diffs visually, share with your team, send feedback to agents with one click.",
+        "license": "Apache-2.0",
+        "updated_at": "2026-09-07T22:40:51Z",
+        "pushed_at": "2026-09-07T18:00:20Z",
+        "archived": false,
+        "default_branch": "main",
+        "name": "@plannotator/pi-extension",
+        "sourceURLs": [
+          "https://github.com/backnotprop/plannotator/tree/9c85310151feb335cb8a8e74beae79349873382d",
+          "https://github.com/backnotprop/plannotator/blob/9c85310151feb335cb8a8e74beae79349873382d/README.md",
+          "https://github.com/backnotprop/plannotator/blob/9c85310151feb335cb8a8e74beae79349873382d/apps/pi-extension/package.json"
+        ],
+        "evidenceLevel": "source-inspected",
+        "disposition": "issue:anchored-feedback",
+        "mechanism": "Embeddable annotation UI and explicit decision/feedback projection; keep OpenPI Plan gate",
+        "manifestVersion": "0.27.12",
+        "manifestLicense": "MIT OR Apache-2.0",
+        "peerDependencies": {
+          "@earendil-works/pi-coding-agent": ">=0.79.1"
+        },
+        "runtimeValidated": false
+      }
+    },
+    {
+      "candidate": "@jmfederico/pi-web",
+      "researchArea": "web",
+      "evidenceTier": "source",
+      "observation": {
+        "repo": "jmfederico/pi-web",
+        "sha": "182c5ade390fc4c31189f44f0daf518817c74e71",
+        "description": "Web UI for Pi Coding Agent that keeps sessions alive in real workspaces.",
+        "license": "MIT",
+        "updated_at": "2026-09-07T18:03:17Z",
+        "pushed_at": "2026-09-07T18:02:40Z",
+        "archived": false,
+        "default_branch": "main",
+        "name": "@jmfederico/pi-web",
+        "sourceURLs": [
+          "https://github.com/jmfederico/pi-web/tree/182c5ade390fc4c31189f44f0daf518817c74e71",
+          "https://github.com/jmfederico/pi-web/blob/182c5ade390fc4c31189f44f0daf518817c74e71/README.md",
+          "https://github.com/jmfederico/pi-web/blob/182c5ade390fc4c31189f44f0daf518817c74e71/package.json"
+        ],
+        "evidenceLevel": "source-inspected",
+        "disposition": "comment:#343",
+        "mechanism": "Native UIContext request lifecycle bridge; no extra daemon/plugin plane",
+        "manifestVersion": "1.202609.0",
+        "manifestLicense": "MIT",
+        "peerDependencies": {
+          "@earendil-works/pi-agent-core": ">=0.84.0",
+          "@earendil-works/pi-ai": ">=0.84.0",
+          "@earendil-works/pi-coding-agent": ">=0.84.0 <0.85.0 || >=0.85.1"
+        },
+        "runtimeValidated": false
+      }
+    },
+    {
+      "candidate": "pi-markdown-preview",
+      "researchArea": "web",
+      "evidenceTier": "source",
+      "observation": {
+        "repo": "omaclaren/pi-markdown-preview",
+        "sha": "273bc5af58095a76c9a02f42ab642aa2e5d5f9f9",
+        "description": "Rendered markdown + LaTeX preview for pi",
+        "license": "MIT",
+        "updated_at": "2026-09-02T14:37:27Z",
+        "pushed_at": "2026-08-31T04:15:34Z",
+        "archived": false,
+        "default_branch": "main",
+        "name": "pi-markdown-preview",
+        "sourceURLs": [
+          "https://github.com/omaclaren/pi-markdown-preview/tree/273bc5af58095a76c9a02f42ab642aa2e5d5f9f9",
+          "https://github.com/omaclaren/pi-markdown-preview/blob/273bc5af58095a76c9a02f42ab642aa2e5d5f9f9/README.md",
+          "https://github.com/omaclaren/pi-markdown-preview/blob/273bc5af58095a76c9a02f42ab642aa2e5d5f9f9/package.json"
+        ],
+        "evidenceLevel": "source-inspected",
+        "disposition": "comment:#345",
+        "mechanism": "Bounded watcher lifecycle with last-good/error/cleanup state",
+        "manifestVersion": "0.16.0",
+        "manifestLicense": "MIT",
+        "peerDependencies": {
+          "@earendil-works/pi-coding-agent": "*",
+          "@earendil-works/pi-tui": "*",
+          "typebox": "*"
+        },
+        "runtimeValidated": false
+      }
+    },
+    {
+      "candidate": "pi-acp",
+      "researchArea": "web",
+      "evidenceTier": "source",
+      "observation": {
+        "repo": "svkozak/pi-acp",
+        "sha": "d1cffc047ab37a096ee70ca39cfc1de463db8d12",
+        "description": "ACP adapter for pi coding agent",
+        "license": "MIT",
+        "updated_at": "2026-09-07T18:21:05Z",
+        "pushed_at": "2026-07-30T21:58:25Z",
+        "archived": false,
+        "default_branch": "main",
+        "name": "pi-acp",
+        "sourceURLs": [
+          "https://github.com/svkozak/pi-acp/tree/d1cffc047ab37a096ee70ca39cfc1de463db8d12",
+          "https://github.com/svkozak/pi-acp/blob/d1cffc047ab37a096ee70ca39cfc1de463db8d12/README.md",
+          "https://github.com/svkozak/pi-acp/blob/d1cffc047ab37a096ee70ca39cfc1de463db8d12/package.json"
+        ],
+        "evidenceLevel": "source-inspected-delegated",
+        "disposition": "discussion-comment:#381",
+        "mechanism": "Pi RPC to ACP and native UI cancellation; interoperability untested",
+        "manifestVersion": "0.0.33",
+        "manifestLicense": "MIT",
+        "peerDependencies": null,
+        "runtimeValidated": false,
+        "detailedEvidence": "ide-research.md"
+      }
+    },
+    {
+      "candidate": "pi-agent",
+      "researchArea": "web",
+      "evidenceTier": "source",
+      "observation": {
+        "repo": "Zetaphor/pi-vscode-extension",
+        "sha": "526df5ead8e0104ea5d176bb5e6fa25e6d75844a",
+        "description": "Pi coding agent, as a VSCode extension",
+        "license": "MIT",
+        "updated_at": "2026-09-02T12:51:12Z",
+        "pushed_at": "2026-05-08T00:51:26Z",
+        "archived": false,
+        "default_branch": "main",
+        "name": "pi-agent",
+        "sourceURLs": [
+          "https://github.com/Zetaphor/pi-vscode-extension/tree/526df5ead8e0104ea5d176bb5e6fa25e6d75844a",
+          "https://github.com/Zetaphor/pi-vscode-extension/blob/526df5ead8e0104ea5d176bb5e6fa25e6d75844a/README.md",
+          "https://github.com/Zetaphor/pi-vscode-extension/blob/526df5ead8e0104ea5d176bb5e6fa25e6d75844a/package.json"
+        ],
+        "evidenceLevel": "source-inspected-delegated",
+        "disposition": "reference:#345",
+        "mechanism": "Native editor diff projection; approval/undo boundaries unsuitable to copy",
+        "manifestVersion": "0.1.0",
+        "manifestLicense": "MIT",
+        "peerDependencies": null,
+        "runtimeValidated": false,
+        "detailedEvidence": "ide-research.md"
+      }
+    },
+    {
+      "candidate": "@tintinweb/vscode-pi-model-chat-provider",
+      "researchArea": "web",
+      "evidenceTier": "source",
+      "observation": {
+        "repo": "tintinweb/vscode-pi-model-chat-provider",
+        "sha": "95d8de3f272a1a491e36a76bba04095d0e927563",
+        "description": "VSCode Language Model Chat Provider integration for Pi coding agent, making Pi models available in VS Code's model picker for use with GitHub Copilot Chat and any extension that consumes the vscode.lm.* APIs.",
+        "license": "MIT",
+        "updated_at": "2026-09-02T08:35:29Z",
+        "pushed_at": "2026-07-23T15:35:39Z",
+        "archived": false,
+        "default_branch": "master",
+        "name": "@tintinweb/vscode-pi-model-chat-provider",
+        "sourceURLs": [
+          "https://github.com/tintinweb/vscode-pi-model-chat-provider/tree/95d8de3f272a1a491e36a76bba04095d0e927563",
+          "https://github.com/tintinweb/vscode-pi-model-chat-provider/blob/95d8de3f272a1a491e36a76bba04095d0e927563/README.md",
+          "https://github.com/tintinweb/vscode-pi-model-chat-provider/blob/95d8de3f272a1a491e36a76bba04095d0e927563/package.json"
+        ],
+        "evidenceLevel": "source-inspected-delegated",
+        "disposition": "discussion-comment:#381",
+        "mechanism": "Avoid tool re-execution; agent-as-provider and inferred identity require caution",
+        "manifestVersion": "0.2.1",
+        "manifestLicense": "MIT",
+        "peerDependencies": null,
+        "runtimeValidated": false,
+        "detailedEvidence": "ide-research.md"
+      }
+    },
+    {
+      "candidate": "pi-nvim-context",
+      "researchArea": "web",
+      "evidenceTier": "source",
+      "observation": {
+        "repo": "omaclaren/pi-nvim-context",
+        "sha": "b3d5bc991dbe125a1173850a6a5927eb632e3e73",
+        "description": "Connect Neovim to standalone Pi coding-agent sessions for explicit context sharing and model-powered editor suggestions",
+        "license": "MIT",
+        "updated_at": "2026-09-03T10:23:58Z",
+        "pushed_at": "2026-09-03T10:24:34Z",
+        "archived": false,
+        "default_branch": "main",
+        "name": "pi-nvim-context",
+        "sourceURLs": [
+          "https://github.com/omaclaren/pi-nvim-context/tree/b3d5bc991dbe125a1173850a6a5927eb632e3e73",
+          "https://github.com/omaclaren/pi-nvim-context/blob/b3d5bc991dbe125a1173850a6a5927eb632e3e73/README.md",
+          "https://github.com/omaclaren/pi-nvim-context/blob/b3d5bc991dbe125a1173850a6a5927eb632e3e73/package.json"
+        ],
+        "evidenceLevel": "source-inspected-delegated",
+        "disposition": "discussion-comment:#381",
+        "mechanism": "Explicit selected context prefill to Pi draft; separate optional completion lifecycle",
+        "manifestVersion": "0.3.2",
+        "manifestLicense": "MIT",
+        "peerDependencies": {
+          "@earendil-works/pi-coding-agent": "*"
+        },
+        "runtimeValidated": false,
+        "detailedEvidence": "ide-research.md"
+      }
+    },
+    {
+      "candidate": "pi-btw",
+      "researchArea": "web",
+      "evidenceTier": "source",
+      "observation": {
+        "repo": "dbachelder/pi-btw",
+        "sha": "4f858102706910ee9d520a9666832f3103631b61",
+        "description": null,
+        "license": "MIT",
+        "updated_at": "2026-09-04T21:48:10Z",
+        "pushed_at": "2026-06-09T22:18:08Z",
+        "archived": false,
+        "default_branch": "main",
+        "name": "pi-btw",
+        "sourceURLs": [
+          "https://github.com/dbachelder/pi-btw/tree/4f858102706910ee9d520a9666832f3103631b61",
+          "https://github.com/dbachelder/pi-btw/blob/4f858102706910ee9d520a9666832f3103631b61/README.md",
+          "https://github.com/dbachelder/pi-btw/blob/4f858102706910ee9d520a9666832f3103631b61/package.json"
+        ],
+        "evidenceLevel": "source-inspected",
+        "disposition": "discussion:web-native-btw",
+        "mechanism": "Side context with explicit handoff; existing OpenPI btw is TUI-only; full coding tools not safe read-only default",
+        "manifestVersion": "0.4.1",
+        "manifestLicense": "MIT",
+        "peerDependencies": {
+          "@earendil-works/pi-ai": ">=0.74.0 <1",
+          "@earendil-works/pi-coding-agent": ">=0.74.0 <1",
+          "@earendil-works/pi-tui": ">=0.74.0 <1"
+        },
+        "runtimeValidated": false
+      }
+    },
+    {
+      "candidate": "pi-ext",
+      "researchArea": "web",
+      "evidenceTier": "source",
+      "observation": {
+        "repo": "tomsej/pi-ext",
+        "sha": "e132c44b3b06f88f7fcfb67b80c91698d8c1814f",
+        "description": "Extensions, skills, and themes for Pi coding agent",
+        "license": "MIT",
+        "updated_at": "2026-09-05T16:52:54Z",
+        "pushed_at": "2026-09-03T17:02:35Z",
+        "archived": false,
+        "default_branch": "main",
+        "name": "pi-ext",
+        "sourceURLs": [
+          "https://github.com/tomsej/pi-ext/tree/e132c44b3b06f88f7fcfb67b80c91698d8c1814f",
+          "https://github.com/tomsej/pi-ext/blob/e132c44b3b06f88f7fcfb67b80c91698d8c1814f/README.md",
+          "https://github.com/tomsej/pi-ext/blob/e132c44b3b06f88f7fcfb67b80c91698d8c1814f/package.json"
+        ],
+        "evidenceLevel": "targeted-source-inspected",
+        "disposition": "reference:#345",
+        "mechanism": "Lazy tool renderers and diff affordances; avoid overriding runtime tools",
+        "manifestVersion": "0.1.0",
+        "manifestLicense": "MIT",
+        "peerDependencies": null,
+        "runtimeValidated": false
+      }
+    },
+    {
+      "candidate": "mitsupi",
+      "researchArea": "web",
+      "evidenceTier": "metadata",
+      "observation": {
+        "repo": "mitsuhiko/agent-stuff",
+        "sha": "122e2994adddb113c04764c5697217dae120fcc6",
+        "description": "These are commands I use with agents, mostly Claude",
+        "license": "Apache-2.0",
+        "updated_at": "2026-09-07T17:51:47Z",
+        "pushed_at": "2026-09-06T09:49:43Z",
+        "archived": false,
+        "default_branch": "main",
+        "name": "mitsupi",
+        "sourceURLs": [
+          "https://github.com/mitsuhiko/agent-stuff/tree/122e2994adddb113c04764c5697217dae120fcc6",
+          "https://github.com/mitsuhiko/agent-stuff/blob/122e2994adddb113c04764c5697217dae120fcc6/README.md",
+          "https://github.com/mitsuhiko/agent-stuff/blob/122e2994adddb113c04764c5697217dae120fcc6/package.json"
+        ],
+        "evidenceLevel": "readme-and-manifest;delegated-safety",
+        "disposition": "merge:safety-research",
+        "mechanism": "Native notify/review primitives; consolidate other agent evidence",
+        "manifestVersion": "1.6.0",
+        "manifestLicense": null,
+        "peerDependencies": {
+          "@earendil-works/pi-coding-agent": "*",
+          "@earendil-works/pi-ai": "*",
+          "@earendil-works/pi-tui": "*",
+          "typebox": "*"
+        },
+        "runtimeValidated": false
+      }
+    },
+    {
+      "candidate": "pi-interactive-shell",
+      "researchArea": "web",
+      "evidenceTier": "metadata",
+      "observation": {
+        "repo": "nicobailon/pi-interactive-shell",
+        "sha": "eedb89a9e4618d7416326d9387085a756a2125ee",
+        "description": "Pi coding agent extension that allows Pi to autonomously control interactive CLIs in an observable overlay. Full PTY emulation, no  tmux, token efficient. User can take over anytime.",
+        "license": null,
+        "updated_at": "2026-09-06T23:13:15Z",
+        "pushed_at": "2026-09-05T05:29:07Z",
+        "archived": false,
+        "default_branch": "main",
+        "name": "pi-interactive-shell",
+        "sourceURLs": [
+          "https://github.com/nicobailon/pi-interactive-shell/tree/eedb89a9e4618d7416326d9387085a756a2125ee",
+          "https://github.com/nicobailon/pi-interactive-shell/blob/eedb89a9e4618d7416326d9387085a756a2125ee/README.md",
+          "https://github.com/nicobailon/pi-interactive-shell/blob/eedb89a9e4618d7416326d9387085a756a2125ee/package.json"
+        ],
+        "evidenceLevel": "readme-and-manifest;delegated-tools",
+        "disposition": "merge:tools-research",
+        "mechanism": "Visible PTY and user takeover; external spawn/monitor is broader than OpenPI invariant",
+        "manifestVersion": "0.15.2",
+        "manifestLicense": "MIT",
+        "peerDependencies": {
+          "@earendil-works/pi-coding-agent": "*",
+          "@earendil-works/pi-tui": "*",
+          "typebox": "*"
+        },
+        "runtimeValidated": false
+      }
+    },
+    {
+      "candidate": "pi-web-access",
+      "researchArea": "tools",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-web-access",
+        "repo": "https://github.com/nicobailon/pi-web-access",
+        "sha": "811ef82a6dd04fe4abd73fa40b079aa39ee1870d",
+        "sourceUrls": [
+          "https://github.com/nicobailon/pi-web-access/blob/811ef82a6dd04fe4abd73fa40b079aa39ee1870d/README.md",
+          "https://registry.npmjs.org/pi-web-access"
+        ],
+        "license": "MIT",
+        "evidenceLevel": "source-inspected",
+        "disposition": "keep-independent-and-discuss-evidence",
+        "reason": "已独立用户安装，search/fetch无需复制；借鉴private bounded full-content cache + passage hash/offset；拒绝把关键词claim status当事实",
+        "unknowns": "未安装、未运行，与 OpenPI 的实际组合尚未验证"
+      }
+    },
+    {
+      "candidate": "@juicesharp/rpiv-web-tools",
+      "researchArea": "tools",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "@juicesharp/rpiv-web-tools",
+        "repo": "https://github.com/juicesharp/rpiv-mono",
+        "sha": "338b264c1ca4fd8828cc849b632f4f7ad88d2e78",
+        "sourceUrls": [
+          "https://github.com/juicesharp/rpiv-mono/blob/338b264c1ca4fd8828cc849b632f4f7ad88d2e78/packages/rpiv-web-tools/README.md",
+          "https://registry.npmjs.org/@juicesharp/rpiv-web-tools"
+        ],
+        "license": "MIT",
+        "evidenceLevel": "primary-docs-manifest",
+        "disposition": "alternative-no-new-issue",
+        "reason": "单次provider override与显式配置错误可比较；与现有web-access重叠",
+        "unknowns": "未安装、未运行，与 OpenPI 的实际组合尚未验证"
+      }
+    },
+    {
+      "candidate": "@ollama/pi-web-search",
+      "researchArea": "tools",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "@ollama/pi-web-search",
+        "repo": null,
+        "sha": null,
+        "sourceUrls": [
+          "https://pi.dev/packages/@ollama/pi-web-search",
+          "https://registry.npmjs.org/@ollama/pi-web-search"
+        ],
+        "license": "MIT",
+        "evidenceLevel": "published-tarball-source-inspected",
+        "disposition": "hold-compatibility-and-provenance",
+        "reason": "npm0.0.5实际import旧@mariozechner和@sinclair/typebox，localhost端点硬编码；README声称仓库404，不推荐",
+        "unknowns": "公开Git repo未找到；固定npm shasum c36fd7dabda15c15e01566f4c4b3dbdf5ef34af4；Pi0.85兼容未知"
+      }
+    },
+    {
+      "candidate": "pi-smart-fetch",
+      "researchArea": "tools",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "pi-smart-fetch",
+        "repo": "https://github.com/Thinkscape/agent-smart-fetch",
+        "sha": "b01116124971de44f16a4477e34c06ba2ab1d0bf",
+        "sourceUrls": [
+          "https://github.com/Thinkscape/agent-smart-fetch/blob/b01116124971de44f16a4477e34c06ba2ab1d0bf/packages/pi-smart-fetch/README.md",
+          "https://registry.npmjs.org/pi-smart-fetch"
+        ],
+        "license": "MIT",
+        "evidenceLevel": "primary-docs-manifest",
+        "disposition": "discussion-only-if-fetch-success-gap",
+        "reason": "下载附件、batch和metadata有价值；收益须同URL盲对照，不因TLS宣传替换当前包",
+        "unknowns": "未安装、未运行，与 OpenPI 的实际组合尚未验证"
+      }
+    },
+    {
+      "candidate": "@narumitw/pi-firecrawl",
+      "researchArea": "tools",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "@narumitw/pi-firecrawl",
+        "repo": "https://github.com/narumiruna/pi-extensions",
+        "sha": "09d0f4d4d8d31f506e6f2478a0060be5f5c31c09",
+        "sourceUrls": [
+          "https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/packages/pi-firecrawl/README.md",
+          "https://registry.npmjs.org/@narumitw/pi-firecrawl"
+        ],
+        "license": "MIT",
+        "evidenceLevel": "primary-docs-manifest",
+        "disposition": "reference-existing-169",
+        "reason": "按需工具、无密钥network失败诊断、有界输出spill；后端覆盖与web-access重叠",
+        "unknowns": "未安装、未运行，与 OpenPI 的实际组合尚未验证"
+      }
+    },
+    {
+      "candidate": "@code-yeongyu/pi-webfetch",
+      "researchArea": "tools",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "@code-yeongyu/pi-webfetch",
+        "repo": "https://github.com/code-yeongyu/pi-webfetch",
+        "sha": "ee045140cbaa784eec420bc0a7bc7d7eec0b7043",
+        "sourceUrls": [
+          "https://github.com/code-yeongyu/pi-webfetch/blob/ee045140cbaa784eec420bc0a7bc7d7eec0b7043/README.md",
+          "https://registry.npmjs.org/@code-yeongyu/pi-webfetch"
+        ],
+        "license": "MIT",
+        "evidenceLevel": "primary-docs-manifest",
+        "disposition": "defer-duplicate",
+        "reason": "5MB/120s边界清楚，但能力重叠；scoped npm名实际404",
+        "unknowns": "未安装、未运行，与 OpenPI 的实际组合尚未验证"
+      }
+    },
+    {
+      "candidate": "@code-yeongyu/pi-websearch",
+      "researchArea": "tools",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "@code-yeongyu/pi-websearch",
+        "repo": "https://github.com/code-yeongyu/pi-websearch",
+        "sha": "ddf5f5d21de57ee3e80f1a6f96aff21a9dd34662",
+        "sourceUrls": [
+          "https://github.com/code-yeongyu/pi-websearch/blob/ddf5f5d21de57ee3e80f1a6f96aff21a9dd34662/README.md",
+          "https://registry.npmjs.org/@code-yeongyu/pi-websearch"
+        ],
+        "license": "MIT",
+        "evidenceLevel": "primary-docs-manifest",
+        "disposition": "defer-fork-coupled",
+        "reason": "默认OpenAI/Anthropic假设senpi内建search，不能称vanilla Pi即插即用；scoped npm名404",
+        "unknowns": "未安装、未运行，与 OpenPI 的实际组合尚未验证"
+      }
+    },
+    {
+      "candidate": "pi-mcp-adapter",
+      "researchArea": "tools",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-mcp-adapter",
+        "repo": "https://github.com/nicobailon/pi-mcp-adapter",
+        "sha": "8243eba3421e301c88c047444f34ab7d5d57163e",
+        "sourceUrls": [
+          "https://github.com/nicobailon/pi-mcp-adapter/blob/8243eba3421e301c88c047444f34ab7d5d57163e/README.md",
+          "https://registry.npmjs.org/pi-mcp-adapter"
+        ],
+        "license": "MIT",
+        "evidenceLevel": "source-inspected",
+        "disposition": "comment-existing-169",
+        "reason": "明确的factory配置隔离、runtime注册、metadata cache、broker approval、owner abort值得真实兼容试点",
+        "unknowns": "未安装、未运行，与 OpenPI 的实际组合尚未验证"
+      }
+    },
+    {
+      "candidate": "pi-agent-browser-native",
+      "researchArea": "tools",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-agent-browser-native",
+        "repo": "https://github.com/fitchmultz/pi-agent-browser-native",
+        "sha": "3d4f36904ff0bc6baa24cb1116b3fe42bbc2f443",
+        "sourceUrls": [
+          "https://github.com/fitchmultz/pi-agent-browser-native/blob/3d4f36904ff0bc6baa24cb1116b3fe42bbc2f443/README.md",
+          "https://registry.npmjs.org/pi-agent-browser-native"
+        ],
+        "license": "MIT",
+        "evidenceLevel": "source-inspected",
+        "disposition": "comment-existing-169",
+        "reason": "强对照：managed session/ref generations、artifact existence、action dispatch/observed outcome分离、cancel/cleanup；不移植全包",
+        "unknowns": "未安装、未运行，与 OpenPI 的实际组合尚未验证"
+      }
+    },
+    {
+      "candidate": "pi-chrome",
+      "researchArea": "tools",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-chrome",
+        "repo": "https://github.com/tianrendong/pi-chrome",
+        "sha": "017ff4b9a639f0b8b213e58a3f30613fc38edcc8",
+        "sourceUrls": [
+          "https://github.com/tianrendong/pi-chrome/blob/017ff4b9a639f0b8b213e58a3f30613fc38edcc8/README.md",
+          "https://registry.npmjs.org/pi-chrome"
+        ],
+        "license": "MIT",
+        "evidenceLevel": "source-inspected",
+        "disposition": "discussion-browser-choice",
+        "reason": "已登录Chrome按Session授权+owned targets可大幅减少外部工具摩擦；真实用户profile与隔离browser取舍需讨论",
+        "unknowns": "未安装、未运行，与 OpenPI 的实际组合尚未验证"
+      }
+    },
+    {
+      "candidate": "@narumitw/pi-chrome-devtools",
+      "researchArea": "tools",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "@narumitw/pi-chrome-devtools",
+        "repo": "https://github.com/narumiruna/pi-extensions",
+        "sha": "09d0f4d4d8d31f506e6f2478a0060be5f5c31c09",
+        "sourceUrls": [
+          "https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/packages/pi-chrome-devtools/README.md",
+          "https://registry.npmjs.org/@narumitw/pi-chrome-devtools"
+        ],
+        "license": "MIT",
+        "evidenceLevel": "primary-docs-manifest",
+        "disposition": "reference-existing-169",
+        "reason": "CDP attach/owned launch；machine-only connection配置与page tool descriptor revalidation值得对照",
+        "unknowns": "未安装、未运行，与 OpenPI 的实际组合尚未验证"
+      }
+    },
+    {
+      "candidate": "betterwright",
+      "researchArea": "tools",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "betterwright",
+        "repo": "https://github.com/BetterWright/betterwright",
+        "sha": "b9f73fc8672750b7e2d67c6dc1c988a5ab2213ba",
+        "sourceUrls": [
+          "https://github.com/BetterWright/betterwright/blob/b9f73fc8672750b7e2d67c6dc1c988a5ab2213ba/README.md",
+          "https://registry.npmjs.org/betterwright"
+        ],
+        "license": "MIT",
+        "evidenceLevel": "source-inspected",
+        "disposition": "discussion-adapter-only-not-runtime",
+        "reason": "Pi原生wrapper区分login/download/proof、清理browser；内建evidence checklist+agent_end auto-followup属于预设流程，不宜整体接管OpenPI",
+        "unknowns": "未安装、未运行，与 OpenPI 的实际组合尚未验证"
+      }
+    },
+    {
+      "candidate": "@narumitw/pi-lsp",
+      "researchArea": "tools",
+      "evidenceTier": "source",
+      "observation": {
+        "id": "narumitw-pi-lsp",
+        "name": "@narumitw/pi-lsp",
+        "repo": "https://github.com/narumiruna/pi-extensions",
+        "sha": "09d0f4d4d8d31f506e6f2478a0060be5f5c31c09",
+        "license": "MIT",
+        "evidenceLevel": "source-reviewed",
+        "disposition": "existing-issue-comment",
+        "existingIssue": 163,
+        "value": "Per-request diagnostics runner with Pi Session scope, abort/drain, explicit cleanup receipt; fix preview by default.",
+        "costUnknown": "Two eager tools; no navigation; repeated cold startup cost; child/path/server trust not validated.",
+        "sources": [
+          "https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/packages/pi-lsp/src/pi-lsp.ts"
+        ],
+        "runtimeValidated": false,
+        "installed": false,
+        "repositoryUrl": "https://github.com/narumiruna/pi-extensions",
+        "sourceUrls": [
+          "https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/packages/pi-lsp/src/pi-lsp.ts"
+        ],
+        "reason": "Per-request diagnostics runner with Pi Session scope, abort/drain, explicit cleanup receipt; fix preview by default.",
+        "unknowns": "Two eager tools; no navigation; repeated cold startup cost; child/path/server trust not validated."
+      }
+    },
+    {
+      "candidate": "pi-lsp-client",
+      "researchArea": "tools",
+      "evidenceTier": "source",
+      "observation": {
+        "id": "pi-lsp-client",
+        "name": "pi-lsp-client",
+        "repo": "https://github.com/code-yeongyu/pi-lsp-client",
+        "sha": "1c981dfcacc456fe4ce9f4120a2f0250b54d6844",
+        "license": "MIT",
+        "evidenceLevel": "source-reviewed",
+        "disposition": "existing-issue-comment",
+        "existingIssue": 163,
+        "value": "Refcounted root/server pool with pending waiters, cancellation-aware acquire and inspectable lifecycle.",
+        "costUnknown": "Six eager tools, automatic post-edit diagnostics, global singleton lifetime versus in-process child ownership unresolved.",
+        "sources": [
+          "https://github.com/code-yeongyu/pi-lsp-client/blob/1c981dfcacc456fe4ce9f4120a2f0250b54d6844/src/lsp/manager.ts"
+        ],
+        "runtimeValidated": false,
+        "installed": false,
+        "repositoryUrl": "https://github.com/code-yeongyu/pi-lsp-client",
+        "sourceUrls": [
+          "https://github.com/code-yeongyu/pi-lsp-client/blob/1c981dfcacc456fe4ce9f4120a2f0250b54d6844/src/lsp/manager.ts"
+        ],
+        "reason": "Refcounted root/server pool with pending waiters, cancellation-aware acquire and inspectable lifecycle.",
+        "unknowns": "Six eager tools, automatic post-edit diagnostics, global singleton lifetime versus in-process child ownership unresolved."
+      }
+    },
+    {
+      "candidate": "pi-lens",
+      "researchArea": "tools",
+      "evidenceTier": "source",
+      "observation": {
+        "id": "pi-lens",
+        "name": "pi-lens",
+        "repo": "https://github.com/apmantza/pi-lens",
+        "sha": "d0d853218f01be917c4f2608820584a8c167253b",
+        "license": "MIT",
+        "evidenceLevel": "source-reviewed-settings-lifecycle",
+        "disposition": "existing-issue-comment",
+        "existingIssue": 163,
+        "value": "Rich semantic navigation and diagnostic evidence; explicit one-way CLI disable.",
+        "costUnknown": "Default autoformat/autofix/tests/scanners/context remain on; project mutation override; large lifecycle surface; no measured incremental value.",
+        "sources": [
+          "https://github.com/apmantza/pi-lens/blob/d0d853218f01be917c4f2608820584a8c167253b/docs/settings.md"
+        ],
+        "runtimeValidated": false,
+        "installed": false,
+        "repositoryUrl": "https://github.com/apmantza/pi-lens",
+        "sourceUrls": [
+          "https://github.com/apmantza/pi-lens/blob/d0d853218f01be917c4f2608820584a8c167253b/docs/settings.md"
+        ],
+        "reason": "Rich semantic navigation and diagnostic evidence; explicit one-way CLI disable.",
+        "unknowns": "Default autoformat/autofix/tests/scanners/context remain on; project mutation override; large lifecycle surface; no measured incremental value."
+      }
+    },
+    {
+      "candidate": "@code-yeongyu/pi-ast-grep",
+      "researchArea": "tools",
+      "evidenceTier": "source",
+      "observation": {
+        "id": "pi-ast-grep-code",
+        "name": "@code-yeongyu/pi-ast-grep",
+        "repo": "https://github.com/code-yeongyu/pi-ast-grep",
+        "sha": "4a7d1beee684d96a6890e5fc55710bb63fecca85",
+        "license": "MIT",
+        "evidenceLevel": "source-reviewed",
+        "disposition": "discussion",
+        "existingIssue": null,
+        "value": "Small separate structural read/rewrite tools and bounded output; rewrite previews default.",
+        "costUnknown": "Caller AbortSignal ignored; binary auto-download without checksum unless offline; no content-bound preview approval.",
+        "sources": [
+          "https://github.com/code-yeongyu/pi-ast-grep/blob/4a7d1beee684d96a6890e5fc55710bb63fecca85/src/ast-grep/tools.ts"
+        ],
+        "runtimeValidated": false,
+        "installed": false,
+        "repositoryUrl": "https://github.com/code-yeongyu/pi-ast-grep",
+        "sourceUrls": [
+          "https://github.com/code-yeongyu/pi-ast-grep/blob/4a7d1beee684d96a6890e5fc55710bb63fecca85/src/ast-grep/tools.ts"
+        ],
+        "reason": "Small separate structural read/rewrite tools and bounded output; rewrite previews default.",
+        "unknowns": "Caller AbortSignal ignored; binary auto-download without checksum unless offline; no content-bound preview approval."
+      }
+    },
+    {
+      "candidate": "lsp-pi",
+      "researchArea": "tools",
+      "evidenceTier": "source",
+      "observation": {
+        "id": "lsp-pi-dap",
+        "name": "lsp-pi",
+        "repo": "https://github.com/trotsky1997/pi-lsp-extension",
+        "sha": "39d56f0cdaf4b5e77ee038f0670de14cd19e228d",
+        "license": "MIT-declared-no-LICENSE-found",
+        "evidenceLevel": "source-reviewed",
+        "disposition": "existing-issue-comment",
+        "existingIssue": 168,
+        "value": "Actual Pi-native DAP tool port with structured/text state and bounded request signal.",
+        "costUnknown": "Old Pi ^0.66; eager global DAP singleton/timer and no debug Session hooks; wide attach/evaluate/memory-write surface; license notice audit required.",
+        "sources": [
+          "https://github.com/trotsky1997/pi-lsp-extension/blob/39d56f0cdaf4b5e77ee038f0670de14cd19e228d/debug.ts"
+        ],
+        "runtimeValidated": false,
+        "installed": false,
+        "repositoryUrl": "https://github.com/trotsky1997/pi-lsp-extension",
+        "sourceUrls": [
+          "https://github.com/trotsky1997/pi-lsp-extension/blob/39d56f0cdaf4b5e77ee038f0670de14cd19e228d/debug.ts"
+        ],
+        "reason": "Actual Pi-native DAP tool port with structured/text state and bounded request signal.",
+        "unknowns": "Old Pi ^0.66; eager global DAP singleton/timer and no debug Session hooks; wide attach/evaluate/memory-write surface; license notice audit required."
+      }
+    },
+    {
+      "candidate": "@juvio15/pi-ast-grep",
+      "researchArea": "tools",
+      "evidenceTier": "source",
+      "observation": {
+        "id": "pi-ast-grep-juvio",
+        "name": "@juvio15/pi-ast-grep",
+        "repo": "bjoernaagaard/pi-ast-grep",
+        "sha": null,
+        "license": "Apache-2.0",
+        "evidenceLevel": "published-source-integrity-verified",
+        "disposition": "discussion",
+        "existingIssue": null,
+        "value": "Compact outline, trusted-project/native UI approval, Pi file mutation queue and preview-first headless gating.",
+        "costUnknown": "Repository URL 404; six tools and default prompt promotion; module-level preview set uses arguments not immutable content; missing Trust API allows.",
+        "sources": [
+          "https://registry.npmjs.org/@juvio15/pi-ast-grep/-/pi-ast-grep-0.4.2.tgz"
+        ],
+        "runtimeValidated": false,
+        "installed": false,
+        "version": "0.4.2",
+        "integrity": "sha512-ohv9dK3Z2dTO7N+oSuCgYKD50U9gkFTmmH5wabVXB3SJNisBxlJpNmO/4kqRkvGBV/rF44YnKjdsvcroD59atQ==",
+        "repositoryStatus": "404 on 2026-09-08",
+        "catalog": "https://pi.dev/packages/@juvio15/pi-ast-grep",
+        "sourceUrls": [
+          "https://registry.npmjs.org/@juvio15/pi-ast-grep/-/pi-ast-grep-0.4.2.tgz"
+        ],
+        "reason": "Compact outline, trusted-project/native UI approval, Pi file mutation queue and preview-first headless gating.",
+        "unknowns": "Repository URL 404; six tools and default prompt promotion; module-level preview set uses arguments not immutable content; missing Trust API allows."
+      }
+    },
+    {
+      "candidate": "pi-context-prune",
+      "researchArea": "context",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-context-prune",
+        "repo": "championswimmer/pi-context-prune",
+        "version": "1.4.0",
+        "license": "MIT",
+        "sha": "92c80e6e26e3dbfcecbe16675c9e192d4dcd85af",
+        "licenseAPI": null,
+        "archived": false,
+        "pushedAt": "2026-09-04T01:43:06Z",
+        "readmePath": "README.md",
+        "evidenceLevel": "fixed_source_inspection",
+        "disposition": "discussion",
+        "related": "new focused reversible-context experiment; relate #190 #313",
+        "minimumMechanism": "Model-visible result projection can shrink while native Session retains original; recover through short tool refs",
+        "compatibilityBoundary": "Separate summarizer adds cost; pruner drops toolResult but keeps tool calls; provider adapter validity must be tested; duplicated resultText in custom entries; per-record recovery cap is not total request cap",
+        "peerDependencies": {
+          "@earendil-works/pi-ai": "*",
+          "@earendil-works/pi-tui": "*",
+          "@earendil-works/pi-coding-agent": "*"
+        },
+        "engines": null,
+        "sourceURLs": [
+          "https://github.com/championswimmer/pi-context-prune/blob/92c80e6e26e3dbfcecbe16675c9e192d4dcd85af/src/pruner.ts",
+          "https://github.com/championswimmer/pi-context-prune/blob/92c80e6e26e3dbfcecbe16675c9e192d4dcd85af/src/indexer.ts",
+          "https://github.com/championswimmer/pi-context-prune/blob/92c80e6e26e3dbfcecbe16675c9e192d4dcd85af/src/query-tool.ts",
+          "https://github.com/championswimmer/pi-context-prune/blob/92c80e6e26e3dbfcecbe16675c9e192d4dcd85af/index.ts#L300-L350"
+        ],
+        "runtimeValidation": "not_run; no third-party installation or execution",
+        "licenseEvidence": "npm declaration; repo LICENSE not found"
+      }
+    },
+    {
+      "candidate": "pi-memory",
+      "researchArea": "context",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-memory",
+        "repo": "jayzeng/pi-memory",
+        "version": "0.4.2",
+        "license": "MIT",
+        "sha": "39e6b998a2279c8fad4a2c6c64e26828c1d6023e",
+        "licenseAPI": "MIT",
+        "archived": false,
+        "pushedAt": "2026-08-11T06:16:03Z",
+        "readmePath": "README.md",
+        "evidenceLevel": "fixed_source_inspection",
+        "disposition": "existing_issue_comment",
+        "related": "#167",
+        "minimumMechanism": "Recoverable deletion before mutation, idempotent restore and explicit stale snapshot receipts",
+        "compatibilityBoundary": "Markdown storage plus optional qmd; auto qmd embedding/setup and ambient memory injection require explicit opt-in; no adoption under current memory boundary",
+        "peerDependencies": {
+          "@earendil-works/pi-ai": ">=0.81.1",
+          "@earendil-works/pi-coding-agent": ">=0.81.1"
+        },
+        "engines": {
+          "node": ">=22.19.0"
+        },
+        "sourceURLs": [
+          "https://github.com/jayzeng/pi-memory/blob/39e6b998a2279c8fad4a2c6c64e26828c1d6023e/index.ts#L1385-L1419",
+          "https://github.com/jayzeng/pi-memory/blob/39e6b998a2279c8fad4a2c6c64e26828c1d6023e/index.ts#L1540-L1580",
+          "https://github.com/jayzeng/pi-memory/blob/39e6b998a2279c8fad4a2c6c64e26828c1d6023e/index.ts#L2113-L2123",
+          "https://github.com/jayzeng/pi-memory/blob/39e6b998a2279c8fad4a2c6c64e26828c1d6023e/index.ts#L2175-L2195"
+        ],
+        "runtimeValidation": "not_run; no third-party installation or execution",
+        "licenseEvidence": "npm declaration and GitHub repository metadata"
+      }
+    },
+    {
+      "candidate": "pi-hermes-memory",
+      "researchArea": "context",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-hermes-memory",
+        "repo": "chandra447/pi-hermes-memory",
+        "version": "0.9.8",
+        "license": "MIT",
+        "sha": "34c6fe49f832e6a0957ce517586158a8bdde71a4",
+        "licenseAPI": "MIT",
+        "archived": false,
+        "pushedAt": "2026-09-05T03:14:11Z",
+        "readmePath": "README.md",
+        "evidenceLevel": "fixed_source_inspection",
+        "disposition": "existing_issue_comment",
+        "related": "#167; #349",
+        "minimumMechanism": "policy-only prompts, bounded source anchors, incremental session-file index and explicit omission",
+        "compatibilityBoundary": "Native Pi hooks and session JSONL; memory policy still carries standing instructions; automatic review/consolidation and subprocess fallback are not OpenPI defaults",
+        "peerDependencies": {
+          "@earendil-works/pi-ai": ">=0.80.6",
+          "@earendil-works/pi-coding-agent": ">=0.80.6"
+        },
+        "engines": null,
+        "sourceURLs": [
+          "https://github.com/chandra447/pi-hermes-memory/blob/34c6fe49f832e6a0957ce517586158a8bdde71a4/src/prompt-context.ts",
+          "https://github.com/chandra447/pi-hermes-memory/blob/34c6fe49f832e6a0957ce517586158a8bdde71a4/src/tools/session-search-tool.ts",
+          "https://github.com/chandra447/pi-hermes-memory/blob/34c6fe49f832e6a0957ce517586158a8bdde71a4/src/store/session-anchor-search.ts",
+          "https://github.com/chandra447/pi-hermes-memory/blob/34c6fe49f832e6a0957ce517586158a8bdde71a4/src/store/session-indexer.ts"
+        ],
+        "runtimeValidation": "not_run; no third-party installation or execution",
+        "licenseEvidence": "npm declaration and GitHub repository metadata"
+      }
+    },
+    {
+      "candidate": "pi-sessions",
+      "researchArea": "context",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "pi-sessions",
+        "repo": "thurstonsand/pi-sessions",
+        "version": "0.12.1",
+        "license": "MIT",
+        "sha": "7197e8a609a2f33dc8a3610a6cf3a4ba3823592d",
+        "licenseAPI": "MIT",
+        "archived": false,
+        "pushedAt": "2026-09-06T08:27:29Z",
+        "readmePath": "README.md",
+        "evidenceLevel": "fixed_readme_and_manifest",
+        "disposition": "existing_issue_comment",
+        "related": "#349 only search subset",
+        "minimumMechanism": "Find by repo/cwd/time/file touched-vs-changed evidence; search vs reachable distinction",
+        "compatibilityBoundary": "Own handoff/messaging/subagent lifecycle overlaps OpenPI; documented child --approve widens trust; Node >=24 <26; README says Pi0.82.1 but current manifest>=0.83.0",
+        "peerDependencies": {
+          "@earendil-works/pi-ai": ">=0.83.0",
+          "@earendil-works/pi-tui": ">=0.83.0",
+          "@earendil-works/pi-agent-core": ">=0.83.0",
+          "@earendil-works/pi-coding-agent": ">=0.83.0"
+        },
+        "engines": {
+          "node": ">=24 <26"
+        },
+        "sourceURLs": [
+          "https://github.com/thurstonsand/pi-sessions/blob/7197e8a609a2f33dc8a3610a6cf3a4ba3823592d/README.md"
+        ],
+        "runtimeValidation": "not_run; no third-party installation or execution",
+        "licenseEvidence": "npm declaration and GitHub repository metadata"
+      }
+    },
+    {
+      "candidate": "@hypabolic/pi-hypa",
+      "researchArea": "context",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "@hypabolic/pi-hypa",
+        "repo": "Hypabolic/Hypa",
+        "version": "0.1.14",
+        "license": "FSL-1.1-ALv2",
+        "sha": "2678616e62f1f2a8d2ae0904f88859c3f19df860",
+        "licenseAPI": "NOASSERTION",
+        "archived": false,
+        "pushedAt": "2026-08-13T01:19:35Z",
+        "readmePath": "packages/pi-hypa/README.md",
+        "evidenceLevel": "fixed_readme_and_manifest",
+        "disposition": "already_covered",
+        "related": "2026-08-09 audit reducer section",
+        "minimumMechanism": "Deterministic reducer + original artifact and provenance",
+        "compatibilityBoundary": "Already researched; current default installs binary/shim and rewrites bash input; FSL-1.1-ALv2 declaration; no new integration recommendation",
+        "peerDependencies": {
+          "@earendil-works/pi-coding-agent": "*"
+        },
+        "engines": null,
+        "sourceURLs": [
+          "https://github.com/Hypabolic/Hypa/blob/2678616e62f1f2a8d2ae0904f88859c3f19df860/packages/pi-hypa/README.md"
+        ],
+        "runtimeValidation": "not_run; no third-party installation or execution",
+        "licenseEvidence": "npm declaration and GitHub repository metadata"
+      }
+    },
+    {
+      "candidate": "@samfp/pi-memory",
+      "researchArea": "context",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "@samfp/pi-memory",
+        "repo": "samfoy/pi-memory",
+        "version": "1.5.0",
+        "license": "MIT",
+        "sha": "da1f96d55706db07f39c3767b84890e89298d5f2",
+        "licenseAPI": "MIT",
+        "archived": false,
+        "pushedAt": "2026-09-02T18:35:02Z",
+        "readmePath": "README.md",
+        "evidenceLevel": "fixed_readme_and_manifest",
+        "disposition": "defer",
+        "related": "existing #167",
+        "minimumMechanism": "One-shot memory injection rather than per-turn prompt rewrites",
+        "compatibilityBoundary": "LLM extraction at shutdown via child pi; confidence>=0.8 is model claim not verified truth; package name distinct from jayzeng/pi-memory",
+        "peerDependencies": {
+          "@sinclair/typebox": "*",
+          "@earendil-works/pi-coding-agent": "*"
+        },
+        "engines": null,
+        "sourceURLs": [
+          "https://github.com/samfoy/pi-memory/blob/da1f96d55706db07f39c3767b84890e89298d5f2/README.md"
+        ],
+        "runtimeValidation": "not_run; no third-party installation or execution",
+        "licenseEvidence": "npm declaration and GitHub repository metadata"
+      }
+    },
+    {
+      "candidate": "pi-session-search",
+      "researchArea": "context",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-session-search",
+        "repo": "samfoy/pi-session-search",
+        "version": "1.4.3",
+        "license": "MIT",
+        "sha": "30acb79abc225ac1907d67eeed1eeb1079890431",
+        "licenseAPI": "MIT",
+        "archived": false,
+        "pushedAt": "2026-07-04T19:55:17Z",
+        "readmePath": "README.md",
+        "evidenceLevel": "fixed_source_inspection",
+        "disposition": "existing_issue_comment",
+        "related": "#349",
+        "minimumMechanism": "Derived FTS5 index with stable session ID, archive move handling, query/read separation",
+        "compatibilityBoundary": "Node >=24 FTS5 dependency; auto global history index not suitable Web authority default; same-size content edits skipped; semantic embeddings optional and outside current Web scope",
+        "peerDependencies": {
+          "@sinclair/typebox": "*",
+          "@earendil-works/pi-coding-agent": "*"
+        },
+        "engines": {
+          "node": ">=24"
+        },
+        "sourceURLs": [
+          "https://github.com/samfoy/pi-session-search/blob/30acb79abc225ac1907d67eeed1eeb1079890431/src/fts-index.ts#L89-L165",
+          "https://github.com/samfoy/pi-session-search/blob/30acb79abc225ac1907d67eeed1eeb1079890431/src/session-index.ts",
+          "https://github.com/samfoy/pi-session-search/blob/30acb79abc225ac1907d67eeed1eeb1079890431/src/fts5-probe.ts",
+          "https://github.com/samfoy/pi-session-search/blob/30acb79abc225ac1907d67eeed1eeb1079890431/src/reader.ts"
+        ],
+        "runtimeValidation": "not_run; no third-party installation or execution",
+        "licenseEvidence": "npm declaration and GitHub repository metadata"
+      }
+    },
+    {
+      "candidate": "pi-usage-widget",
+      "researchArea": "context",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "pi-usage-widget",
+        "repo": "cullendotdev/pi-usage-widget",
+        "version": "0.2.1",
+        "license": "MIT",
+        "sha": "976d3dfc11bbb1a5a2cacd05d9a00963d5e15bc7",
+        "licenseAPI": "MIT",
+        "archived": false,
+        "pushedAt": "2026-06-24T12:41:47Z",
+        "readmePath": "README.md",
+        "evidenceLevel": "fixed_readme_and_manifest",
+        "disposition": "defer",
+        "related": "relate #313",
+        "minimumMechanism": "Usage timeline grouped provider/model/time scopes including nested sessions",
+        "compatibilityBoundary": "Operator UI reference only; all-session scanning needs scope/dedup limits; totals are normalized recorded usage not invoices; no default widget duplication",
+        "peerDependencies": {
+          "@earendil-works/pi-tui": "*",
+          "@earendil-works/pi-coding-agent": "*"
+        },
+        "engines": null,
+        "sourceURLs": [
+          "https://github.com/cullendotdev/pi-usage-widget/blob/976d3dfc11bbb1a5a2cacd05d9a00963d5e15bc7/README.md"
+        ],
+        "runtimeValidation": "not_run; no third-party installation or execution",
+        "licenseEvidence": "npm declaration and GitHub repository metadata"
+      }
+    },
+    {
+      "candidate": "@gintasz/pi-neuralyzer",
+      "researchArea": "context",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "@gintasz/pi-neuralyzer",
+        "repo": "gintasz/neuralyzer",
+        "version": "0.1.1",
+        "license": "MIT",
+        "sha": "5d5cf3ea206307f31c8592d1e79f4037c00a94d0",
+        "licenseAPI": "MIT",
+        "archived": false,
+        "pushedAt": "2026-08-07T09:18:33Z",
+        "readmePath": "README.md",
+        "evidenceLevel": "fixed_readme_and_manifest",
+        "disposition": "do_not_adopt",
+        "related": "related #154 and existing context-pivot",
+        "minimumMechanism": "One small reset primitive",
+        "compatibilityBoundary": "Blind first-message replay loses later corrections/constraints and repeats task; OpenPI already has Pi-native Session/context-pivot; no concrete net-new need",
+        "peerDependencies": {
+          "@earendil-works/pi-coding-agent": ">=0.79.0"
+        },
+        "engines": {
+          "node": ">=22"
+        },
+        "sourceURLs": [
+          "https://github.com/gintasz/neuralyzer/blob/5d5cf3ea206307f31c8592d1e79f4037c00a94d0/README.md"
+        ],
+        "runtimeValidation": "not_run; no third-party installation or execution",
+        "licenseEvidence": "npm declaration and GitHub repository metadata"
+      }
+    },
+    {
+      "candidate": "context-mode",
+      "researchArea": "context",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "context-mode",
+        "repo": "mksglu/context-mode",
+        "version": "1.0.169",
+        "license": "Elastic-2.0",
+        "sha": "33f7eb90f17bbe1b7c39aa126b989b6fa73850c8",
+        "licenseAPI": "NOASSERTION",
+        "archived": false,
+        "pushedAt": "2026-09-07T12:06:52Z",
+        "readmePath": "README.md",
+        "evidenceLevel": "fixed_readme_and_manifest",
+        "disposition": "do_not_adopt",
+        "related": "related #300; prior reducer investigation",
+        "minimumMechanism": "Large raw result indexed out of context, retrieve relevant slices",
+        "compatibilityBoundary": "Broad MCP runtime and routing instructions, new context/session storage; Elastic-2.0 declaration; 98% claim not OpenPI end-to-end evidence",
+        "peerDependencies": null,
+        "engines": {
+          "node": ">=22.5.0"
+        },
+        "sourceURLs": [
+          "https://github.com/mksglu/context-mode/blob/33f7eb90f17bbe1b7c39aa126b989b6fa73850c8/README.md"
+        ],
+        "runtimeValidation": "not_run; no third-party installation or execution",
+        "licenseEvidence": "npm declaration and GitHub repository metadata"
+      }
+    },
+    {
+      "candidate": "pi-lean-ctx",
+      "researchArea": "context",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "pi-lean-ctx",
+        "repo": "yvgude/lean-ctx",
+        "version": "3.10.1",
+        "license": "Apache-2.0",
+        "sha": "e710e85a2f4782f3d8732fcda38ae9ee7a772e05",
+        "licenseAPI": "Apache-2.0",
+        "archived": false,
+        "pushedAt": "2026-09-07T20:33:46Z",
+        "readmePath": "packages/pi-lean-ctx/README.md",
+        "evidenceLevel": "fixed_readme_and_manifest",
+        "disposition": "defer",
+        "related": "prior reducer investigation",
+        "minimumMechanism": "Local deterministic source/output reduction behind bounded tools",
+        "compatibilityBoundary": "Rust runtime plus embedded MCP bridge default; additive duplicate tool surface or replacement semantics; author marks experimental, not a performance guarantee",
+        "peerDependencies": {
+          "typebox": "^1.0.0",
+          "@earendil-works/pi-tui": "*",
+          "@earendil-works/pi-coding-agent": ">=0.74.0"
+        },
+        "engines": null,
+        "sourceURLs": [
+          "https://github.com/yvgude/lean-ctx/blob/e710e85a2f4782f3d8732fcda38ae9ee7a772e05/packages/pi-lean-ctx/README.md"
+        ],
+        "runtimeValidation": "not_run; no third-party installation or execution",
+        "licenseEvidence": "npm declaration and GitHub repository metadata"
+      }
+    },
+    {
+      "candidate": "pi-memory-honcho",
+      "researchArea": "context",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "pi-memory-honcho",
+        "repo": "acsezen/pi-memory-honcho",
+        "version": "0.3.3",
+        "license": "MIT",
+        "sha": "9439404513e7650fc215bfeb30bd03bad72bd33a",
+        "licenseAPI": "MIT",
+        "archived": false,
+        "pushedAt": "2026-06-20T10:32:42Z",
+        "readmePath": "README.md",
+        "evidenceLevel": "fixed_readme_and_manifest",
+        "disposition": "do_not_adopt",
+        "related": "existing #167",
+        "minimumMechanism": "Explicit profile/search/context separation and health diagnostics",
+        "compatibilityBoundary": "External/self-hosted Honcho dependency; default saveMessages upload and every-turn injection; old @mariozechner peer namespace; privacy/cost/lifecycle expand scope",
+        "peerDependencies": {
+          "@sinclair/typebox": "*",
+          "@mariozechner/pi-ai": "*",
+          "@mariozechner/pi-coding-agent": "*"
+        },
+        "engines": null,
+        "sourceURLs": [
+          "https://github.com/acsezen/pi-memory-honcho/blob/9439404513e7650fc215bfeb30bd03bad72bd33a/README.md"
+        ],
+        "runtimeValidation": "not_run; no third-party installation or execution",
+        "licenseEvidence": "npm declaration and GitHub repository metadata"
+      }
+    },
+    {
+      "candidate": "pi-fold",
+      "researchArea": "context",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-fold",
+        "repo": "shaneconner/fold",
+        "version": "4.1.6",
+        "license": "MIT",
+        "sha": "7eb2ab47e291f4616ba4850e3648724fa5600a16",
+        "licenseAPI": "MIT",
+        "archived": false,
+        "pushedAt": "2026-09-06T17:35:15Z",
+        "readmePath": "README.md",
+        "evidenceLevel": "fixed_source_inspection",
+        "disposition": "discussion",
+        "related": "same reversible-context experiment; relate #190 #313",
+        "minimumMechanism": "Stage marks without prefix mutation, commit in batches; recover exact referenced source with total byte budget",
+        "compatibilityBoundary": "Large context controller with automatic thresholds, native compaction interception and rollback; nine-action tool; learn narrow mechanism only; README benchmark not independently reproduced",
+        "peerDependencies": {
+          "@earendil-works/pi-coding-agent": ">=0.83.0 <1"
+        },
+        "engines": {
+          "node": ">=22"
+        },
+        "sourceURLs": [
+          "https://github.com/shaneconner/fold/blob/7eb2ab47e291f4616ba4850e3648724fa5600a16/extensions/active-context.ts#L3327-L3331",
+          "https://github.com/shaneconner/fold/blob/7eb2ab47e291f4616ba4850e3648724fa5600a16/extensions/active-context.ts#L3665-L3715",
+          "https://github.com/shaneconner/fold/blob/7eb2ab47e291f4616ba4850e3648724fa5600a16/extensions/lib/folding.ts#L1414-L1478",
+          "https://github.com/shaneconner/fold/blob/7eb2ab47e291f4616ba4850e3648724fa5600a16/extensions/evidence.js#L90-L122"
+        ],
+        "runtimeValidation": "not_run; no third-party installation or execution",
+        "licenseEvidence": "npm declaration and GitHub repository metadata"
+      }
+    },
+    {
+      "candidate": "pi-cache-graph",
+      "researchArea": "context",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-cache-graph",
+        "repo": "championswimmer/pi-cache-graph",
+        "version": "1.0.2",
+        "license": "MIT",
+        "sha": "40c5ae469c3956f7aba7fadc40f64391c1c74706",
+        "licenseAPI": null,
+        "archived": false,
+        "pushedAt": "2026-08-30T17:43:13Z",
+        "readmePath": "README.md",
+        "evidenceLevel": "fixed_source_inspection",
+        "disposition": "existing_issue_comment",
+        "related": "#156; relate #313",
+        "minimumMechanism": "Separate active branch and whole-tree usage timelines and export",
+        "compatibilityBoundary": "OpenPI already has per-turn diagnostic tracker; package counts assistant only, while OpenPI also counts toolResult/compaction/branch_summary usage; no inferred provider billing facts",
+        "peerDependencies": {
+          "@earendil-works/pi-ai": "*",
+          "@earendil-works/pi-tui": "*",
+          "@earendil-works/pi-coding-agent": "*"
+        },
+        "engines": null,
+        "sourceURLs": [
+          "https://github.com/championswimmer/pi-cache-graph/blob/40c5ae469c3956f7aba7fadc40f64391c1c74706/src/session-data.ts",
+          "https://github.com/championswimmer/pi-cache-graph/blob/40c5ae469c3956f7aba7fadc40f64391c1c74706/src/cache-math.ts",
+          "https://github.com/championswimmer/pi-cache-graph/blob/40c5ae469c3956f7aba7fadc40f64391c1c74706/src/export.ts"
+        ],
+        "runtimeValidation": "not_run; no third-party installation or execution",
+        "licenseEvidence": "npm declaration; repo LICENSE not found"
+      }
+    },
+    {
+      "candidate": "gentle-engram",
+      "researchArea": "context",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "gentle-engram",
+        "repo": "Gentleman-Programming/engram",
+        "version": "0.1.11",
+        "license": "MIT",
+        "sha": "869a3fb3aecc8353d95d2a47b108075e9398ecc1",
+        "licenseAPI": "MIT",
+        "archived": false,
+        "pushedAt": "2026-09-07T11:00:14Z",
+        "readmePath": "plugin/pi/README.md",
+        "evidenceLevel": "fixed_readme_and_manifest",
+        "disposition": "defer",
+        "related": "existing #167",
+        "minimumMechanism": "Search then bounded fetch, project-scoped curated memory",
+        "compatibilityBoundary": "Native mem tools plus HTTP/MCP service and memory protocol; additional storage/service owner; cloud sync opt-in, no need to adopt to learn mechanism",
+        "peerDependencies": {
+          "pi-mcp-adapter": ">=2.5.0",
+          "@earendil-works/pi-tui": ">=0.74.0",
+          "@earendil-works/pi-coding-agent": "*"
+        },
+        "engines": null,
+        "sourceURLs": [
+          "https://github.com/Gentleman-Programming/engram/blob/869a3fb3aecc8353d95d2a47b108075e9398ecc1/plugin/pi/README.md"
+        ],
+        "runtimeValidation": "not_run; no third-party installation or execution",
+        "licenseEvidence": "npm declaration and GitHub repository metadata"
+      }
+    },
+    {
+      "candidate": "pi-vetter",
+      "researchArea": "safety",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-vetter",
+        "repo": "https://github.com/jesset/pi-vetter",
+        "sha": "7e620ca5c6a3d09dba3badaab5664d0bc5ba9568",
+        "sourceURLs": [
+          "https://github.com/jesset/pi-vetter/blob/7e620ca5c6a3d09dba3badaab5664d0bc5ba9568/package.json",
+          "https://github.com/jesset/pi-vetter/blob/7e620ca5c6a3d09dba3badaab5664d0bc5ba9568/src/core/engine.ts",
+          "https://github.com/jesset/pi-vetter/blob/7e620ca5c6a3d09dba3badaab5664d0bc5ba9568/src/core/rules.ts",
+          "https://github.com/jesset/pi-vetter/blob/7e620ca5c6a3d09dba3badaab5664d0bc5ba9568/src/install/gated-installer.ts",
+          "https://github.com/jesset/pi-vetter/blob/7e620ca5c6a3d09dba3badaab5664d0bc5ba9568/src/scanners/provenance.ts"
+        ],
+        "evidenceLevel": "source-reviewed",
+        "disposition": "discussion",
+        "mechanism": "Version/integrity/file digests; baseline-aware cache; incomplete scanner evidence caps ALLOW to ASK; typed install drift outcomes.",
+        "compatibility": "Repository manifest 0.4.1; Pi peer *, dev Pi TUI ^0.84.3; Node >=22.19. No runtime compatibility test.",
+        "license": "MIT",
+        "cost": "Registry/scanner network requests; sigstore/tar dependencies; false positives and unavailable sources must remain visible.",
+        "reason": "Good artifact-bound review receipt; OpenPI has no installer now. Discuss read-only native-package diagnostics before any integration."
+      }
+    },
+    {
+      "candidate": "pi-sandbox",
+      "researchArea": "safety",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-sandbox",
+        "repo": "https://github.com/carderne/pi-sandbox",
+        "sha": "079be62e8de18665cdd9b810a879d419a00a8565",
+        "sourceURLs": [
+          "https://github.com/carderne/pi-sandbox/blob/079be62e8de18665cdd9b810a879d419a00a8565/package.json",
+          "https://github.com/carderne/pi-sandbox/blob/079be62e8de18665cdd9b810a879d419a00a8565/src/extension.ts",
+          "https://github.com/carderne/pi-sandbox/blob/079be62e8de18665cdd9b810a879d419a00a8565/src/sandbox-runtime.ts",
+          "https://github.com/carderne/pi-sandbox/blob/079be62e8de18665cdd9b810a879d419a00a8565/README.md"
+        ],
+        "evidenceLevel": "source-reviewed",
+        "disposition": "discussion",
+        "mechanism": "Wrap native Bash operations in sandbox-exec/bwrap; file tools use separate path gates; session/project/global approval scope and timeout deny.",
+        "compatibility": "0.6.7; Pi ^0.80.0 does not include OpenPI Pi 0.85.1; untested current compatibility.",
+        "license": "MIT",
+        "cost": "OS/runtime/rg requirements; external fork; network proxy; concurrent Session ownership.",
+        "reason": "True bash subprocess isolation but not whole Pi process isolation. Current init failure falls back to localBash; do not transplant as fail-closed enforcement."
+      }
+    },
+    {
+      "candidate": "@gotgenes/pi-permission-system",
+      "researchArea": "safety",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "@gotgenes/pi-permission-system",
+        "repo": "https://github.com/gotgenes/pi-packages",
+        "sha": "6ee70e9f4571c2ae96b50e6105ad887c20d8d0a2",
+        "sourceURLs": [
+          "https://github.com/gotgenes/pi-packages/blob/6ee70e9f4571c2ae96b50e6105ad887c20d8d0a2/packages/pi-permission-system/package.json",
+          "https://github.com/gotgenes/pi-packages/blob/6ee70e9f4571c2ae96b50e6105ad887c20d8d0a2/packages/pi-permission-system/src/authority/delegation-envelope.ts",
+          "https://github.com/gotgenes/pi-packages/blob/6ee70e9f4571c2ae96b50e6105ad887c20d8d0a2/packages/pi-permission-system/src/logging/log-redaction.ts",
+          "https://github.com/gotgenes/pi-packages/blob/6ee70e9f4571c2ae96b50e6105ad887c20d8d0a2/packages/pi-permission-system/src/logging/log-file-permissions.ts"
+        ],
+        "evidenceLevel": "source-reviewed",
+        "disposition": "comment-existing-169-and-454",
+        "mechanism": "Bound external-authorizer grants; unknown authority surface cannot grant; structural log masking and owner-only files separate from exact human approval payload.",
+        "compatibility": "31.1.2; Pi >=0.79.0 includes 0.85.1 declaratively; dev 0.79.1; OpenPI in-process child compatibility untested.",
+        "license": "MIT",
+        "cost": "tree-sitter-bash/web-tree-sitter/zod; separate policy and forwarding lifecycle.",
+        "reason": "Update Aug-09 audit with current bounded authority/diagnostic evidence; existing #169 covers compatibility seam."
+      }
+    },
+    {
+      "candidate": "@gotgenes/pi-permission-model-judge",
+      "researchArea": "safety",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "@gotgenes/pi-permission-model-judge",
+        "repo": "https://github.com/gotgenes/pi-packages",
+        "sha": "6ee70e9f4571c2ae96b50e6105ad887c20d8d0a2",
+        "sourceURLs": [
+          "https://github.com/gotgenes/pi-packages/blob/6ee70e9f4571c2ae96b50e6105ad887c20d8d0a2/packages/pi-permission-model-judge/package.json",
+          "https://github.com/gotgenes/pi-packages/blob/6ee70e9f4571c2ae96b50e6105ad887c20d8d0a2/packages/pi-permission-model-judge/README.md"
+        ],
+        "evidenceLevel": "readme-and-manifest",
+        "disposition": "hold",
+        "mechanism": "Only typo-pattern-matched external-directory asks invoke model; returns deny or defer, never allow; records reason/cost.",
+        "compatibility": "Requires permission-system >=27.0.0; no OpenPI integration test.",
+        "license": "MIT",
+        "cost": "Extra model latency/cost and configured typo patterns.",
+        "reason": "Useful example of AI advice bounded by runtime. Not a general auto-approval engine; unclear user value relative to parent correction."
+      }
+    },
+    {
+      "candidate": "@aliou/pi-guardrails",
+      "researchArea": "safety",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "@aliou/pi-guardrails",
+        "repo": "https://github.com/aliou/pi-guardrails",
+        "sha": "e27e4bf96e18497436c2580fd9d0548bc7e2608d",
+        "sourceURLs": [
+          "https://github.com/aliou/pi-guardrails/blob/e27e4bf96e18497436c2580fd9d0548bc7e2608d/package.json",
+          "https://github.com/aliou/pi-guardrails/blob/e27e4bf96e18497436c2580fd9d0548bc7e2608d/extensions/permission-gate/index.ts",
+          "https://github.com/aliou/pi-guardrails/blob/e27e4bf96e18497436c2580fd9d0548bc7e2608d/extensions/permission-gate/grants.ts",
+          "https://github.com/aliou/pi-guardrails/blob/e27e4bf96e18497436c2580fd9d0548bc7e2608d/extensions/permission-gate/rules.ts"
+        ],
+        "evidenceLevel": "source-reviewed",
+        "disposition": "comment-existing-343",
+        "mechanism": "Permission prompt-opened/closed events in try/finally; allow-once/session/deny/stop outcomes; no UI blocks.",
+        "compatibility": "0.17.1; Pi peer *, dev 0.79.6. Downloaded repo tree lacks some manifest targets; npm artifact not checked.",
+        "license": "MIT declared in package.json; no root LICENSE found",
+        "cost": "Settings/helper dependencies and own configuration surface.",
+        "reason": "Useful UI lifecycle evidence for #343, not replacement guard nor demonstrated package-install compatibility."
+      }
+    },
+    {
+      "candidate": "filter-output",
+      "researchArea": "safety",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "filter-output",
+        "repo": "https://github.com/michalvavra/agents",
+        "sha": "c355e3c358fbef4122141ee51d8887fe273ff8b6",
+        "sourceURLs": [
+          "https://github.com/michalvavra/agents/blob/c355e3c358fbef4122141ee51d8887fe273ff8b6/agents/pi/extensions/filter-output.ts",
+          "https://github.com/michalvavra/agents/blob/c355e3c358fbef4122141ee51d8887fe273ff8b6/LICENSE",
+          "https://github.com/michalvavra/agents/blob/c355e3c358fbef4122141ee51d8887fe273ff8b6/package.json"
+        ],
+        "evidenceLevel": "source-reviewed",
+        "disposition": "hold",
+        "mechanism": "tool_result text redaction plus whole sensitive-file suppression.",
+        "compatibility": "Imports current Pi package namespace; no tested OpenPI or minimum Pi range.",
+        "license": "MIT-0",
+        "cost": "Prefix regex maintenance; false positives; content projection diverges from original execution.",
+        "reason": "Skips isError results and .env.example; does not protect arbitrary tools, original process, network or all persistence. Learn boundary and explicit omission receipts, not blanket safety claim."
+      }
+    },
+    {
+      "candidate": "security",
+      "researchArea": "safety",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "security",
+        "repo": "https://github.com/michalvavra/agents",
+        "sha": "c355e3c358fbef4122141ee51d8887fe273ff8b6",
+        "sourceURLs": [
+          "https://github.com/michalvavra/agents/blob/c355e3c358fbef4122141ee51d8887fe273ff8b6/agents/pi/extensions/security.ts",
+          "https://github.com/michalvavra/agents/blob/c355e3c358fbef4122141ee51d8887fe273ff8b6/LICENSE",
+          "https://github.com/michalvavra/agents/blob/c355e3c358fbef4122141ee51d8887fe273ff8b6/package.json"
+        ],
+        "evidenceLevel": "readme-and-source-screened",
+        "disposition": "no-action",
+        "mechanism": "Regex dangerous-command confirmations and protected write paths; no UI denies.",
+        "compatibility": "Current Pi imports; no OpenPI integration test.",
+        "license": "MIT-0",
+        "cost": "Regex coverage and overlapping guard semantics.",
+        "reason": "OpenPI already has narrow cleanup provenance guard. Not a sandbox; broadened static denylist has unproven incremental value."
+      }
+    },
+    {
+      "candidate": "permission-pi / pi-hooks permission",
+      "researchArea": "safety",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "permission-pi / pi-hooks permission",
+        "repo": "https://github.com/prateekmedia/pi-hooks",
+        "sha": "5590a3bacbbdd055fb49d2ca031abe2c9f3e6c25",
+        "sourceURLs": [
+          "https://github.com/prateekmedia/pi-hooks/blob/5590a3bacbbdd055fb49d2ca031abe2c9f3e6c25/permission/README.md",
+          "https://github.com/prateekmedia/pi-hooks/blob/5590a3bacbbdd055fb49d2ca031abe2c9f3e6c25/permission/package.json",
+          "https://github.com/prateekmedia/pi-hooks/blob/5590a3bacbbdd055fb49d2ca031abe2c9f3e6c25/permission/permission-core.ts"
+        ],
+        "evidenceLevel": "readme-and-source-screened",
+        "disposition": "no-action",
+        "mechanism": "Four static permission levels and most-restrictive matched command rule; print-mode blocks insufficient authority.",
+        "compatibility": "Manifest package is permission-pi 1.0.5; Pi ^0.74.0 excludes 0.85.1.",
+        "license": "MIT",
+        "cost": "Second configuration model and shell grammar maintenance.",
+        "reason": "Coarse levels encode workflow assumptions; not orthogonal enough for direct adoption."
+      }
+    },
+    {
+      "candidate": "mitsupi",
+      "researchArea": "safety",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "mitsupi / notify",
+        "repo": "https://github.com/mitsuhiko/agent-stuff",
+        "sha": "122e2994adddb113c04764c5697217dae120fcc6",
+        "sourceURLs": [
+          "https://github.com/mitsuhiko/agent-stuff/blob/122e2994adddb113c04764c5697217dae120fcc6/extensions/notify.ts",
+          "https://github.com/mitsuhiko/agent-stuff/blob/122e2994adddb113c04764c5697217dae120fcc6/package.json",
+          "https://github.com/mitsuhiko/agent-stuff/blob/122e2994adddb113c04764c5697217dae120fcc6/LICENSE"
+        ],
+        "evidenceLevel": "source-reviewed",
+        "disposition": "discussion",
+        "mechanism": "agent_end triggers bounded plain-text OSC777 notification, stripping terminal/control sequences.",
+        "compatibility": "mitsupi1.6.0; Pi peer *; supported terminal-specific OSC777; no browser Notifications API.",
+        "license": "Apache-2.0",
+        "cost": "Notification permission/privacy/duplicate events for parent+children; limited terminal support.",
+        "reason": "Worth discussing attention delivery, but agent_end cannot imply Goal/Workflow success and summary may expose private text."
+      }
+    },
+    {
+      "candidate": "@narumitw/pi-caffeinate",
+      "researchArea": "safety",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "@narumitw/pi-caffeinate",
+        "repo": "https://github.com/narumiruna/pi-extensions",
+        "sha": "09d0f4d4d8d31f506e6f2478a0060be5f5c31c09",
+        "sourceURLs": [
+          "https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/packages/pi-caffeinate/package.json",
+          "https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/packages/pi-caffeinate/src/caffeinate.ts",
+          "https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/packages/pi-caffeinate/README.md"
+        ],
+        "evidenceLevel": "source-reviewed",
+        "disposition": "discussion",
+        "mechanism": "Acquire inhibitor on agent_start; active-turn counter; release on agent_end/shutdown; generation/abort guards asynchronous D-Bus startup and settings rollback.",
+        "compatibility": "0.49.7; Pi peer *, dev0.85.0; built dist entry and Pi TUI kit dependency; no OpenPI child test.",
+        "license": "MIT",
+        "cost": "Cross-platform OS processes/D-Bus; system/display power policy; module-level state in source.",
+        "reason": "Useful long-task QoL but process-wide/shared module state and background child ownership need proving before recommending."
+      }
+    },
+    {
+      "candidate": "@narumitw/pi-retry",
+      "researchArea": "safety",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "@narumitw/pi-retry",
+        "repo": "https://github.com/narumiruna/pi-extensions",
+        "sha": "09d0f4d4d8d31f506e6f2478a0060be5f5c31c09",
+        "sourceURLs": [
+          "https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/deprecated/pi-retry/README.md",
+          "https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/deprecated/pi-retry/package.json"
+        ],
+        "evidenceLevel": "readme-and-manifest",
+        "disposition": "no-action-deprecated",
+        "mechanism": "Former provider-specific retry classification and stall watchdog.",
+        "compatibility": "Current repository explicitly deprecates it: Pi owns provider retry, websocket renewal and timeout settings.",
+        "license": "MIT",
+        "cost": "Duplicate watchdog may abort valid long streams.",
+        "reason": "Important discovery correction: popular listing is stale here; do not add redundant retry layer."
+      }
+    },
+    {
+      "candidate": "pi-verdict",
+      "researchArea": "safety",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-verdict",
+        "repo": "https://github.com/jesset/pi-verdict",
+        "sha": "1386a9521681b6f8e4ef1a445d6f13beb0212d57",
+        "sourceURLs": [
+          "https://github.com/jesset/pi-verdict/blob/1386a9521681b6f8e4ef1a445d6f13beb0212d57/package.json",
+          "https://github.com/jesset/pi-verdict/blob/1386a9521681b6f8e4ef1a445d6f13beb0212d57/README.md",
+          "https://github.com/jesset/pi-verdict/blob/1386a9521681b6f8e4ef1a445d6f13beb0212d57/docs/security-principles.md",
+          "https://github.com/jesset/pi-verdict/blob/1386a9521681b6f8e4ef1a445d6f13beb0212d57/extensions/pi-verdict.ts"
+        ],
+        "evidenceLevel": "source-screened",
+        "disposition": "discussion-grouped-authority",
+        "mechanism": "Deterministic deny floor then contextual model allow/ask/deny; noninteractive ask denies; explicit judgment-not-proof boundary.",
+        "compatibility": "Requires Pi >=0.84 in README; no current OpenPI integration test.",
+        "license": "MIT",
+        "cost": "Model call for uncertain tool calls; 25s timeout; prompt-policy risk and self-protection complexity.",
+        "reason": "Not a default dependency. Compare deny-only advisory option; authorization remains runtime/human-owned."
+      }
+    },
+    {
+      "candidate": "@czottmann/pi-automode",
+      "researchArea": "safety",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "@czottmann/pi-automode",
+        "repo": "https://github.com/czottmann/pi-automode",
+        "sha": "d556f006bd705d4eddc5c49ce4fcc8d9b82c1657",
+        "sourceURLs": [
+          "https://github.com/czottmann/pi-automode/blob/d556f006bd705d4eddc5c49ce4fcc8d9b82c1657/package.json",
+          "https://github.com/czottmann/pi-automode/blob/d556f006bd705d4eddc5c49ce4fcc8d9b82c1657/README.md"
+        ],
+        "evidenceLevel": "readme-and-manifest",
+        "disposition": "discussion-grouped-authority",
+        "mechanism": "Deterministic guard then context classifier; read-only inspect surface backed by enforced runtime state and source-identity exemption.",
+        "compatibility": "1.16.0; Pi peer *, dev^0.84.1; declared Pi/OMP18 support, no OpenPI integration test.",
+        "license": "MIT",
+        "cost": "unbash and classifier latency/cost; another safety policy.",
+        "reason": "Read-only diagnostics worth learning; not sandbox and does not guard user ! commands."
+      }
+    },
+    {
+      "candidate": "cc-safety-net",
+      "researchArea": "safety",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "cc-safety-net",
+        "repo": "https://github.com/kenryu42/cc-safety-net",
+        "sha": "10326fac666de7ca515e3492820242eadc316916",
+        "sourceURLs": [
+          "https://github.com/kenryu42/cc-safety-net/blob/10326fac666de7ca515e3492820242eadc316916/package.json",
+          "https://github.com/kenryu42/cc-safety-net/blob/10326fac666de7ca515e3492820242eadc316916/README.md"
+        ],
+        "evidenceLevel": "readme-and-manifest",
+        "disposition": "no-action",
+        "mechanism": "Multi-agent-host pre-execution destructive-command and sensitive-file guard with Pi dist adapter.",
+        "compatibility": "2.3.3; pi.extensions dist/pi/index.js; no declared Pi peer minimum; no OpenPI acceptance.",
+        "license": "MIT",
+        "cost": "Cross-host adapters and rule maintenance; overlapping cleanup guards.",
+        "reason": "Broad host coverage is not evidence of complete OS mediation; current narrow OpenPI guard already owned."
+      }
+    },
+    {
+      "candidate": "@trim21/personal-pi-extensions",
+      "researchArea": "safety",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "@trim21/personal-pi-extensions",
+        "repo": "https://github.com/trim21/pi-extensions",
+        "sha": "79d7f01c4b4c42a6125e368eefcee66c21992058",
+        "sourceURLs": [
+          "https://github.com/trim21/pi-extensions/blob/79d7f01c4b4c42a6125e368eefcee66c21992058/package.json",
+          "https://github.com/trim21/pi-extensions/blob/79d7f01c4b4c42a6125e368eefcee66c21992058/README.md"
+        ],
+        "evidenceLevel": "readme-and-manifest",
+        "disposition": "hold",
+        "mechanism": "Collection advertises bwrap/workspace guard alongside model adapters and tools.",
+        "compatibility": "0.1.0 manifest; Pi >=0.84.1, Node>=24.14; bwrap not in fetched package pi.extensions manifest.",
+        "license": "unknown: no license field or root LICENSE observed",
+        "cost": "Large collection, external binary and provider stack, license unclear.",
+        "reason": "Do not recommend whole bundle; advertised feature and shipped activation contract must be checked separately."
+      }
+    },
+    {
+      "candidate": "pi-subagents",
+      "researchArea": "execution",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-subagents",
+        "repo": "nicobailon/pi-subagents",
+        "commit": "56f247ac86169cfffa1af9a4c07997c33804bf9a",
+        "sourceURLs": [
+          "https://github.com/nicobailon/pi-subagents/blob/56f247ac86169cfffa1af9a4c07997c33804bf9a/src/runs/background/notify.ts",
+          "https://github.com/nicobailon/pi-subagents/blob/56f247ac86169cfffa1af9a4c07997c33804bf9a/src/runs/background/result-delivery-ownership.ts",
+          "https://github.com/nicobailon/pi-subagents/blob/56f247ac86169cfffa1af9a4c07997c33804bf9a/src/runs/shared/spawn-budget.ts",
+          "https://github.com/nicobailon/pi-subagents/blob/56f247ac86169cfffa1af9a4c07997c33804bf9a/src/api/background-work.ts"
+        ],
+        "evidenceLevel": "source-read",
+        "disposition": "comment-existing-160",
+        "license": "MIT",
+        "version": "0.66.0",
+        "compatibility": "Pi coding-agent *; pi-ai >=0.80.0; not runtime-tested"
+      }
+    },
+    {
+      "candidate": "@tintinweb/pi-subagents",
+      "researchArea": "execution",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "@tintinweb/pi-subagents",
+        "repo": "tintinweb/pi-subagents",
+        "commit": "e955e29c51b7a6cce37e1108cd2d6c57a77e151c",
+        "sourceURLs": [
+          "https://github.com/tintinweb/pi-subagents/blob/e955e29c51b7a6cce37e1108cd2d6c57a77e151c/src/agent-manager.ts",
+          "https://github.com/tintinweb/pi-subagents/blob/e955e29c51b7a6cce37e1108cd2d6c57a77e151c/src/workflow/journal.ts"
+        ],
+        "evidenceLevel": "source-read",
+        "disposition": "no-new-issue-overlap",
+        "license": "MIT",
+        "version": "0.19.0",
+        "compatibility": "Pi peers >=0.84.0; not runtime-tested"
+      }
+    },
+    {
+      "candidate": "pi-background-tasks",
+      "researchArea": "execution",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-background-tasks",
+        "repo": "ismailsaleekh/pi-background-tasks",
+        "commit": "14aa4ef382952f073bd4d540f57d6e8e3c2789a2",
+        "sourceURLs": [
+          "https://github.com/ismailsaleekh/pi-background-tasks/blob/14aa4ef382952f073bd4d540f57d6e8e3c2789a2/src/core/delegate/result-package.ts",
+          "https://github.com/ismailsaleekh/pi-background-tasks/blob/14aa4ef382952f073bd4d540f57d6e8e3c2789a2/src/core/durable-fs.ts",
+          "https://github.com/ismailsaleekh/pi-background-tasks/blob/14aa4ef382952f073bd4d540f57d6e8e3c2789a2/src/core/registry.ts"
+        ],
+        "evidenceLevel": "source-read",
+        "disposition": "comment-existing-160-196",
+        "license": "ISC",
+        "version": "2.5.0",
+        "compatibility": "Node >=22.19.0; Pi peers ^0.81.1 || ^0.82.1 || ^0.83.0 || ^0.84.0 exclude 0.85.1"
+      }
+    },
+    {
+      "candidate": "@aliou/pi-processes",
+      "researchArea": "execution",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "@aliou/pi-processes",
+        "repo": "aliou/pi-processes",
+        "commit": "f155117d6a0cb644b316dbf99676956400527754",
+        "sourceURLs": [
+          "https://github.com/aliou/pi-processes/blob/f155117d6a0cb644b316dbf99676956400527754/extensions/processes/notifications/service.ts",
+          "https://github.com/aliou/pi-processes/blob/f155117d6a0cb644b316dbf99676956400527754/extensions/processes/notifications/registry.ts"
+        ],
+        "evidenceLevel": "source-read",
+        "disposition": "no-new-issue-overlap",
+        "license": "MIT",
+        "version": "0.12.0",
+        "compatibility": "Node >=22.19.0; Pi peers *; not runtime-tested"
+      }
+    },
+    {
+      "candidate": "pi-interactive-subagents",
+      "researchArea": "execution",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-interactive-subagents",
+        "repo": "HazAT/pi-interactive-subagents",
+        "commit": "c100577ebf7393a11d098ad9810ec6c269dcfc30",
+        "sourceURLs": [
+          "https://github.com/HazAT/pi-interactive-subagents/blob/c100577ebf7393a11d098ad9810ec6c269dcfc30/pi-extension/subagents/activity.ts",
+          "https://github.com/HazAT/pi-interactive-subagents/blob/c100577ebf7393a11d098ad9810ec6c269dcfc30/pi-extension/subagents/status.ts"
+        ],
+        "evidenceLevel": "source-read",
+        "disposition": "research-reference-existing-196",
+        "license": "MIT",
+        "version": "3.7.2",
+        "compatibility": "Legacy @mariozechner Pi peers; requires cmux/tmux/zellij/WezTerm; no current-runtime test"
+      }
+    },
+    {
+      "candidate": "@quintinshaw/pi-dynamic-workflows",
+      "researchArea": "execution",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "@quintinshaw/pi-dynamic-workflows",
+        "repo": "QuintinShaw/pi-dynamic-workflows",
+        "commit": "1c0f7462aa8a007afb8112f073887590a57ea82d",
+        "sourceURLs": [
+          "https://github.com/QuintinShaw/pi-dynamic-workflows/blob/1c0f7462aa8a007afb8112f073887590a57ea82d/src/worktree.ts",
+          "https://github.com/QuintinShaw/pi-dynamic-workflows/blob/1c0f7462aa8a007afb8112f073887590a57ea82d/src/usage-limit-scheduler.ts"
+        ],
+        "evidenceLevel": "source-read",
+        "disposition": "reject-direct-adoption-refresh",
+        "license": "MIT",
+        "version": "3.10.1",
+        "compatibility": "Pi coding-agent >=0.80.8; not runtime-tested"
+      }
+    },
+    {
+      "candidate": "pi-agent-bus",
+      "researchArea": "execution",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-agent-bus",
+        "repo": "kylebrodeur/pi-agent-bus",
+        "commit": "135706d797247efeca377c4637d8f94f8857d80b",
+        "sourceURLs": [
+          "https://github.com/kylebrodeur/pi-agent-bus/blob/135706d797247efeca377c4637d8f94f8857d80b/packages/pi-agent-bus-node/src/LLMProvider.ts",
+          "https://github.com/kylebrodeur/pi-agent-bus/blob/135706d797247efeca377c4637d8f94f8857d80b/packages/pi-agent-bus-node/src/Agent.ts"
+        ],
+        "evidenceLevel": "source-read",
+        "disposition": "reject-second-agent-runtime",
+        "license": "MIT",
+        "version": "0.1.7",
+        "compatibility": "No Pi compatibility declaration in root; abstract provider plus dummy implementation"
+      }
+    },
+    {
+      "candidate": "@gintasz/pi-neuralyzer",
+      "researchArea": "execution",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "@gintasz/pi-neuralyzer",
+        "repo": "gintasz/neuralyzer",
+        "commit": "5d5cf3ea206307f31c8592d1e79f4037c00a94d0",
+        "sourceURLs": [
+          "https://github.com/gintasz/neuralyzer/blob/5d5cf3ea206307f31c8592d1e79f4037c00a94d0/packages/pi-neuralyzer/src/index.ts",
+          "https://github.com/gintasz/neuralyzer/blob/5d5cf3ea206307f31c8592d1e79f4037c00a94d0/packages/pi-neuralyzer/package.json"
+        ],
+        "evidenceLevel": "source-read",
+        "disposition": "research-reference-existing-154",
+        "license": "MIT",
+        "version": "0.1.1",
+        "compatibility": "Node >=22; Pi >=0.79.0; not runtime-tested"
+      }
+    },
+    {
+      "candidate": "pi-crew",
+      "researchArea": "execution",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-crew",
+        "repo": "baphuongna/pi-crew",
+        "commit": "627f59c9c6891eb9c78307ca17d24907bd5dae79",
+        "sourceURLs": [
+          "https://github.com/baphuongna/pi-crew/blob/627f59c9c6891eb9c78307ca17d24907bd5dae79/src/workflows/topology-analyzer.ts",
+          "https://github.com/baphuongna/pi-crew/blob/627f59c9c6891eb9c78307ca17d24907bd5dae79/src/workflows/preflight-validator.ts"
+        ],
+        "evidenceLevel": "source-read",
+        "disposition": "research-reference-existing-197-381",
+        "license": "MIT",
+        "version": "0.10.3",
+        "compatibility": "Node >=22; Pi peers *; own workflow and broker; not runtime-tested"
+      }
+    },
+    {
+      "candidate": "@gotgenes/pi-subagents",
+      "researchArea": "execution",
+      "evidenceTier": "metadata",
+      "observation": {
+        "name": "@gotgenes/pi-subagents",
+        "repo": "gotgenes/pi-packages",
+        "commit": "6ee70e9f4571c2ae96b50e6105ad887c20d8d0a2",
+        "sourceURLs": [
+          "https://github.com/gotgenes/pi-packages/blob/6ee70e9f4571c2ae96b50e6105ad887c20d8d0a2/packages/pi-subagents/README.md",
+          "https://registry.npmjs.org/@gotgenes%2fpi-subagents/latest"
+        ],
+        "evidenceLevel": "readme-and-npm-metadata",
+        "disposition": "no-new-issue-overlap",
+        "license": "MIT",
+        "version": "21.4.5",
+        "compatibility": "Pi coding-agent >=0.81.0; not runtime-tested",
+        "identityCaveat": "pi.dev repo link points to stale standalone gotgenes/pi-subagents 1.0.0; npm metadata locates current monorepo"
+      }
+    },
+    {
+      "candidate": "@narumitw/pi-worktree",
+      "researchArea": "execution",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "@narumitw/pi-worktree",
+        "repo": "narumiruna/pi-extensions",
+        "commit": "09d0f4d4d8d31f506e6f2478a0060be5f5c31c09",
+        "sourceURLs": [
+          "https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/packages/pi-worktree/src/git.ts"
+        ],
+        "evidenceLevel": "source-read-and-openpi-production-reproduced",
+        "disposition": "new-P1-issue",
+        "license": "MIT",
+        "version": "0.51.7",
+        "compatibility": "Pi peers *; dev 0.85.0"
+      }
+    },
+    {
+      "candidate": "mitsupi",
+      "researchArea": "execution",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "mitsupi review",
+        "repo": "mitsuhiko/agent-stuff",
+        "commit": "122e2994adddb113c04764c5697217dae120fcc6",
+        "sourceURLs": [
+          "https://github.com/mitsuhiko/agent-stuff/blob/122e2994adddb113c04764c5697217dae120fcc6/extensions/review.ts"
+        ],
+        "evidenceLevel": "source-read",
+        "disposition": "comment-existing-154",
+        "license": "Apache-2.0",
+        "version": "1.6.0",
+        "compatibility": "Pi peer *; requires UI"
+      }
+    },
+    {
+      "candidate": "pi-ext",
+      "researchArea": "execution",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-ext review",
+        "repo": "tomsej/pi-ext",
+        "commit": "e132c44b3b06f88f7fcfb67b80c91698d8c1814f",
+        "sourceURLs": [
+          "https://github.com/tomsej/pi-ext/blob/e132c44b3b06f88f7fcfb67b80c91698d8c1814f/extensions/review/review.ts"
+        ],
+        "evidenceLevel": "source-read",
+        "disposition": "no-new-issue-derived-overlap",
+        "license": "Apache-2.0 (component); MIT (root)",
+        "version": "private 0.1.0",
+        "compatibility": "Pi ^0.82.0; legacy alias ^0.80.3; not runtime-tested"
+      }
+    },
+    {
+      "candidate": "pi-worktree-extension",
+      "researchArea": "execution",
+      "evidenceTier": "source",
+      "observation": {
+        "name": "pi-worktree-extension",
+        "repo": "AjayPoshak/pi-worktree-extension",
+        "commit": "50df0b2fb049e556758e6fb6b22d0f0016ff8b9b",
+        "sourceURLs": [
+          "https://github.com/AjayPoshak/pi-worktree-extension/blob/50df0b2fb049e556758e6fb6b22d0f0016ff8b9b/src/worktrees.ts"
+        ],
+        "evidenceLevel": "targeted-source-read",
+        "disposition": "observe-no-new-issue",
+        "license": "MIT",
+        "version": "1.0.7",
+        "compatibility": "Node >=22.19; Pi peers *; not runtime-tested"
+      }
+    }
+  ]
+}

--- a/docs/research/PI_COMMUNITY_ECOSYSTEM_2026-09-08.md
+++ b/docs/research/PI_COMMUNITY_ECOSYSTEM_2026-09-08.md
@@ -6,7 +6,7 @@
 - 范围：Web/IDE、外部工具与 MCP、Context/Memory、执行与 Worktree、安全与长任务体验。
 - 版本与证据清单：[候选清单](PI_COMMUNITY_ECOSYSTEM_2026-09-08.candidates.json)。GitHub 源码 SHA、源码 manifest 和 npm 发布版本分开记录。
 - 历史关系：补充 [2026-08-09 社区包审计](../design/PI_COMMUNITY_PACKAGE_AUDIT_2026-08-09.md)，不覆盖其历史结论；Supersedes: none。
-- 相关 Issue/Discussion/PR：见文末发布回执。所有公共跟踪项链接回本记录。
+- 相关 Issue/Discussion：见发布回执；文档 [Draft PR #479](https://github.com/openpi-dev/openpi/pull/479)。所有公共跟踪项链接回本记录。
 
 ## 结论
 
@@ -89,7 +89,29 @@ Node 26.3.0 / Git 2.50.1 的两种合成 fixture 中，直接调用生产 `recla
 
 ## 发布回执
 
-公开项在去重和回读后记录于此。研究记录与候选清单保留为独立文档变更，不改变运行时代码、默认配置或安装行为。
+已发布并逐条回读确认：**2 个新 Issue、5 篇 Ideas Discussion、9 条已有 Issue 评论、1 条已有 Discussion 评论**。已有关闭项保留关闭状态，只补充研究或回归证据。
+
+| 类型 | 主题 / 回执 |
+| --- | --- |
+| 新 Issue | [#472 bug(worktree): 自动回收会删除被 index flags 隐藏的未提交修改 [P1]](https://github.com/openpi-dev/openpi/issues/472) |
+| 新 Issue | [#473 feat(web): 支持从回答选区生成带来源和内容版本的反馈草稿](https://github.com/openpi-dev/openpi/issues/473) |
+| 新 Discussion | [#474 可恢复的工具结果折叠：怎样验证它比原生 compaction 更有价值？](https://github.com/openpi-dev/openpi/discussions/474) |
+| 新 Discussion | [#475 社区包风险收据：只读评估应由独立插件、Skill 还是 OpenPI 承担？](https://github.com/openpi-dev/openpi/discussions/475) |
+| 新 Discussion | [#476 长任务离开屏幕后：通知与保持唤醒应绑定哪个执行事实？](https://github.com/openpi-dev/openpi/discussions/476) |
+| 新 Discussion | [#477 Web 侧问：怎样呈现已有 Pi-native /btw 而不污染主上下文？](https://github.com/openpi-dev/openpi/discussions/477) |
+| 新 Discussion | [#478 外部检索的来源展示：何时值得增加可回查原文的证据入口？](https://github.com/openpi-dev/openpi/discussions/478) |
+| Issue 补充 | [#343 原生 Web 交互适配](https://github.com/openpi-dev/openpi/issues/343#issuecomment-5577485330) |
+| Issue 补充 | [#345 产物授权与版本预览](https://github.com/openpi-dev/openpi/issues/345#issuecomment-5577485973) |
+| Issue 补充 | [#169 MCP 逐调用权限与兼容试点](https://github.com/openpi-dev/openpi/issues/169#issuecomment-5577486546) |
+| Issue 补充 | [#163 LSP 单请求与共享池](https://github.com/openpi-dev/openpi/issues/163#issuecomment-5577486898) |
+| Issue 补充 | [#168 Pi 原生 DAP 候选](https://github.com/openpi-dev/openpi/issues/168#issuecomment-5577487575) |
+| Issue 补充 | [#349 会话检索源锚点与增量失效](https://github.com/openpi-dev/openpi/issues/349#issuecomment-5577488155) |
+| Issue 补充 | [#156 Cache / usage 统计口径](https://github.com/openpi-dev/openpi/issues/156#issuecomment-5577488531) |
+| Issue 补充 | [#167 可恢复删除与快照失效](https://github.com/openpi-dev/openpi/issues/167#issuecomment-5577488981) |
+| Issue 补充 | [#160 后台终态、投递与消费收据](https://github.com/openpi-dev/openpi/issues/160#issuecomment-5577489557) |
+| Discussion 补充 | [#381 ACP / Agent provider / 草稿 prefill](https://github.com/openpi-dev/openpi/discussions/381#discussioncomment-18339579) |
+
+文档变更：[Draft PR #479](https://github.com/openpi-dev/openpi/pull/479)。仓库验证：`bun run check` 通过；`bun run test` 通过（Node 1461 passed / 1 skipped / 0 failed，Web Vitest 113 passed）；JSON 可解析、相对链接和 diff whitespace 检查通过。以上检查只验证仓库文档变更的交付，不证明社区方案运行兼容或采用收益。
 
 <!-- publication-receipts -->
 

--- a/docs/research/PI_COMMUNITY_ECOSYSTEM_2026-09-08.md
+++ b/docs/research/PI_COMMUNITY_ECOSYSTEM_2026-09-08.md
@@ -1,0 +1,173 @@
+# Pi 社区能力研究：值得学习的机制与验证入口
+
+- 状态：`validated`，仅指下列来源、源码路径和隔离 Git 探针经过核对；采用建议仍是提案，不是已采纳的 Decision。
+- 创建日期 / 最后核实：2026-09-08。
+- OpenPI 对照：`ed9dbc1018f890fd54375f5371990ddfee8af5df`；开发 Pi 基线 `0.85.1`。
+- 范围：Web/IDE、外部工具与 MCP、Context/Memory、执行与 Worktree、安全与长任务体验。
+- 版本与证据清单：[候选清单](PI_COMMUNITY_ECOSYSTEM_2026-09-08.candidates.json)。GitHub 源码 SHA、源码 manifest 和 npm 发布版本分开记录。
+- 历史关系：补充 [2026-08-09 社区包审计](../design/PI_COMMUNITY_PACKAGE_AUDIT_2026-08-09.md)，不覆盖其历史结论；Supersedes: none。
+- 相关 Issue/Discussion/PR：见文末发布回执。所有公共跟踪项链接回本记录。
+
+## 结论
+
+优先学习能够补齐 OpenPI 真实任务路径的小机制：原生交互请求能够在 Web 回答、生成的产物能够领取并检查版本、选中的原文能够成为可审阅的反馈草稿、历史结果能够定位到源消息、后台完成能够留下投递收据。
+
+本轮还从社区 Worktree 实现中发现了 OpenPI 的具体数据保全缺口：`assume-unchanged` / `skip-worktree` 可以让修改从 status 中消失，当前 `reclaimWorktree` 会成功删除合成修改内容。这个问题具有直接生产函数证据，应独立修复。
+
+社区包的数量、下载量、README 功能或 peer 通配范围不证明质量及当前兼容性。没有推荐批量安装，没有修改用户包配置，没有运行第三方插件或付费模型。学习一个机制不要求采用它的所有工具、存储、后台进程和默认策略。
+
+## 方法与证据等级
+
+本轮共 74 条方向研究记录，合并同名包/集合后为 **70 个包或扩展候选**；其中 **49 个候选阅读了具体实现源码**，其余核对文档与发布元数据。源码阅读包含针对性检查，不能理解为 49 个整包完成深度审计或运行验收。
+
+发现入口包括 [Pi Package Catalog](https://pi.dev/packages) 和 [BubblePtr/awesome-pi 固定目录](https://github.com/BubblePtr/awesome-pi/blob/bed430639d03e3cbf8588e6ff5ef5104574c1401/README.md)。后者提取出 146 条目录线索，仅用于发现，不把它们全部算作已审查插件。目录当前展示约 5.4k 包，这不是本轮完整覆盖范围。
+
+[qualisero 的当前 README](https://github.com/qualisero/awesome-pi-agent/blob/d2ffdd4433fc4f64a59c8ffbb9a344a32ee669a7/README.md) 已声明过时并退休，不能使用旧搜索快照当现状。每个入选候选继续核对维护者仓库、发布 manifest 或公开发布源码。包目录、npm repository 字段、GitHub HEAD 和 npm tarball 可能不一致。
+
+- `metadata`：维护者 README、manifest、版本及许可声明核对，不证明实现或运行结果。
+- `source`：阅读固定源码中的具体控制、存储或交互路径，不证明整包兼容、无缺陷或用户收益。
+- `fixture`：仅 Worktree 项执行隔离合成 Git 仓库及 OpenPI 生产函数，分别检查回执、磁盘文件和分支。
+- `runtime acceptance / benchmark`：本轮没有第三方插件运行验收、跨平台认证、模型效果或成本 Benchmark。声明支持的版本范围与实际通过测试的版本不同。
+
+独立复核检查了关键提案、已有 Issue/Discussion 和探针记录，纠正了“已有 TUI /btw 被描述成新能力”、Memory 研究建议被当作已采纳约束、以及 registry/latest 引用漂移等问题。独立复核没有重跑删除探针，也不构成第二次运行认证。
+
+## 确定有价值的工作
+
+### 1. Worktree 自动回收必须识别被 index 隐藏的修改
+
+OpenPI [status/ignored 检查与回收](https://github.com/openpi-dev/openpi/blob/ed9dbc1018f890fd54375f5371990ddfee8af5df/extensions/shared/worktree.ts#L383-L487) 没有检查 index flags。[`@narumitw/pi-worktree`](https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/packages/pi-worktree/src/git.ts#L658-L695) 将隐藏 tracked 内容视为需要保留的数据，提供了可借鉴的检查机制。
+
+Node 26.3.0 / Git 2.50.1 的两种合成 fixture 中，直接调用生产 `reclaimWorktree` 均返回 `removed:true, branchDeleted:true, dirty:false, ignored:false, commits:0`；独立检查确认修改文件、worktree 目录和分支消失。这不是声称标记会自动从父 checkout 继承，也不是 ignored 文件问题。没有运行完整 Child/Workflow 生命周期。
+
+应先保证 unknown/index inventory 失败时保留数据，不为检查清除用户标记，不自动 reset/clean。普通 sparse checkout 的安全回收是另一项需要证明的边界。[规范化探针回执](PI_COMMUNITY_WORKTREE_INDEX_FLAGS_2026-09-08.json)保留固定源码与两组执行结果。
+
+### 2. Web 需要能回应 Pi 原生交互的适配层
+
+[`@jmfederico/pi-web`](https://github.com/jmfederico/pi-web/blob/182c5ade390fc4c31189f44f0daf518817c74e71/src/server/sessions/piSessionService.ts#L1824-L1904) 将 confirm/select/input 转成有 Session 身份的 pending request、浏览器事件与等待中的 Promise。超时、abort、Session teardown 关闭准确请求；[等待器](https://github.com/jmfederico/pi-web/blob/182c5ade390fc4c31189f44f0daf518817c74e71/src/server/sessions/extensionDialogWaiters.ts#L28-L101)与可观察状态分离。
+
+这给 [#343](https://github.com/openpi-dev/openpi/issues/343) 提供具体实现样本。回复需绑定 Session/runtime epoch/request id，刷新只恢复投影，过期/重复答复不得授权。原生三种简单请求不等于任意 `ui.custom` 界面都可用，OpenPI ask_user 等自定义 UI 需要独立适配或明确不支持。Pi 和原扩展继续拥有权限规则，不引入社区项目的独立 daemon 或多机器控制面。
+
+### 3. 产物访问、版本与反馈应形成完整路径
+
+[`pi-studio` 的资源 grant](https://github.com/omaclaren/pi-studio/blob/e04fc7aa3275b0f3f69cbbc0cbc7393a58b9f4bd/shared/studio-resource-grants.js#L5-L164)区分精确文件和目录；[watcher](https://github.com/omaclaren/pi-studio/blob/e04fc7aa3275b0f3f69cbbc0cbc7393a58b9f4bd/shared/studio-file-watcher.js#L25-L95)用内容 revision 判断更新。[pi-markdown-preview](https://github.com/omaclaren/pi-markdown-preview/blob/273bc5af58095a76c9a02f42ab642aa2e5d5f9f9/index.ts#L4872-L4892)明确展示上次可用预览与清理失败。
+
+已有 [#345](https://github.com/openpi-dev/openpi/issues/345) 应先完成 Session/workspace 归属的只读产物入口：生成 → 预览/下载 → 修改 → 看见新版本。relative link 按产物目录解析，认证由宿主处理；不能开放任意本地路径。可编辑文件浏览器后置，内容版本检查不应被表述为解决了全部文件系统竞态。
+
+新建的窄功能提案是：已完成回答中的选区 → 带原文、message/Session 身份和内容版本的反馈草稿 → 用户显式发送。[Plannotator 的选区数据](https://github.com/backnotprop/plannotator/blob/9c85310151feb335cb8a8e74beae79349873382d/packages/ui/types.ts#L61-L85)与[反馈导出](https://github.com/backnotprop/plannotator/blob/9c85310151feb335cb8a8e74beae79349873382d/packages/ui/utils/parser.ts#L1442-L1462)是参考；其[锚点漂移限制](https://github.com/backnotprop/plannotator/blob/9c85310151feb335cb8a8e74beae79349873382d/packages/ui/HANDOFF.md#L258-L285)也应进入验收。先解决引用与草稿归属，不自动发消息、批准 Plan 或创建审阅 Agent。
+
+### 4. 现有研究 Issue 可以落到具体对照对象
+
+| 跟踪 | 本轮新增对照 | 应验证的机制与反例 |
+| --- | --- | --- |
+| [#169 外部能力](https://github.com/openpi-dev/openpi/issues/169) | [pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-adapter/blob/8243eba3421e301c88c047444f34ab7d5d57163e/tool-approval.ts#L91-L182) | 独立配置、逐内部调用 broker、owner 取消；顶层 `mcp` 同名不能证明读写权限相同 |
+| [#163 LSP](https://github.com/openpi-dev/openpi/issues/163) | [pi-lsp 单请求 scope](https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/packages/pi-lsp/src/session-lifecycle.ts#L24-L57)、[pi-lsp-client 共享池](https://github.com/code-yeongyu/pi-lsp-client/blob/1c981dfcacc456fe4ce9f4120a2f0250b54d6844/src/lsp/manager.ts) | 比较冷/热开销、诊断新鲜度、取消与清理；不直接复制六个常驻工具/自动安装 |
+| [#168 DAP](https://github.com/openpi-dev/openpi/issues/168) | [lsp-pi 的原生 Pi DAP 入口](https://github.com/trotsky1997/pi-lsp-extension/blob/39d56f0cdaf4b5e77ee038f0670de14cd19e228d/debug.ts#L1-L16) | 可以降低实验成本；旧依赖、全局 manager、attach/evaluate/写内存仍需收窄和适配 |
+| [#349 历史搜索](https://github.com/openpi-dev/openpi/issues/349) | [pi-session-search 增量 FTS](https://github.com/samfoy/pi-session-search/blob/30acb79abc225ac1907d67eeed1eeb1079890431/src/fts-index.ts#L89-L165)、[hermes 源锚点](https://github.com/chandra447/pi-hermes-memory/blob/34c6fe49f832e6a0957ce517586158a8bdde71a4/src/store/session-anchor-search.ts#L1-L120) | 索引可重建、结果能回原消息；同 size 修改、CJK、超长单行、总扫描预算必须验收 |
+| [#156 Cache 诊断](https://github.com/openpi-dev/openpi/issues/156) | [pi-cache-graph](https://github.com/championswimmer/pi-cache-graph/blob/40c5ae469c3956f7aba7fadc40f64391c1c74706/src/session-data.ts) | 借鉴 active branch / whole tree 的口径展示；OpenPI 已有逐 turn tracker，且已统计更多 usage-bearing entry，不能照搬而回退 |
+| [#167 Durable Learning](https://github.com/openpi-dev/openpi/issues/167) | [pi-memory forget/restore](https://github.com/jayzeng/pi-memory/blob/39e6b998a2279c8fad4a2c6c64e26828c1d6023e/index.ts#L2113-L2195) | 未来若证明值得采用，应可恢复删除、立即失效旧注入快照；本轮不决定建立 Memory 系统 |
+| [#160 后台投递](https://github.com/openpi-dev/openpi/issues/160) | Pi 社区后台任务与 Subagent 的 owner / delivery 实现，见候选清单 | producer 终态、transport 接收、消费收据分别记录；借鉴持久回执，不统一执行状态机 |
+| [Discussion #381 互操作](https://github.com/openpi-dev/openpi/discussions/381) | [pi-acp](https://github.com/svkozak/pi-acp/blob/d1cffc047ab37a096ee70ca39cfc1de463db8d12/src/acp/session.ts#L871-L965)、[pi-nvim-context prefill](https://github.com/omaclaren/pi-nvim-context/blob/b3d5bc991dbe125a1173850a6a5927eb632e3e73/index.ts#L345-L368) | 区分协议映射、Agent-as-provider、仅追加草稿；工具已执行的投影不能触发二次执行 |
+
+## 先讨论、再用实验决定的方向
+
+1. **可恢复的工具结果折叠。** [pi-fold 的 bounded peek](https://github.com/shaneconner/fold/blob/7eb2ab47e291f4616ba4850e3648724fa5600a16/extensions/lib/folding.ts#L1414-L1478)与 [pi-context-prune](https://github.com/championswimmer/pi-context-prune/blob/92c80e6e26e3dbfcecbe16675c9e192d4dcd85af/src/pruner.ts)可比较 pending/commit、摘要及按需回读。基线是现有 Pi compaction/pivot；必须计入 summarizer、缓存改写、回读和 child 成本，并验证 tool call/result 配对与源引用权限。上下文变短不是收益结论。
+2. **包产物风险收据。** [pi-vetter](https://github.com/jesset/pi-vetter/blob/7e620ca5c6a3d09dba3badaab5664d0bc5ba9568/src/install/gated-installer.ts)绑定版本、integrity、基线与文件摘要。应先比较独立包、Skill/维护者流程、只读诊断的价值；Pi 继续拥有安装更新。扫描 incomplete、来源不匹配、签名无法验证必须分别呈现，不能把 ALLOW 当安全担保，安装后对比也不能阻止已执行的脚本。
+3. **长任务通知与保持唤醒。** [notify](https://github.com/mitsuhiko/agent-stuff/blob/122e2994adddb113c04764c5697217dae120fcc6/extensions/notify.ts)和 [pi-caffeinate](https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/packages/pi-caffeinate/src/caffeinate.ts)提供小机制。需证明父 idle/child active、多个 Session、迟到获取、shutdown、权限拒绝下 owner 与通知不失真。`agent_end` 不等于 Goal/Workflow 完成，通知请求不等于已送达。
+4. **Web 呈现已有 /btw。** OpenPI 已有 TUI 旁问和非主模型 context 的持久记录。借 [pi-btw](https://github.com/dbachelder/pi-btw/blob/4f858102706910ee9d520a9666832f3103631b61/README.md)和 Pi Studio 比较一次侧问、多轮面板、显式 Bring to main，先证明比普通追问/fork 更有价值。社区侧 Session 的 write/bash 权限不能当只读模板。
+5. **可回查原文的来源展示。** [pi-web-access 的 source/passages](https://github.com/nicobailon/pi-web-access/blob/811ef82a6dd04fe4abd73fa40b079aa39ee1870d/source-check.ts#L11-L54)保留抓取版本、hash、offset 与错误。值得验证最小来源展示能否减少用户核对步骤；其 supported/contradicted/confidence 是[英文词重叠启发式](https://github.com/nicobailon/pi-web-access/blob/811ef82a6dd04fe4abd73fa40b079aa39ee1870d/source-check.ts#L162-L214)，不能变成 OpenPI 的事实认证。
+
+另外两个候选保留在研究清单，不为数量额外发帖：登录态浏览器与隔离 QA 浏览器的先后顺序；AST package 与 Skill 调用同一个已安装 binary 的收益对照。已有 #169/#165 可以承接它们的后续证据。
+
+## 当前不建议整体采用的情况
+
+- 已有 Subagent/Workflow/Tasks/Goal/Plan/Footer 的重复实现；更多 agent 数量、固定流程和独立 daemon 不是增益证明。
+- Browser/PTY/Memory 包中额外的后台 worker、直接模型调用、自动下载、cloud embedding 或自动 context 注入；这些成本必须显式决定。
+- Bash-only sandbox 不等于约束整个 Agent，初始化失败退回普通 Bash 不能用于强制隔离承诺。模型 authorizer 或正则 guard 也不能成为系统隔离根。
+- 源码与发布产物不同：pi-mcp-adapter 源码允许 Pi AI 0.85，而本轮 [npm 2.32.1](https://registry.npmjs.org/pi-mcp-adapter/2.32.1)只声明 `^0.84.1`；实际兼容仍未验证。
+- `@gotgenes/pi-subagents` 的目录 repo 与 npm 当前 monorepo 不同；`@ollama/pi-web-search` 发布源码仍有旧 Pi imports，声称的 repo 本轮 404；这些都是来源身份限制，不应推断维护者动机。
+- context-mode 的 ELv2、Hypa 的 FSL-1.1-ALv2 与 MIT 不同；某些包只有 manifest 许可声明而没有找到 LICENSE。清单保留证据层级，不据此宣布代码可随意复制。
+
+## 发布回执
+
+公开项在去重和回读后记录于此。研究记录与候选清单保留为独立文档变更，不改变运行时代码、默认配置或安装行为。
+
+<!-- publication-receipts -->
+
+<!-- candidate-index -->
+
+## 候选索引
+
+字段、版本、许可证据、兼容限制和取舍详情见 JSON 清单；本表只提供可浏览入口。
+
+| 候选 | 方向 | 已读证据 |
+| --- | --- | --- |
+| [@aliou/pi-guardrails](https://github.com/aliou/pi-guardrails/blob/e27e4bf96e18497436c2580fd9d0548bc7e2608d/package.json) | 安全/体验 | 实现源码（未运行） |
+| [@aliou/pi-processes](https://github.com/aliou/pi-processes/blob/f155117d6a0cb644b316dbf99676956400527754/extensions/processes/notifications/service.ts) | 执行 | 实现源码（未运行） |
+| [@code-yeongyu/pi-ast-grep](https://github.com/code-yeongyu/pi-ast-grep/blob/4a7d1beee684d96a6890e5fc55710bb63fecca85/src/ast-grep/tools.ts) | 外部工具 | 实现源码（未运行） |
+| [@code-yeongyu/pi-webfetch](https://github.com/code-yeongyu/pi-webfetch/blob/ee045140cbaa784eec420bc0a7bc7d7eec0b7043/README.md) | 外部工具 | README/manifest |
+| [@code-yeongyu/pi-websearch](https://github.com/code-yeongyu/pi-websearch/blob/ddf5f5d21de57ee3e80f1a6f96aff21a9dd34662/README.md) | 外部工具 | README/manifest |
+| [@czottmann/pi-automode](https://github.com/czottmann/pi-automode/blob/d556f006bd705d4eddc5c49ce4fcc8d9b82c1657/package.json) | 安全/体验 | README/manifest |
+| [@gintasz/pi-neuralyzer](https://github.com/gintasz/neuralyzer/blob/5d5cf3ea206307f31c8592d1e79f4037c00a94d0/README.md) | 上下文、执行 | 实现源码（未运行） |
+| [@gotgenes/pi-permission-model-judge](https://github.com/gotgenes/pi-packages/blob/6ee70e9f4571c2ae96b50e6105ad887c20d8d0a2/packages/pi-permission-model-judge/package.json) | 安全/体验 | README/manifest |
+| [@gotgenes/pi-permission-system](https://github.com/gotgenes/pi-packages/blob/6ee70e9f4571c2ae96b50e6105ad887c20d8d0a2/packages/pi-permission-system/package.json) | 安全/体验 | 实现源码（未运行） |
+| [@gotgenes/pi-subagents](https://github.com/gotgenes/pi-packages/blob/6ee70e9f4571c2ae96b50e6105ad887c20d8d0a2/packages/pi-subagents/README.md) | 执行 | README/manifest |
+| [@hypabolic/pi-hypa](https://github.com/Hypabolic/Hypa/blob/2678616e62f1f2a8d2ae0904f88859c3f19df860/packages/pi-hypa/README.md) | 上下文 | README/manifest |
+| [@jmfederico/pi-web](https://github.com/jmfederico/pi-web/tree/182c5ade390fc4c31189f44f0daf518817c74e71) | Web/IDE | 实现源码（未运行） |
+| [@juicesharp/rpiv-web-tools](https://github.com/juicesharp/rpiv-mono/blob/338b264c1ca4fd8828cc849b632f4f7ad88d2e78/packages/rpiv-web-tools/README.md) | 外部工具 | README/manifest |
+| [@juvio15/pi-ast-grep](https://registry.npmjs.org/@juvio15/pi-ast-grep/-/pi-ast-grep-0.4.2.tgz) | 外部工具 | 实现源码（未运行） |
+| [@narumitw/pi-caffeinate](https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/packages/pi-caffeinate/package.json) | 安全/体验 | 实现源码（未运行） |
+| [@narumitw/pi-chrome-devtools](https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/packages/pi-chrome-devtools/README.md) | 外部工具 | README/manifest |
+| [@narumitw/pi-firecrawl](https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/packages/pi-firecrawl/README.md) | 外部工具 | README/manifest |
+| [@narumitw/pi-lsp](https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/packages/pi-lsp/src/pi-lsp.ts) | 外部工具 | 实现源码（未运行） |
+| [@narumitw/pi-retry](https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/deprecated/pi-retry/README.md) | 安全/体验 | README/manifest |
+| [@narumitw/pi-worktree](https://github.com/narumiruna/pi-extensions/blob/09d0f4d4d8d31f506e6f2478a0060be5f5c31c09/packages/pi-worktree/src/git.ts) | 执行 | 实现源码（未运行） |
+| [@ollama/pi-web-search](https://pi.dev/packages/@ollama/pi-web-search) | 外部工具 | 实现源码（未运行） |
+| [@plannotator/pi-extension](https://github.com/backnotprop/plannotator/tree/9c85310151feb335cb8a8e74beae79349873382d) | Web/IDE | 实现源码（未运行） |
+| [@quintinshaw/pi-dynamic-workflows](https://github.com/QuintinShaw/pi-dynamic-workflows/blob/1c0f7462aa8a007afb8112f073887590a57ea82d/src/worktree.ts) | 执行 | 实现源码（未运行） |
+| [@samfp/pi-memory](https://github.com/samfoy/pi-memory/blob/da1f96d55706db07f39c3767b84890e89298d5f2/README.md) | 上下文 | README/manifest |
+| [@tintinweb/pi-subagents](https://github.com/tintinweb/pi-subagents/blob/e955e29c51b7a6cce37e1108cd2d6c57a77e151c/src/agent-manager.ts) | 执行 | 实现源码（未运行） |
+| [@tintinweb/vscode-pi-model-chat-provider](https://github.com/tintinweb/vscode-pi-model-chat-provider/tree/95d8de3f272a1a491e36a76bba04095d0e927563) | Web/IDE | 实现源码（未运行） |
+| [@trim21/personal-pi-extensions](https://github.com/trim21/pi-extensions/blob/79d7f01c4b4c42a6125e368eefcee66c21992058/package.json) | 安全/体验 | README/manifest |
+| [betterwright](https://github.com/BetterWright/betterwright/blob/b9f73fc8672750b7e2d67c6dc1c988a5ab2213ba/README.md) | 外部工具 | 实现源码（未运行） |
+| [cc-safety-net](https://github.com/kenryu42/cc-safety-net/blob/10326fac666de7ca515e3492820242eadc316916/package.json) | 安全/体验 | README/manifest |
+| [context-mode](https://github.com/mksglu/context-mode/blob/33f7eb90f17bbe1b7c39aa126b989b6fa73850c8/README.md) | 上下文 | README/manifest |
+| [filter-output](https://github.com/michalvavra/agents/blob/c355e3c358fbef4122141ee51d8887fe273ff8b6/agents/pi/extensions/filter-output.ts) | 安全/体验 | 实现源码（未运行） |
+| [gentle-engram](https://github.com/Gentleman-Programming/engram/blob/869a3fb3aecc8353d95d2a47b108075e9398ecc1/plugin/pi/README.md) | 上下文 | README/manifest |
+| [lsp-pi](https://github.com/trotsky1997/pi-lsp-extension/blob/39d56f0cdaf4b5e77ee038f0670de14cd19e228d/debug.ts) | 外部工具 | 实现源码（未运行） |
+| [mitsupi](https://github.com/mitsuhiko/agent-stuff/tree/122e2994adddb113c04764c5697217dae120fcc6) | Web/IDE、安全/体验、执行 | 实现源码（未运行） |
+| [permission-pi / pi-hooks permission](https://github.com/prateekmedia/pi-hooks/blob/5590a3bacbbdd055fb49d2ca031abe2c9f3e6c25/permission/README.md) | 安全/体验 | 实现源码（未运行） |
+| [pi-acp](https://github.com/svkozak/pi-acp/tree/d1cffc047ab37a096ee70ca39cfc1de463db8d12) | Web/IDE | 实现源码（未运行） |
+| [pi-agent](https://github.com/Zetaphor/pi-vscode-extension/tree/526df5ead8e0104ea5d176bb5e6fa25e6d75844a) | Web/IDE | 实现源码（未运行） |
+| [pi-agent-browser-native](https://github.com/fitchmultz/pi-agent-browser-native/blob/3d4f36904ff0bc6baa24cb1116b3fe42bbc2f443/README.md) | 外部工具 | 实现源码（未运行） |
+| [pi-agent-bus](https://github.com/kylebrodeur/pi-agent-bus/blob/135706d797247efeca377c4637d8f94f8857d80b/packages/pi-agent-bus-node/src/LLMProvider.ts) | 执行 | 实现源码（未运行） |
+| [pi-background-tasks](https://github.com/ismailsaleekh/pi-background-tasks/blob/14aa4ef382952f073bd4d540f57d6e8e3c2789a2/src/core/delegate/result-package.ts) | 执行 | 实现源码（未运行） |
+| [pi-btw](https://github.com/dbachelder/pi-btw/tree/4f858102706910ee9d520a9666832f3103631b61) | Web/IDE | 实现源码（未运行） |
+| [pi-cache-graph](https://github.com/championswimmer/pi-cache-graph/blob/40c5ae469c3956f7aba7fadc40f64391c1c74706/src/session-data.ts) | 上下文 | 实现源码（未运行） |
+| [pi-chrome](https://github.com/tianrendong/pi-chrome/blob/017ff4b9a639f0b8b213e58a3f30613fc38edcc8/README.md) | 外部工具 | 实现源码（未运行） |
+| [pi-context-prune](https://github.com/championswimmer/pi-context-prune/blob/92c80e6e26e3dbfcecbe16675c9e192d4dcd85af/src/pruner.ts) | 上下文 | 实现源码（未运行） |
+| [pi-crew](https://github.com/baphuongna/pi-crew/blob/627f59c9c6891eb9c78307ca17d24907bd5dae79/src/workflows/topology-analyzer.ts) | 执行 | 实现源码（未运行） |
+| [pi-ext](https://github.com/tomsej/pi-ext/tree/e132c44b3b06f88f7fcfb67b80c91698d8c1814f) | Web/IDE、执行 | 实现源码（未运行） |
+| [pi-fold](https://github.com/shaneconner/fold/blob/7eb2ab47e291f4616ba4850e3648724fa5600a16/extensions/active-context.ts#L3327-L3331) | 上下文 | 实现源码（未运行） |
+| [pi-hermes-memory](https://github.com/chandra447/pi-hermes-memory/blob/34c6fe49f832e6a0957ce517586158a8bdde71a4/src/prompt-context.ts) | 上下文 | 实现源码（未运行） |
+| [pi-interactive-shell](https://github.com/nicobailon/pi-interactive-shell/tree/eedb89a9e4618d7416326d9387085a756a2125ee) | Web/IDE | README/manifest |
+| [pi-interactive-subagents](https://github.com/HazAT/pi-interactive-subagents/blob/c100577ebf7393a11d098ad9810ec6c269dcfc30/pi-extension/subagents/activity.ts) | 执行 | 实现源码（未运行） |
+| [pi-lean-ctx](https://github.com/yvgude/lean-ctx/blob/e710e85a2f4782f3d8732fcda38ae9ee7a772e05/packages/pi-lean-ctx/README.md) | 上下文 | README/manifest |
+| [pi-lens](https://github.com/apmantza/pi-lens/blob/d0d853218f01be917c4f2608820584a8c167253b/docs/settings.md) | 外部工具 | 实现源码（未运行） |
+| [pi-lsp-client](https://github.com/code-yeongyu/pi-lsp-client/blob/1c981dfcacc456fe4ce9f4120a2f0250b54d6844/src/lsp/manager.ts) | 外部工具 | 实现源码（未运行） |
+| [pi-markdown-preview](https://github.com/omaclaren/pi-markdown-preview/tree/273bc5af58095a76c9a02f42ab642aa2e5d5f9f9) | Web/IDE | 实现源码（未运行） |
+| [pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-adapter/blob/8243eba3421e301c88c047444f34ab7d5d57163e/README.md) | 外部工具 | 实现源码（未运行） |
+| [pi-memory](https://github.com/jayzeng/pi-memory/blob/39e6b998a2279c8fad4a2c6c64e26828c1d6023e/index.ts#L1385-L1419) | 上下文 | 实现源码（未运行） |
+| [pi-memory-honcho](https://github.com/acsezen/pi-memory-honcho/blob/9439404513e7650fc215bfeb30bd03bad72bd33a/README.md) | 上下文 | README/manifest |
+| [pi-nvim-context](https://github.com/omaclaren/pi-nvim-context/tree/b3d5bc991dbe125a1173850a6a5927eb632e3e73) | Web/IDE | 实现源码（未运行） |
+| [pi-sandbox](https://github.com/carderne/pi-sandbox/blob/079be62e8de18665cdd9b810a879d419a00a8565/package.json) | 安全/体验 | 实现源码（未运行） |
+| [pi-session-search](https://github.com/samfoy/pi-session-search/blob/30acb79abc225ac1907d67eeed1eeb1079890431/src/fts-index.ts#L89-L165) | 上下文 | 实现源码（未运行） |
+| [pi-sessions](https://github.com/thurstonsand/pi-sessions/blob/7197e8a609a2f33dc8a3610a6cf3a4ba3823592d/README.md) | 上下文 | README/manifest |
+| [pi-smart-fetch](https://github.com/Thinkscape/agent-smart-fetch/blob/b01116124971de44f16a4477e34c06ba2ab1d0bf/packages/pi-smart-fetch/README.md) | 外部工具 | README/manifest |
+| [pi-studio](https://github.com/omaclaren/pi-studio/tree/e04fc7aa3275b0f3f69cbbc0cbc7393a58b9f4bd) | Web/IDE | 实现源码（未运行） |
+| [pi-subagents](https://github.com/nicobailon/pi-subagents/blob/56f247ac86169cfffa1af9a4c07997c33804bf9a/src/runs/background/notify.ts) | 执行 | 实现源码（未运行） |
+| [pi-usage-widget](https://github.com/cullendotdev/pi-usage-widget/blob/976d3dfc11bbb1a5a2cacd05d9a00963d5e15bc7/README.md) | 上下文 | README/manifest |
+| [pi-verdict](https://github.com/jesset/pi-verdict/blob/1386a9521681b6f8e4ef1a445d6f13beb0212d57/package.json) | 安全/体验 | 实现源码（未运行） |
+| [pi-vetter](https://github.com/jesset/pi-vetter/blob/7e620ca5c6a3d09dba3badaab5664d0bc5ba9568/package.json) | 安全/体验 | 实现源码（未运行） |
+| [pi-web-access](https://github.com/nicobailon/pi-web-access/blob/811ef82a6dd04fe4abd73fa40b079aa39ee1870d/README.md) | 外部工具 | 实现源码（未运行） |
+| [pi-worktree-extension](https://github.com/AjayPoshak/pi-worktree-extension/blob/50df0b2fb049e556758e6fb6b22d0f0016ff8b9b/src/worktrees.ts) | 执行 | 实现源码（未运行） |
+| [security](https://github.com/michalvavra/agents/blob/c355e3c358fbef4122141ee51d8887fe273ff8b6/agents/pi/extensions/security.ts) | 安全/体验 | 实现源码（未运行） |

--- a/docs/research/PI_COMMUNITY_WORKTREE_INDEX_FLAGS_2026-09-08.json
+++ b/docs/research/PI_COMMUNITY_WORKTREE_INDEX_FLAGS_2026-09-08.json
@@ -58,5 +58,7 @@
   "evidenceBoundary": "Synthetic Git repositories only; no third-party plugin, model, full Child/Workflow lifecycle or private project data.",
   "relatedResearch": "PI_COMMUNITY_ECOSYSTEM_2026-09-08.md",
   "supersedes": null,
-  "localUnpublishedReceiptSha256": "66c708bc81d39ee00d36435d0a0d9d35a7e4ffb93161c429c734a3f4e2b0b899"
+  "localUnpublishedReceiptSha256": "66c708bc81d39ee00d36435d0a0d9d35a7e4ffb93161c429c734a3f4e2b0b899",
+  "relatedIssue": "https://github.com/openpi-dev/openpi/issues/472",
+  "relatedPullRequest": "https://github.com/openpi-dev/openpi/pull/479"
 }

--- a/docs/research/PI_COMMUNITY_WORKTREE_INDEX_FLAGS_2026-09-08.json
+++ b/docs/research/PI_COMMUNITY_WORKTREE_INDEX_FLAGS_2026-09-08.json
@@ -1,0 +1,62 @@
+{
+  "source": "openpi-dev/openpi@ed9dbc1018f890fd54375f5371990ddfee8af5df",
+  "node": "v26.3.0",
+  "git": "git version 2.50.1 (Apple Git-155)",
+  "results": [
+    {
+      "flag": "assume-unchanged",
+      "before": {
+        "status": "",
+        "ignored": "",
+        "flags": "h tracked.txt\n",
+        "modifiedFileExists": true
+      },
+      "cleanup": {
+        "removed": true,
+        "branchDeleted": true,
+        "branch": "probe-assume-unchanged",
+        "baseSha": "95af7055a9aaaefa56fda469842e2183952bee24",
+        "detached": false,
+        "headSha": "95af7055a9aaaefa56fda469842e2183952bee24",
+        "commits": 0,
+        "dirty": false,
+        "untracked": false,
+        "ignored": false
+      },
+      "worktreeExistsAfter": false,
+      "modifiedFileExistsAfter": false,
+      "branchesAfter": ""
+    },
+    {
+      "flag": "skip-worktree",
+      "before": {
+        "status": "",
+        "ignored": "",
+        "flags": "S tracked.txt\n",
+        "modifiedFileExists": true
+      },
+      "cleanup": {
+        "removed": true,
+        "branchDeleted": true,
+        "branch": "probe-skip-worktree",
+        "baseSha": "95af7055a9aaaefa56fda469842e2183952bee24",
+        "detached": false,
+        "headSha": "95af7055a9aaaefa56fda469842e2183952bee24",
+        "commits": 0,
+        "dirty": false,
+        "untracked": false,
+        "ignored": false
+      },
+      "worktreeExistsAfter": false,
+      "modifiedFileExistsAfter": false,
+      "branchesAfter": ""
+    }
+  ],
+  "status": "validated-isolated-production-function-fixture",
+  "created": "2026-09-08",
+  "lastVerified": "2026-09-08",
+  "evidenceBoundary": "Synthetic Git repositories only; no third-party plugin, model, full Child/Workflow lifecycle or private project data.",
+  "relatedResearch": "PI_COMMUNITY_ECOSYSTEM_2026-09-08.md",
+  "supersedes": null,
+  "localUnpublishedReceiptSha256": "66c708bc81d39ee00d36435d0a0d9d35a7e4ffb93161c429c734a3f4e2b0b899"
+}

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -8,6 +8,8 @@ Research records preserve sourced investigation and distinguish observations, in
 
 ## Validated investigations
 
+- [`PI_COMMUNITY_ECOSYSTEM_2026-09-08.md`](PI_COMMUNITY_ECOSYSTEM_2026-09-08.md) — 70 个社区包/扩展候选、固定来源、取舍与公开跟踪；包含 Worktree index flags 的隔离生产函数证据，不是插件兼容认证。
+
 - [`WEB_STARTUP_2026-09-07.md`](WEB_STARTUP_2026-09-07.md) — terminal startup feedback, browser-launch waiting, and exploratory timing limits ([#450](https://github.com/openpi-dev/openpi/issues/450)).
 
 - [`WEB_STREAMING_MARKDOWN_2026-09-07.md`](WEB_STREAMING_MARKDOWN_2026-09-07.md) — unchanged historical Markdown parsing during streaming, bounded React component reuse and deterministic regression evidence ([#434](https://github.com/openpi-dev/openpi/issues/434)).


### PR DESCRIPTION
## Problem

Pi 社区有大量包和扩展，但目录收录、README 功能、固定源码、已发布 npm 产物及 OpenPI 运行兼容性容易混在一起；已有研究也需要与当前实现和公开跟踪项对照。

## Value

保留 70 个包或扩展候选的第一手资料、版本身份和采用取舍，让后续实施能从具体源码与实验入口继续。Worktree 数据保全与 Web 选区反馈已分别提交到 #472、#473；不确定价值的方向进入 Discussions #474–#478。

## Approach

- 保存 74 条方向研究记录，合并同名包/集合后为 70 个候选；49 个候选检查了具体实现源码，其余核对 README/manifest。
- 区分来源核实、静态机制、隔离探针、运行兼容与采用决策；补充 2026-08-09 旧研究，保留历史结论。
- 保存脱除临时机器路径的 Worktree 生产函数探针回执；研究记录与 Issue/Discussion 双向关联。
- 现有 LSP、DAP、MCP、历史搜索、Cache、Memory、后台投递与 ACP 方向补充证据，不另建重复需求。

## Validation

- `bun run check` 通过。
- `bun run test` 通过：Node tests 1461 passed / 1 skipped / 0 failed；Web Vitest 113 passed。
- 新 JSON 可解析、文档相对链接存在、`git diff --check` 通过；公开内容检查未包含私人 Session、凭据或本机个人路径。
- 独立复核检查关键公开结论与去重；合成 Git fixture 直接调用 OpenPI `reclaimWorktree` 复现两种 index flags 下的数据丢失。
- 未安装或执行第三方插件，未调用模型，未做插件兼容认证或性能 Benchmark。仓库测试通过不代表社区方案已被验证采用。

## Impact

本 PR 归档研究与公开跟踪回执。实现由对应 Issue 跟进；运行时、模型工具、用户配置、依赖和安装行为没有变更。
