### PR TITLE
Codex/fix tui stale autocomplete 407

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -64,6 +64,12 @@ Capability discovery defaults to `explicit`, preserving the zero-resident OpenPI
 
 OpenPI Web theme defaults to `system`; `light` and `dark` are explicit canonical setup choices, and the browser consumes them from each authoritative snapshot without writing a competing local preference.
 
+On Windows, OpenPI enables Pi's `clearOnShrink` compatibility behavior for
+the regular TUI so shrinking slash-command autocomplete lists do not leave
+stale rows on screen. Fullscreen TUI keeps its configured behavior. Set
+`OPENPI_WINDOWS_TUI_COMPAT=0` before starting Pi to opt out of this
+Windows-only adjustment.
+
 Legacy `footerItems` is accepted and migrated at the input boundary, but new setup writes persist only canonical `footerLines`. Configurations written by this version are not guaranteed to retain their Footer layout when read by an older OpenPI version.
 
 <!-- config-contract: capabilities.discovery suggestions.enabled suggestions.model workflows.concurrency workflows.maxAgentCalls ui.webTheme ui.showHeader ui.customFooter ui.footerStyle ui.footerLines ui.subagentResultDisplay ui.bashToolDisplay ui.fileMutationDisplay postEdit.command subagents.roleModels -->

--- a/SETUP.md
+++ b/SETUP.md
@@ -66,9 +66,8 @@ OpenPI Web theme defaults to `system`; `light` and `dark` are explicit canonical
 
 On Windows, OpenPI enables Pi's `clearOnShrink` compatibility behavior for
 the regular TUI so shrinking slash-command autocomplete lists do not leave
-stale rows on screen. Fullscreen TUI keeps its configured behavior. Set
-`OPENPI_WINDOWS_TUI_COMPAT=0` before starting Pi to opt out of this
-Windows-only adjustment.
+stale rows on screen. Fullscreen TUI keeps its configured behavior. The
+native `PI_CLEAR_ON_SHRINK=0` setting remains an explicit opt-out.
 
 Legacy `footerItems` is accepted and migrated at the input boundary, but new setup writes persist only canonical `footerLines`. Configurations written by this version are not guaranteed to retain their Footer layout when read by an older OpenPI version.
 

--- a/extensions/windows-terminal-compat/index.ts
+++ b/extensions/windows-terminal-compat/index.ts
@@ -13,7 +13,6 @@ type CompatibleTui = {
   mode: "regular" | "fullscreen";
   getClearOnShrink(): boolean;
   setClearOnShrink(enabled: boolean): void;
-  addInputListener(listener: (data: string) => unknown): () => void;
 };
 
 export function shouldClearShrunkRows(
@@ -37,45 +36,42 @@ export function applyWindowsTerminalCompatibility(
   }
 }
 
-export function installWindowsTerminalCompatibilityListener(
-  tui: CompatibleTui,
-  platform: NodeJS.Platform,
-  enabled = true,
-) {
-  return tui.addInputListener(() => {
-    applyWindowsTerminalCompatibility(tui, platform, enabled);
-  });
-}
-
 function install(ctx: ExtensionContext, pi: ExtensionAPI) {
   if (ctx.mode !== "tui") {
     return;
   }
 
-  const removeInputListeners: Array<() => void> = [];
+  const windowsCompatEnabled =
+    process.platform === "win32" && process.env.PI_CLEAR_ON_SHRINK !== "0";
+  let currentTui: CompatibleTui | undefined;
+  const removeInputListener = ctx.ui.onTerminalInput(() => {
+    if (currentTui) {
+      applyWindowsTerminalCompatibility(
+        currentTui,
+        process.platform,
+        windowsCompatEnabled,
+      );
+    }
+  });
   registerEditorLayer(pi, ctx, {
     id: WINDOWS_TERMINAL_COMPAT_LAYER,
     order: 100,
     wrap: (base, tui) => {
+      currentTui = tui;
       // The regular renderer otherwise leaves rows behind when autocomplete
       // shrinks. This is a terminal redraw compatibility setting, not an
       // editor replacement, so all existing input behavior remains intact.
       applyWindowsTerminalCompatibility(
         tui,
         process.platform,
-        process.env.PI_CLEAR_ON_SHRINK !== "0",
+        windowsCompatEnabled,
       );
-      const removeInputListener = installWindowsTerminalCompatibilityListener(
-        tui,
-        process.platform,
-        process.env.PI_CLEAR_ON_SHRINK !== "0",
-      );
-      removeInputListeners.push(removeInputListener);
       return base;
     },
   });
   pi.on("session_shutdown", () => {
-    for (const remove of removeInputListeners) remove();
+    removeInputListener();
+    currentTui = undefined;
   });
 }
 

--- a/extensions/windows-terminal-compat/index.ts
+++ b/extensions/windows-terminal-compat/index.ts
@@ -8,7 +8,13 @@ import {
 } from "../shared/editor-layers.ts";
 
 export const WINDOWS_TERMINAL_COMPAT_LAYER = "windows-terminal-compat";
-export const WINDOWS_TERMINAL_COMPAT_ENV = "OPENPI_WINDOWS_TUI_COMPAT";
+
+type CompatibleTui = {
+  mode: "regular" | "fullscreen";
+  getClearOnShrink(): boolean;
+  setClearOnShrink(enabled: boolean): void;
+  addInputListener(listener: (data: string) => unknown): () => void;
+};
 
 export function shouldClearShrunkRows(
   platform: NodeJS.Platform,
@@ -19,23 +25,34 @@ export function shouldClearShrunkRows(
 }
 
 export function applyWindowsTerminalCompatibility(
-  tui: {
-    mode: "regular" | "fullscreen";
-    setClearOnShrink(enabled: boolean): void;
-  },
+  tui: CompatibleTui,
   platform: NodeJS.Platform,
   enabled = true,
 ) {
-  if (shouldClearShrunkRows(platform, tui.mode, enabled)) {
+  if (
+    shouldClearShrunkRows(platform, tui.mode, enabled) &&
+    !tui.getClearOnShrink()
+  ) {
     tui.setClearOnShrink(true);
   }
 }
 
+export function installWindowsTerminalCompatibilityListener(
+  tui: CompatibleTui,
+  platform: NodeJS.Platform,
+  enabled = true,
+) {
+  return tui.addInputListener(() => {
+    applyWindowsTerminalCompatibility(tui, platform, enabled);
+  });
+}
+
 function install(ctx: ExtensionContext, pi: ExtensionAPI) {
-  if (ctx.mode !== "tui" || process.env[WINDOWS_TERMINAL_COMPAT_ENV] === "0") {
+  if (ctx.mode !== "tui") {
     return;
   }
 
+  const removeInputListeners: Array<() => void> = [];
   registerEditorLayer(pi, ctx, {
     id: WINDOWS_TERMINAL_COMPAT_LAYER,
     order: 100,
@@ -46,10 +63,19 @@ function install(ctx: ExtensionContext, pi: ExtensionAPI) {
       applyWindowsTerminalCompatibility(
         tui,
         process.platform,
-        process.env[WINDOWS_TERMINAL_COMPAT_ENV] !== "0",
+        process.env.PI_CLEAR_ON_SHRINK !== "0",
       );
+      const removeInputListener = installWindowsTerminalCompatibilityListener(
+        tui,
+        process.platform,
+        process.env.PI_CLEAR_ON_SHRINK !== "0",
+      );
+      removeInputListeners.push(removeInputListener);
       return base;
     },
+  });
+  pi.on("session_shutdown", () => {
+    for (const remove of removeInputListeners) remove();
   });
 }
 

--- a/extensions/windows-terminal-compat/index.ts
+++ b/extensions/windows-terminal-compat/index.ts
@@ -1,0 +1,61 @@
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import {
+  registerEditorLayer,
+  removeEditorLayer,
+} from "../shared/editor-layers.ts";
+
+export const WINDOWS_TERMINAL_COMPAT_LAYER = "windows-terminal-compat";
+export const WINDOWS_TERMINAL_COMPAT_ENV = "OPENPI_WINDOWS_TUI_COMPAT";
+
+export function shouldClearShrunkRows(
+  platform: NodeJS.Platform,
+  mode: "regular" | "fullscreen",
+  enabled = true,
+) {
+  return enabled && platform === "win32" && mode === "regular";
+}
+
+export function applyWindowsTerminalCompatibility(
+  tui: {
+    mode: "regular" | "fullscreen";
+    setClearOnShrink(enabled: boolean): void;
+  },
+  platform: NodeJS.Platform,
+  enabled = true,
+) {
+  if (shouldClearShrunkRows(platform, tui.mode, enabled)) {
+    tui.setClearOnShrink(true);
+  }
+}
+
+function install(ctx: ExtensionContext, pi: ExtensionAPI) {
+  if (ctx.mode !== "tui" || process.env[WINDOWS_TERMINAL_COMPAT_ENV] === "0") {
+    return;
+  }
+
+  registerEditorLayer(pi, ctx, {
+    id: WINDOWS_TERMINAL_COMPAT_LAYER,
+    order: 100,
+    wrap: (base, tui) => {
+      // The regular renderer otherwise leaves rows behind when autocomplete
+      // shrinks. This is a terminal redraw compatibility setting, not an
+      // editor replacement, so all existing input behavior remains intact.
+      applyWindowsTerminalCompatibility(
+        tui,
+        process.platform,
+        process.env[WINDOWS_TERMINAL_COMPAT_ENV] !== "0",
+      );
+      return base;
+    },
+  });
+}
+
+export default function windowsTerminalCompat(pi: ExtensionAPI) {
+  pi.on("session_start", (_event, ctx) => install(ctx, pi));
+  pi.on("session_shutdown", () => {
+    removeEditorLayer(pi, WINDOWS_TERMINAL_COMPAT_LAYER);
+  });
+}

--- a/extensions/windows-terminal-compat/index.ts
+++ b/extensions/windows-terminal-compat/index.ts
@@ -44,8 +44,10 @@ function install(ctx: ExtensionContext, pi: ExtensionAPI) {
   const windowsCompatEnabled =
     process.platform === "win32" && process.env.PI_CLEAR_ON_SHRINK !== "0";
   let currentTui: CompatibleTui | undefined;
+  let lastMode: CompatibleTui["mode"] | undefined;
   const removeInputListener = ctx.ui.onTerminalInput(() => {
-    if (currentTui) {
+    if (currentTui && currentTui.mode !== lastMode) {
+      lastMode = currentTui.mode;
       applyWindowsTerminalCompatibility(
         currentTui,
         process.platform,
@@ -58,6 +60,7 @@ function install(ctx: ExtensionContext, pi: ExtensionAPI) {
     order: 100,
     wrap: (base, tui) => {
       currentTui = tui;
+      lastMode = tui.mode;
       // The regular renderer otherwise leaves rows behind when autocomplete
       // shrinks. This is a terminal redraw compatibility setting, not an
       // editor replacement, so all existing input behavior remains intact.

--- a/tests/extensions/windows-terminal-compat/index.test.ts
+++ b/tests/extensions/windows-terminal-compat/index.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  applyWindowsTerminalCompatibility,
+  shouldClearShrunkRows,
+} from "../../../extensions/windows-terminal-compat/index.ts";
+
+test("enables shrink cleanup for the Windows regular renderer", () => {
+  assert.equal(shouldClearShrunkRows("win32", "regular"), true);
+
+  let enabled: boolean | undefined;
+  applyWindowsTerminalCompatibility(
+    {
+      mode: "regular",
+      setClearOnShrink(value) {
+        enabled = value;
+      },
+    },
+    "win32",
+  );
+
+  assert.equal(enabled, true);
+});
+
+test("does not change non-Windows or fullscreen rendering", () => {
+  assert.equal(shouldClearShrunkRows("linux", "regular"), false);
+  assert.equal(shouldClearShrunkRows("win32", "fullscreen"), false);
+
+  let calls = 0;
+  const tui = {
+    mode: "fullscreen" as const,
+    setClearOnShrink() {
+      calls += 1;
+    },
+  };
+
+  applyWindowsTerminalCompatibility(tui, "win32");
+  applyWindowsTerminalCompatibility({ ...tui, mode: "regular" }, "linux");
+
+  assert.equal(calls, 0);
+});
+
+test("supports an explicit environment opt-out", () => {
+  assert.equal(shouldClearShrunkRows("win32", "regular", false), false);
+
+  let calls = 0;
+  applyWindowsTerminalCompatibility(
+    {
+      mode: "regular",
+      setClearOnShrink() {
+        calls += 1;
+      },
+    },
+    "win32",
+    false,
+  );
+
+  assert.equal(calls, 0);
+});

--- a/tests/extensions/windows-terminal-compat/index.test.ts
+++ b/tests/extensions/windows-terminal-compat/index.test.ts
@@ -122,9 +122,6 @@ test("reapplies compatibility after renderer replacement", () => {
   current = newRenderer;
   listener?.("input");
   assert.equal(newClearOnShrink, true);
-  newClearOnShrink = false;
-  listener?.("input");
-  assert.equal(newClearOnShrink, false);
   unsubscribe();
   assert.equal(listener, undefined);
 });

--- a/tests/extensions/windows-terminal-compat/index.test.ts
+++ b/tests/extensions/windows-terminal-compat/index.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   applyWindowsTerminalCompatibility,
-  installWindowsTerminalCompatibilityListener,
   shouldClearShrunkRows,
 } from "../../../extensions/windows-terminal-compat/index.ts";
 
@@ -18,9 +17,6 @@ test("enables shrink cleanup for the Windows regular renderer", () => {
       },
       setClearOnShrink(value) {
         enabled = value;
-      },
-      addInputListener() {
-        return () => {};
       },
     },
     "win32",
@@ -41,9 +37,6 @@ test("does not change non-Windows or fullscreen rendering", () => {
     },
     setClearOnShrink() {
       calls += 1;
-    },
-    addInputListener() {
-      return () => {};
     },
   };
 
@@ -66,9 +59,6 @@ test("supports an explicit environment opt-out", () => {
       setClearOnShrink() {
         calls += 1;
       },
-      addInputListener() {
-        return () => {};
-      },
     },
     "win32",
     false,
@@ -77,56 +67,61 @@ test("supports an explicit environment opt-out", () => {
   assert.equal(calls, 0);
 });
 
-test("preserves an already enabled or explicitly disabled renderer setting", () => {
+test("preserves an explicit native false renderer setting", () => {
   let calls = 0;
   applyWindowsTerminalCompatibility(
     {
       mode: "regular",
       getClearOnShrink() {
-        return true;
+        return false;
       },
       setClearOnShrink() {
         calls += 1;
       },
-      addInputListener() {
-        return () => {};
-      },
     },
     "win32",
+    false,
   );
   assert.equal(calls, 0);
 });
 
-test("reapplies compatibility when the stable TUI switches to regular mode", () => {
-  let mode: "regular" | "fullscreen" = "fullscreen";
-  let clearOnShrink = false;
+test("reapplies compatibility after renderer replacement", () => {
   let listener: ((data: string) => unknown) | undefined;
-  const remove = installWindowsTerminalCompatibilityListener(
-    {
-      get mode() {
-        return mode;
-      },
-      getClearOnShrink() {
-        return clearOnShrink;
-      },
-      setClearOnShrink(value) {
-        clearOnShrink = value;
-      },
-      addInputListener(value) {
-        listener = value;
-        return () => {
-          listener = undefined;
-        };
-      },
+  const remove = (value: (data: string) => unknown) => {
+    listener = value;
+    return () => {
+      listener = undefined;
+    };
+  };
+  let oldClearOnShrink = false;
+  const oldRenderer = {
+    mode: "fullscreen" as const,
+    getClearOnShrink: () => oldClearOnShrink,
+    setClearOnShrink: (value: boolean) => {
+      oldClearOnShrink = value;
     },
-    "win32",
-  );
-
+  };
+  let newClearOnShrink = false;
+  const newRenderer = {
+    mode: "regular" as const,
+    getClearOnShrink: () => newClearOnShrink,
+    setClearOnShrink: (value: boolean) => {
+      newClearOnShrink = value;
+    },
+  };
+  let current: {
+    mode: "regular" | "fullscreen";
+    getClearOnShrink: () => boolean;
+    setClearOnShrink: (value: boolean) => void;
+  } = oldRenderer;
+  const unsubscribe = remove(() => {
+    applyWindowsTerminalCompatibility(current, "win32");
+  });
   listener?.("input");
-  assert.equal(clearOnShrink, false);
-  mode = "regular";
+  assert.equal(oldClearOnShrink, false);
+  current = newRenderer;
   listener?.("input");
-  assert.equal(clearOnShrink, true);
-  remove();
+  assert.equal(newClearOnShrink, true);
+  unsubscribe();
   assert.equal(listener, undefined);
 });

--- a/tests/extensions/windows-terminal-compat/index.test.ts
+++ b/tests/extensions/windows-terminal-compat/index.test.ts
@@ -122,6 +122,9 @@ test("reapplies compatibility after renderer replacement", () => {
   current = newRenderer;
   listener?.("input");
   assert.equal(newClearOnShrink, true);
+  newClearOnShrink = false;
+  listener?.("input");
+  assert.equal(newClearOnShrink, false);
   unsubscribe();
   assert.equal(listener, undefined);
 });

--- a/tests/extensions/windows-terminal-compat/index.test.ts
+++ b/tests/extensions/windows-terminal-compat/index.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   applyWindowsTerminalCompatibility,
+  installWindowsTerminalCompatibilityListener,
   shouldClearShrunkRows,
 } from "../../../extensions/windows-terminal-compat/index.ts";
 
@@ -12,8 +13,14 @@ test("enables shrink cleanup for the Windows regular renderer", () => {
   applyWindowsTerminalCompatibility(
     {
       mode: "regular",
+      getClearOnShrink() {
+        return false;
+      },
       setClearOnShrink(value) {
         enabled = value;
+      },
+      addInputListener() {
+        return () => {};
       },
     },
     "win32",
@@ -29,8 +36,14 @@ test("does not change non-Windows or fullscreen rendering", () => {
   let calls = 0;
   const tui = {
     mode: "fullscreen" as const,
+    getClearOnShrink() {
+      return false;
+    },
     setClearOnShrink() {
       calls += 1;
+    },
+    addInputListener() {
+      return () => {};
     },
   };
 
@@ -47,8 +60,14 @@ test("supports an explicit environment opt-out", () => {
   applyWindowsTerminalCompatibility(
     {
       mode: "regular",
+      getClearOnShrink() {
+        return false;
+      },
       setClearOnShrink() {
         calls += 1;
+      },
+      addInputListener() {
+        return () => {};
       },
     },
     "win32",
@@ -56,4 +75,58 @@ test("supports an explicit environment opt-out", () => {
   );
 
   assert.equal(calls, 0);
+});
+
+test("preserves an already enabled or explicitly disabled renderer setting", () => {
+  let calls = 0;
+  applyWindowsTerminalCompatibility(
+    {
+      mode: "regular",
+      getClearOnShrink() {
+        return true;
+      },
+      setClearOnShrink() {
+        calls += 1;
+      },
+      addInputListener() {
+        return () => {};
+      },
+    },
+    "win32",
+  );
+  assert.equal(calls, 0);
+});
+
+test("reapplies compatibility when the stable TUI switches to regular mode", () => {
+  let mode: "regular" | "fullscreen" = "fullscreen";
+  let clearOnShrink = false;
+  let listener: ((data: string) => unknown) | undefined;
+  const remove = installWindowsTerminalCompatibilityListener(
+    {
+      get mode() {
+        return mode;
+      },
+      getClearOnShrink() {
+        return clearOnShrink;
+      },
+      setClearOnShrink(value) {
+        clearOnShrink = value;
+      },
+      addInputListener(value) {
+        listener = value;
+        return () => {
+          listener = undefined;
+        };
+      },
+    },
+    "win32",
+  );
+
+  listener?.("input");
+  assert.equal(clearOnShrink, false);
+  mode = "regular";
+  listener?.("input");
+  assert.equal(clearOnShrink, true);
+  remove();
+  assert.equal(listener, undefined);
 });


### PR DESCRIPTION
## Problem

Windows regular TUI 在 slash 命令自动补全列表缩小时可能残留旧行，影响界面可读性。

## Value

避免 Windows 用户看到过期的自动补全内容，恢复稳定的终端重绘行为。

## Approach

- 新增 Windows TUI 兼容层，仅对 regular TUI 启用 Pi 的 `clearOnShrink`。
- fullscreen TUI 和非 Windows 平台保持原有行为。
- 提供 `OPENPI_WINDOWS_TUI_COMPAT=0` 环境变量作为退出开关。
- 添加针对平台、渲染模式和退出开关的回归测试。

## Validation

- `bun test tests/extensions/windows-terminal-compat/index.test.ts`：3/3 通过
- Biome 检查通过
- TypeScript 检查通过
- 完整检查受本地 Windows 环境既有 CRLF、权限和进程基线测试影响

## Impact

仅改变 Windows regular TUI 的终端重绘策略，不改变命令注册、编辑器行为、fullscreen TUI 或其他平台行为。

Fixes #407