### PR TITLE
chore(release): 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tt-a1i/openpi",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "OpenPI — a Pi-native multi-agent workbench with background execution, isolated subagents, replay-safe workflows, goals, tasks, and observable TUI",
   "license": "MIT",
   "author": "tt-a1i",


### PR DESCRIPTION
## Problem

The Cursor native-request recovery fix in #484 is merged but is not available in the npm release.

## Value

Publish the fix as patch version 0.8.1 so Cursor-backed Pi children can recover to advertised Pi tools.

## Approach

Bump package.json from 0.8.0 to 0.8.1. This release contains #484 and the version bump only.

## Validation

The implementation passed full local checks/tests, all CI jobs, and actual Cursor child tool-recovery acceptance. Release-version `bun run check` and `bun run test` passed (Node 1,465 passed / 1 skipped; Vitest 113 passed). PR CI is running; the tag release workflow also validates and publishes a single npm artifact.

## Impact

Package version only; no additional runtime, configuration, or schema changes.
