### PR TITLE
chore(release): prepare OpenPI 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tt-a1i/openpi",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "OpenPI — a Pi-native multi-agent workbench with background execution, isolated subagents, replay-safe workflows, goals, tasks, and observable TUI",
   "license": "MIT",
   "author": "tt-a1i",


### PR DESCRIPTION
Current main contains 15 commits since v0.7.0, including Web authentication and trust diagnostics, runtime inspection, archived Session recovery, inspectable prompt/tool-call trajectories, and startup/model-selection fixes. Prepare 0.8.0 so these changes can ship through the existing tagged npm release workflow.

Only package.json changes from 0.7.0 to 0.8.0. The lockfile has no root version field. Runtime code, dependencies and committed Web assets are unchanged by this PR.

Validation: local `bun run check` passed; `bun run test` passed (1,461 Node tests passed, one platform skip; 113 Vitest tests passed). Exact PR head `2ba63d7889560c756cfb96a044c42fb82cbb1b83` passed Node 22/24/26, Windows and Web E2E CI: https://github.com/openpi-dev/openpi/actions/runs/34176175953.

The candidate tarball contains 232 files, including the Web assets, CLI and third-party notices. A fresh isolated install with lockfile-selected Pi peers passed unique-source `pi list`, offline RPC extension discovery, Web static assets, unauthenticated API rejection (401), authenticated snapshot (200), and graceful shutdown. No model call was made. Candidate integrity: `sha512-3KxmKwwK9y08ShVw1p9TZGwKqn7hsYpZlyk0wG9MbWwxyDQQbJs4//77yssfhL7cnWwX0Y/HCinGf7pMlLc33A==`.

The user explicitly authorized administrator merge after the normal SHA-guarded merge was rejected for the missing approving review. Merged at `993fd8e22ff5c7495c1b5c19f9d64c0b6b97c252`; `v0.8.0` points to that commit.

Published [OpenPI 0.8.0](https://github.com/openpi-dev/openpi/releases/tag/v0.8.0) and [npm 0.8.0](https://www.npmjs.com/package/@tt-a1i/openpi/v/0.8.0), with latest set to 0.8.0. [Tagged Release workflow](https://github.com/openpi-dev/openpi/actions/runs/34176854550) passed. The downloaded npm tarball is byte-identical to its CI artifact; registry signature and Sigstore SLSA provenance verified against the release workflow, tag and commit. Published integrity: `sha512-fUHztbcChJrnwLjuLp7UlduGySGpL4QlR0VLMvZd0mllqc9MASFKD+LQcBYB8eVdImLL/qxJC3otph2f8fBTBQ==`. All 232 file contents match the locally tested candidate.

Repeated the isolated install smoke using the registry tarball: unique Pi source, offline RPC extension discovery, Web assets, API auth (401/200), and graceful shutdown all passed. No live model call was made. Existing local Pi installations were not updated.
