### PR TITLE
fix(tui): present /btw asides as self-contained child pages

### DIFF
--- a/extensions/shared/agent-session-page.ts
+++ b/extensions/shared/agent-session-page.ts
@@ -2,7 +2,12 @@ import type {
   KeybindingsManager,
   Theme,
 } from "@earendil-works/pi-coding-agent";
-import type { Component, Focusable, TUI } from "@earendil-works/pi-tui";
+import type {
+  Component,
+  Focusable,
+  TUI,
+  TuiMouseEvent,
+} from "@earendil-works/pi-tui";
 import {
   Key,
   matchesKey,
@@ -88,6 +93,8 @@ export class AgentSessionPage implements Component, Focusable {
    * "output produced before I looked" from "output arriving while I watch".
    */
   private anchored = false;
+  private mouseReporting = false;
+  private disposed = false;
 
   private _focused = false;
   get focused() {
@@ -95,6 +102,16 @@ export class AgentSessionPage implements Component, Focusable {
   }
   set focused(value: boolean) {
     this._focused = value;
+    // In regular mode the terminal otherwise scrolls its own history, exposing
+    // the parent above a partially visible child page. Fullscreen Pi already
+    // owns mouse reporting and dispatches normalized events to handleMouse.
+    const capture = value && !this.disposed && this.tui.mode === "regular";
+    if (capture !== this.mouseReporting) {
+      this.mouseReporting = capture;
+      this.tui.terminal.write(
+        capture ? "\x1b[?1000h\x1b[?1006h" : "\x1b[?1000l\x1b[?1006l",
+      );
+    }
   }
 
   constructor(
@@ -112,6 +129,14 @@ export class AgentSessionPage implements Component, Focusable {
   }
 
   handleInput(data: string) {
+    const mouse = /^\x1b\[<(\d+);\d+;\d+([Mm])$/.exec(data);
+    if (mouse) {
+      const button = Number(mouse[1]);
+      if (mouse[2] === "M" && (button & 64) !== 0 && (button & 3) < 2) {
+        this.scroll((button & 1) === 0 ? -SCROLL_STEP : SCROLL_STEP);
+      }
+      return;
+    }
     const state = this.source.getState();
     if (this.keybindings.matches(data, "app.tools.expand")) {
       this.toolsExpanded = !this.toolsExpanded;
@@ -188,6 +213,22 @@ export class AgentSessionPage implements Component, Focusable {
       this.tui.requestRender();
       return;
     }
+  }
+
+  private scroll(delta: number) {
+    this.viewport.scrollBy(delta, this.rowCount, this.viewportSize);
+    this.tui.requestRender();
+  }
+
+  handleMouse(event: TuiMouseEvent) {
+    if (event.type !== "wheel") return;
+    this.scroll(event.wheelDelta ?? 0);
+    return { handled: true };
+  }
+
+  dispose() {
+    this.disposed = true;
+    this.focused = false;
   }
 
   private rule(width: number, left = "", right = "") {
@@ -304,9 +345,8 @@ export class AgentSessionPage implements Component, Focusable {
       transcript.length,
       transcriptCapacity,
     );
-    // Both directions are reported. Opening a child page follows the end, which
-    // scrolls the beginning of a long answer out of view; without an "above"
-    // marker that output looks lost rather than merely off-screen.
+    // Both directions are reported so hidden output is discoverable whether
+    // the reader is at the opening, following new output, or paused between.
     const overflowNote = [
       linesAbove > 0 ? `↑ ${linesAbove}` : "",
       linesBelow > 0 ? `↓ ${linesBelow}` : "",

--- a/extensions/shared/agent-session-page.ts
+++ b/extensions/shared/agent-session-page.ts
@@ -82,6 +82,12 @@ export class AgentSessionPage implements Component, Focusable {
   private rowCount = 0;
   private viewportSize = 1;
   private toolsExpanded: boolean;
+  /**
+   * Whether the opening anchor has been decided. A page opens on a transcript
+   * that already exists, so the first render is the only moment that can tell
+   * "output produced before I looked" from "output arriving while I watch".
+   */
+  private anchored = false;
 
   private _focused = false;
   get focused() {
@@ -246,6 +252,17 @@ export class AgentSessionPage implements Component, Focusable {
     });
     this.rowCount = transcript.length;
     this.viewportSize = transcriptCapacity;
+    // A child page opens on work that already happened. Following the end would
+    // start a long answer partway through, hiding its beginning, so the first
+    // render anchors at the start of anything that already overflows. A page
+    // that opens on a short or empty transcript keeps following, so streaming
+    // output still scrolls into view as it arrives.
+    if (!this.anchored) {
+      this.anchored = true;
+      if (transcript.length > transcriptCapacity) {
+        this.viewport.scrollToTop(transcript.length, transcriptCapacity);
+      }
+    }
     this.viewport.reconcile(transcript.length, transcriptCapacity);
 
     const lines = [

--- a/extensions/shared/agent-session-page.ts
+++ b/extensions/shared/agent-session-page.ts
@@ -279,16 +279,28 @@ export class AgentSessionPage implements Component, Focusable {
     while (body.length < bodyHeight) body.push("");
     lines.push(...body.slice(0, bodyHeight));
 
+    const linesAbove = this.viewport.linesAbove(
+      transcript.length,
+      transcriptCapacity,
+    );
+    const linesBelow = this.viewport.linesBelow(
+      transcript.length,
+      transcriptCapacity,
+    );
+    // Both directions are reported. Opening a child page follows the end, which
+    // scrolls the beginning of a long answer out of view; without an "above"
+    // marker that output looks lost rather than merely off-screen.
+    const overflowNote = [
+      linesAbove > 0 ? `↑ ${linesAbove}` : "",
+      linesBelow > 0 ? `↓ ${linesBelow}` : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
     lines.push(
       this.rule(
         width,
         this.theme.fg("borderAccent", "─"),
-        this.viewport.followingEnd
-          ? ""
-          : this.theme.fg(
-              "dim",
-              `↓ ${this.viewport.linesBelow(transcript.length, transcriptCapacity)}`,
-            ),
+        overflowNote ? this.theme.fg("dim", overflowNote) : "",
       ),
     );
     const keys = (binding: Parameters<KeybindingsManager["getKeys"]>[0]) =>

--- a/extensions/shared/transcript-viewport.ts
+++ b/extensions/shared/transcript-viewport.ts
@@ -43,4 +43,12 @@ export class TranscriptViewport {
   linesBelow(rowCount: number, viewportSize: number) {
     return maxScrollTop(rowCount, viewportSize) - this.scrollTop;
   }
+
+  /**
+   * Rows scrolled off the top. Following the end still hides everything above
+   * the viewport, so a reader needs this to know unseen output exists.
+   */
+  linesAbove(rowCount: number, viewportSize: number) {
+    return Math.min(this.scrollTop, maxScrollTop(rowCount, viewportSize));
+  }
 }

--- a/extensions/subagents/src/ui/takeover.ts
+++ b/extensions/subagents/src/ui/takeover.ts
@@ -11,7 +11,12 @@ import type {
   KeybindingsManager,
   Theme,
 } from "@earendil-works/pi-coding-agent";
-import type { Component, Focusable, TUI } from "@earendil-works/pi-tui";
+import type {
+  Component,
+  Focusable,
+  TUI,
+  TuiMouseEvent,
+} from "@earendil-works/pi-tui";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { AgentSessionPage } from "../../../shared/agent-session-page.ts";
 import { hintLine, panelFrame } from "../../../shared/screen-chrome.ts";
@@ -476,6 +481,7 @@ export class TakeoverView implements Component, Focusable {
     if (this.closed) return false;
     this.closed = true;
     this.unsubscribe();
+    this.page.dispose();
     if (this.ticker) clearInterval(this.ticker);
     if (this.renderTimer) clearTimeout(this.renderTimer);
     this.renderTimer = undefined;
@@ -492,6 +498,10 @@ export class TakeoverView implements Component, Focusable {
 
   handleInput(data: string): void {
     this.page.handleInput(data);
+  }
+
+  handleMouse(event: TuiMouseEvent) {
+    return this.page.handleMouse(event);
   }
 
   render(width: number): string[] {

--- a/extensions/workflows/dashboard.ts
+++ b/extensions/workflows/dashboard.ts
@@ -18,7 +18,11 @@ import {
   getAgentDir,
   type KeybindingsManager,
 } from "@earendil-works/pi-coding-agent";
-import { type TUI, truncateToWidth } from "@earendil-works/pi-tui";
+import {
+  type TUI,
+  type TuiMouseEvent,
+  truncateToWidth,
+} from "@earendil-works/pi-tui";
 import { AgentSessionPage } from "../shared/agent-session-page.ts";
 import { fitNavigationSides } from "../shared/below-editor-navigation.ts";
 import { contextPercent } from "../shared/context-utilization.ts";
@@ -768,6 +772,19 @@ type View = "list" | "detail" | "transcript";
 type DetailFocus = "phases" | "agents";
 
 export class WorkflowDashboard {
+  private _focused = false;
+  get focused() {
+    return this._focused;
+  }
+  set focused(value: boolean) {
+    this._focused = value;
+    if (this.transcriptPage) this.transcriptPage.focused = value;
+  }
+
+  handleMouse(event: TuiMouseEvent) {
+    return this.transcriptPage?.handleMouse(event);
+  }
+
   private view: View = "list";
   private entries: RunEntry[] = [];
   private historyLoaded = false;
@@ -872,6 +889,7 @@ export class WorkflowDashboard {
     this.disposed = true;
     if (this.timer) clearInterval(this.timer);
     this.timer = undefined;
+    this.transcriptPage?.dispose();
     this.transcriptPage = undefined;
   }
 
@@ -1177,6 +1195,7 @@ export class WorkflowDashboard {
           };
         },
         close: () => {
+          this.transcriptPage?.dispose();
           this.transcriptPage = undefined;
           this.view = "detail";
           this.detailFocus = "agents";
@@ -1186,6 +1205,7 @@ export class WorkflowDashboard {
       },
       { toolsExpanded: this.initialToolsExpanded },
     );
+    this.transcriptPage.focused = this.focused;
     this.tui.requestRender();
   }
 

--- a/tests/extensions/shared/agent-session-page.test.ts
+++ b/tests/extensions/shared/agent-session-page.test.ts
@@ -39,6 +39,112 @@ function tui(rows: number) {
   return { terminal: { rows }, requestRender() {} } as unknown as TUI;
 }
 
+test("regular child page captures wheel scrolling only while focused", () => {
+  const writes: string[] = [];
+  const host = {
+    mode: "regular",
+    terminal: { rows: 20, write: (data: string) => writes.push(data) },
+    requestRender() {},
+  } as unknown as TUI;
+  const rows = Array.from({ length: 60 }, (_, index) => `mouse row ${index}`);
+  const page = new AgentSessionPage(host, theme, keybindings, {
+    getState: () => ({
+      id: "mouse",
+      title: "mouse",
+      status: "running",
+      document: {
+        items: [
+          {
+            kind: "assistant",
+            parts: [{ type: "text", text: rows.join("\n\n") }],
+          },
+        ],
+      },
+    }),
+    close() {},
+  });
+  const render = () => stripVTControlCharacters(page.render(80).join("\n"));
+  try {
+    assert.equal(writes.length, 0);
+    page.focused = true;
+    page.focused = true;
+    assert.deepEqual(writes, ["\x1b[?1000h\x1b[?1006h"]);
+    assert.match(render(), /mouse row 0\b/);
+    page.handleInput("\x1b[<65;10;10M");
+    assert.doesNotMatch(render(), /mouse row 0\b/);
+    page.handleInput("\x1b[<64;10;10M");
+    assert.match(render(), /mouse row 0\b/);
+    // Wheel-up pauses following, even if output subsequently grows.
+    rows.push("new tail");
+    assert.match(render(), /mouse row 0\b/);
+    page.handleInput("G");
+    assert.match(render(), /new tail/);
+    page.focused = false;
+    assert.equal(writes.at(-1), "\x1b[?1000l\x1b[?1006l");
+    page.focused = true;
+  } finally {
+    page.dispose();
+  }
+  assert.equal(writes.at(-1), "\x1b[?1000l\x1b[?1006l");
+  const count = writes.length;
+  page.dispose();
+  page.focused = true;
+  assert.equal(writes.length, count);
+});
+
+test("fullscreen child page uses host mouse dispatch without changing terminal modes", () => {
+  const host = {
+    mode: "fullscreen",
+    terminal: {
+      rows: 20,
+      write() {
+        assert.fail("fullscreen host owns mouse modes");
+      },
+    },
+    requestRender() {},
+  } as unknown as TUI;
+  const page = new AgentSessionPage(host, theme, keybindings, {
+    getState: () => ({
+      ...state(),
+      document: {
+        items: [
+          {
+            kind: "assistant",
+            parts: [
+              {
+                type: "text",
+                text: Array.from({ length: 60 }, (_, i) => `wheel ${i}`).join(
+                  "\n\n",
+                ),
+              },
+            ],
+          },
+        ],
+      },
+    }),
+    close() {},
+  });
+  page.focused = true;
+  assert.match(page.render(80).join("\n"), /wheel 0\b/);
+  const result = page.handleMouse({
+    type: "wheel",
+    button: "none",
+    x: 10,
+    y: 10,
+    screenX: 10,
+    screenY: 10,
+    width: 80,
+    height: 20,
+    shift: false,
+    alt: false,
+    ctrl: false,
+    wheelDelta: 6,
+  });
+  assert.equal(result?.handled, true);
+  assert.doesNotMatch(page.render(80).join("\n"), /wheel 0\b/);
+  page.dispose();
+});
+
 function state(): AgentSessionPageState {
   return {
     id: "child-1",
@@ -185,7 +291,7 @@ test("a child page inherits an expanded parent state on its first render", () =>
   );
 });
 
-test("a child page reports an answer's opening scrolled above the viewport", () => {
+test("a child page reports output hidden in either direction", () => {
   // A /btw answer longer than one screen: the page opens at the beginning, so
   // the end is what sits off-screen and must be reported.
   const long: AgentSessionPageState = {

--- a/tests/extensions/shared/agent-session-page.test.ts
+++ b/tests/extensions/shared/agent-session-page.test.ts
@@ -184,3 +184,62 @@ test("a child page inherits an expanded parent state on its first render", () =>
     /output-marker/,
   );
 });
+
+test("a child page reports an answer's opening scrolled above the viewport", () => {
+  // A /btw answer longer than one screen: the page follows the end, so the
+  // opening is off-screen and the reader must be told it exists.
+  const long: AgentSessionPageState = {
+    id: "btw-1",
+    title: "by the way",
+    status: "done",
+    document: {
+      items: [
+        { kind: "user", text: "two questions" },
+        {
+          kind: "assistant",
+          parts: [
+            {
+              type: "text",
+              text: Array.from(
+                { length: 60 },
+                (_, index) => `answer line ${index}`,
+              ).join("\n\n"),
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  const page = new AgentSessionPage(tui(20), theme, keybindings, {
+    getState: () => long,
+    close() {},
+  });
+  const opened = page.render(80);
+  const openedText = stripVTControlCharacters(opened.join("\n"));
+
+  // The overlay still owns exactly the terminal rows it was given.
+  assert.equal(opened.length, 20);
+  assert.match(openedText, /↑ \d+/);
+  assert.doesNotMatch(openedText, /↓ \d+/);
+
+  // Jumping to the top inverts which side is hidden, without resizing the page.
+  page.handleInput("g");
+  const atTop = page.render(80);
+  const atTopText = stripVTControlCharacters(atTop.join("\n"));
+  assert.equal(atTop.length, 20);
+  assert.match(atTopText, /answer line 0/);
+  assert.match(atTopText, /↓ \d+/);
+  assert.doesNotMatch(atTopText, /↑ \d+/);
+});
+
+test("a child page whose transcript fits shows no overflow markers", () => {
+  const page = new AgentSessionPage(tui(24), theme, keybindings, {
+    getState: state,
+    close() {},
+  });
+
+  const text = stripVTControlCharacters(page.render(60).join("\n"));
+  assert.doesNotMatch(text, /↑ \d+/);
+  assert.doesNotMatch(text, /↓ \d+/);
+});

--- a/tests/extensions/shared/agent-session-page.test.ts
+++ b/tests/extensions/shared/agent-session-page.test.ts
@@ -186,8 +186,8 @@ test("a child page inherits an expanded parent state on its first render", () =>
 });
 
 test("a child page reports an answer's opening scrolled above the viewport", () => {
-  // A /btw answer longer than one screen: the page follows the end, so the
-  // opening is off-screen and the reader must be told it exists.
+  // A /btw answer longer than one screen: the page opens at the beginning, so
+  // the end is what sits off-screen and must be reported.
   const long: AgentSessionPageState = {
     id: "btw-1",
     title: "by the way",
@@ -220,17 +220,108 @@ test("a child page reports an answer's opening scrolled above the viewport", () 
 
   // The overlay still owns exactly the terminal rows it was given.
   assert.equal(opened.length, 20);
-  assert.match(openedText, /↑ \d+/);
-  assert.doesNotMatch(openedText, /↓ \d+/);
+  // The question that prompted the answer is the first thing a reader sees.
+  assert.match(openedText, /two questions/);
+  assert.match(openedText, /answer line 0/);
+  assert.match(openedText, /↓ \d+/);
+  assert.doesNotMatch(openedText, /↑ \d+/);
 
-  // Jumping to the top inverts which side is hidden, without resizing the page.
-  page.handleInput("g");
-  const atTop = page.render(80);
-  const atTopText = stripVTControlCharacters(atTop.join("\n"));
-  assert.equal(atTop.length, 20);
-  assert.match(atTopText, /answer line 0/);
-  assert.match(atTopText, /↓ \d+/);
-  assert.doesNotMatch(atTopText, /↑ \d+/);
+  // Jumping to the end inverts which side is hidden, without resizing the page.
+  page.handleInput("G");
+  const atEnd = page.render(80);
+  const atEndText = stripVTControlCharacters(atEnd.join("\n"));
+  assert.equal(atEnd.length, 20);
+  assert.match(atEndText, /answer line 59/);
+  assert.match(atEndText, /↑ \d+/);
+  assert.doesNotMatch(atEndText, /↓ \d+/);
+});
+
+test("a child page opens on the start of output that predates it", () => {
+  // The reported /btw defect: two questions asked, and the answer to the first
+  // was never visible because the page opened pinned to the transcript end.
+  const answer = [
+    "first heading",
+    ...Array.from({ length: 15 }, (_, index) => `first detail ${index}`),
+    "second heading",
+    ...Array.from({ length: 15 }, (_, index) => `second detail ${index}`),
+  ].join("\n\n");
+  const state: AgentSessionPageState = {
+    id: "btw-1",
+    title: "by the way",
+    status: "done",
+    document: {
+      items: [
+        { kind: "user", text: "ask two things" },
+        { kind: "assistant", parts: [{ type: "text", text: answer }] },
+      ],
+    },
+  };
+
+  const page = new AgentSessionPage(tui(30), theme, keybindings, {
+    getState: () => state,
+    close() {},
+  });
+  const text = stripVTControlCharacters(page.render(80).join("\n"));
+
+  assert.match(text, /ask two things/);
+  assert.match(text, /first heading/);
+  assert.doesNotMatch(text, /second detail 14/);
+});
+
+test("a live child still follows output that arrives while it is watched", () => {
+  // Anchoring at the start must not disable following for a running child.
+  const rows = ["starting"];
+  const page = new AgentSessionPage(tui(20), theme, keybindings, {
+    getState: () => ({
+      id: "sa-1",
+      title: "live child",
+      status: "running" as const,
+      document: {
+        items: rows.map((text) => ({
+          kind: "assistant" as const,
+          parts: [{ type: "text" as const, text }],
+        })),
+      },
+    }),
+    close() {},
+  });
+
+  page.render(80);
+  for (let index = 0; index < 60; index += 1) rows.push(`streamed ${index}`);
+  assert.match(
+    stripVTControlCharacters(page.render(80).join("\n")),
+    /streamed 59/,
+  );
+});
+
+test("a busy child opens at the start and resumes following on demand", () => {
+  const rows = Array.from({ length: 60 }, (_, index) => `existing ${index}`);
+  const page = new AgentSessionPage(tui(20), theme, keybindings, {
+    getState: () => ({
+      id: "sa-2",
+      title: "busy child",
+      status: "running" as const,
+      document: {
+        items: rows.map((text) => ({
+          kind: "assistant" as const,
+          parts: [{ type: "text" as const, text }],
+        })),
+      },
+    }),
+    close() {},
+  });
+
+  assert.match(
+    stripVTControlCharacters(page.render(80).join("\n")),
+    /existing 0/,
+  );
+
+  page.handleInput("G");
+  rows.push("arrived while following");
+  assert.match(
+    stripVTControlCharacters(page.render(80).join("\n")),
+    /arrived while following/,
+  );
 });
 
 test("a child page whose transcript fits shows no overflow markers", () => {

--- a/tests/extensions/shared/transcript-viewport.test.ts
+++ b/tests/extensions/shared/transcript-viewport.test.ts
@@ -63,3 +63,26 @@ test("paused viewport clamps safely across shrink and resize without resuming", 
   assert.equal(viewport.scrollTop, 0);
   assert.equal(viewport.followingEnd, false);
 });
+
+test("a viewport reports hidden rows above, including while following", () => {
+  const viewport = new TranscriptViewport();
+
+  // Following the end still hides the beginning of a long transcript.
+  viewport.reconcile(20, 5);
+  assert.equal(viewport.linesAbove(20, 5), 15);
+  assert.equal(viewport.linesBelow(20, 5), 0);
+
+  viewport.scrollToTop(20, 5);
+  assert.equal(viewport.linesAbove(20, 5), 0);
+  assert.equal(viewport.linesBelow(20, 5), 15);
+
+  viewport.scrollBy(4, 20, 5);
+  assert.equal(viewport.linesAbove(20, 5), 4);
+  assert.equal(viewport.linesBelow(20, 5), 11);
+
+  // A transcript that fits has nothing hidden in either direction.
+  const fits = new TranscriptViewport();
+  fits.reconcile(3, 10);
+  assert.equal(fits.linesAbove(3, 10), 0);
+  assert.equal(fits.linesBelow(3, 10), 0);
+});

--- a/tests/extensions/subagents/takeover.test.ts
+++ b/tests/extensions/subagents/takeover.test.ts
@@ -82,6 +82,60 @@ function dashboard(subs: SubagentSnapshot[], rows = 30) {
   );
 }
 
+test("takeover forwards wheel events and releases mouse capture on close", () => {
+  const writes: string[] = [];
+  const host = {
+    mode: "regular",
+    terminal: { rows: 20, write: (data: string) => writes.push(data) },
+    requestRender() {},
+  } as unknown as TUI;
+  let closed = false;
+  const view = new TakeoverView(
+    host,
+    theme,
+    keys,
+    "wheel",
+    model([
+      snap("wheel", "done", {
+        transcript: Array.from({ length: 60 }, (_, i) => ({
+          kind: "assistant" as const,
+          parts: [{ type: "text" as const, text: `wheel row ${i}` }],
+        })),
+      }),
+    ]),
+    () => {
+      closed = true;
+    },
+  );
+  try {
+    view.focused = true;
+    assert.match(view.render(80).join("\n"), /wheel row 0\b/);
+    assert.equal(
+      view.handleMouse({
+        type: "wheel",
+        button: "none",
+        x: 10,
+        y: 10,
+        screenX: 10,
+        screenY: 10,
+        width: 80,
+        height: 20,
+        shift: false,
+        alt: false,
+        ctrl: false,
+        wheelDelta: 6,
+      })?.handled,
+      true,
+    );
+    assert.doesNotMatch(view.render(80).join("\n"), /wheel row 0\b/);
+    view.handleInput("tui.select.cancel");
+    assert.equal(closed, true);
+    assert.equal(writes.at(-1), "\x1b[?1000l\x1b[?1006l");
+  } finally {
+    view.dispose();
+  }
+});
+
 test("picker and takeover display text cannot inject terminal controls", () => {
   assert.equal(
     sanitizeSubagentDisplayLine(

--- a/tests/extensions/subagents/takeover.test.ts
+++ b/tests/extensions/subagents/takeover.test.ts
@@ -238,14 +238,19 @@ test("takeover scroll indicator lives in its rule without changing overlay heigh
     () => {},
   );
   try {
-    const pinned = view.render(80);
-    assert.equal(pinned.length, 20);
-    assert.doesNotMatch(pinned.join("\n"), /↓ \d+/);
+    // Opening a takeover on an existing transcript starts at its beginning, so
+    // the hidden remainder is reported below.
+    const opened = view.render(80);
+    assert.equal(opened.length, 20);
+    assert.match(opened.join("\n"), /output 0/);
+    assert.match(opened.join("\n"), /↓ \d+/);
+    assert.doesNotMatch(opened.join("\n"), /↑ \d+/);
 
-    view.handleInput("tui.editor.pageUp");
+    // The indicator rides its rule: paging keeps the overlay exactly as tall.
+    view.handleInput("tui.editor.pageDown");
     const scrolled = view.render(80);
-    assert.equal(scrolled.length, pinned.length);
-    assert.match(scrolled.join("\n"), /↓ \d+/);
+    assert.equal(scrolled.length, opened.length);
+    assert.match(scrolled.join("\n"), /↑ \d+/);
     assert.doesNotMatch(scrolled.join("\n"), /lines below/);
   } finally {
     view.dispose();

--- a/tests/extensions/workflows/dashboard.test.ts
+++ b/tests/extensions/workflows/dashboard.test.ts
@@ -654,6 +654,7 @@ test("direct workflow navigation drills right and returns left through every lev
 });
 
 test("Workflow transcript follows, pauses on its top row, and resumes", () => {
+  const mouseModes: string[] = [];
   const transcript = Array.from({ length: 40 }, (_, index) => ({
     role: "assistant" as const,
     text: `line ${index}`,
@@ -690,7 +691,8 @@ test("Workflow transcript follows, pauses on its top row, and resumes", () => {
   writeRun(details.runId, details.startedAt);
   const dashboard = new WorkflowDashboard(
     {
-      terminal: { rows: 20 },
+      mode: "regular",
+      terminal: { rows: 20, write: (data: string) => mouseModes.push(data) },
       requestRender() {},
     } as unknown as TUI,
     {
@@ -713,9 +715,11 @@ test("Workflow transcript follows, pauses on its top row, and resumes", () => {
   );
 
   try {
+    dashboard.focused = true;
     dashboard.handleInput("right");
     dashboard.handleInput("right");
     // A transcript page opens on the start of work that already happened.
+    assert.equal(mouseModes.at(-1), "\x1b[?1000h\x1b[?1006h");
     const opened = dashboard.render(80).join("\n");
     assert.match(opened, /line 0\b/);
     assert.doesNotMatch(opened, /line 39/);
@@ -724,7 +728,20 @@ test("Workflow transcript follows, pauses on its top row, and resumes", () => {
     const pinned = dashboard.render(80).join("\n");
     assert.match(pinned, /line 39/);
 
-    dashboard.handleInput("k");
+    dashboard.handleMouse({
+      type: "wheel",
+      button: "none",
+      x: 10,
+      y: 10,
+      screenX: 10,
+      screenY: 10,
+      width: 80,
+      height: 20,
+      shift: false,
+      alt: false,
+      ctrl: false,
+      wheelDelta: -6,
+    });
     const paused = dashboard.render(80);
     const anchor = paused.find((line) => /line \d+/.test(line));
     assert.ok(anchor);
@@ -745,6 +762,8 @@ test("Workflow transcript follows, pauses on its top row, and resumes", () => {
     const resumed = dashboard.render(80).join("\n");
     assert.match(resumed, /line 44/);
     assert.doesNotMatch(resumed, /↓ \d+/);
+    dashboard.handleInput("h");
+    assert.equal(mouseModes.at(-1), "\x1b[?1000l\x1b[?1006l");
   } finally {
     dashboard.dispose();
   }

--- a/tests/extensions/workflows/dashboard.test.ts
+++ b/tests/extensions/workflows/dashboard.test.ts
@@ -715,9 +715,14 @@ test("Workflow transcript follows, pauses on its top row, and resumes", () => {
   try {
     dashboard.handleInput("right");
     dashboard.handleInput("right");
+    // A transcript page opens on the start of work that already happened.
+    const opened = dashboard.render(80).join("\n");
+    assert.match(opened, /line 0\b/);
+    assert.doesNotMatch(opened, /line 39/);
+
+    dashboard.handleInput("G");
     const pinned = dashboard.render(80).join("\n");
     assert.match(pinned, /line 39/);
-    assert.doesNotMatch(pinned, /line 0\b/);
 
     dashboard.handleInput("k");
     const paused = dashboard.render(80);


### PR DESCRIPTION
## Problem

Fixes #460.

Opening `/btw` on a long answer misrepresented the child transcript in three
ways that compounded into the reported symptom — a page that looked pasted into
the middle of the screen with content lost at both sides of the seam:

1. **The page opened at the end of the transcript.** `TranscriptViewport`
   follows the end by default, and the page reconciled to that on its first
   render. A `/btw` answer longer than one screen therefore started partway
   through: asked two questions, the answer to the first was never visible and
   the page began at the second heading.
2. **Hidden output above was never reported.** The scroll indicator was
   `followingEnd ? "" : "↓ N"`, so the state that hides the beginning was
   exactly the state that displayed nothing. The missing opening read as lost
   output rather than off-screen output.
3. **The mouse wheel scrolled the terminal's own history.** In regular
   (non-fullscreen) mode nothing captured wheel events, so scrolling inside the
   child page moved the host terminal's scrollback instead. That slid the
   parent conversation into view above a child page still occupying the lower
   rows — the "two cut fragments pasted together in the middle of the screen"
   the issue describes.

None of this lost data: leaving `/btw` and expanding with Ctrl+O showed the full
answer. All three defects were in the operator-facing projection.

## Value

A `/btw` aside reads as a self-contained page. The answer starts at its
beginning, hidden output is discoverable in whichever direction it exists, and
the wheel scrolls the page instead of dragging the parent conversation into it.
The fix lands in `extensions/shared/agent-session-page.ts`, so Direct Subagent
takeover and Workflow child transcript pages get the same behavior.

## Approach

Three commits, each with its own tests:

- `1e11ff5` — `TranscriptViewport` gains `linesAbove()`, symmetric to
  `linesBelow()` and clamped by the same `maxScrollTop`. The page reports both
  directions in the rule row it already renders, so the overlay keeps the exact
  terminal height it declares.
- `f88ca0f` — the first render anchors at the start when the transcript already
  overflows, and keeps following otherwise. The distinction is "output produced
  before I looked" versus "output arriving while I watch": a live child still
  scrolls streaming output into view, and reaching the end explicitly resumes
  following as before. `TranscriptViewport` stays a pure follow-to-end
  primitive; the page, which knows the lifecycle, decides the opening anchor.
- `eebcd75` — wheel handling split by TUI mode. In `regular` mode the page
  enables SGR mouse reporting (`?1000h`/`?1006h`) while focused and restores it
  on blur and dispose, parsing wheel events itself. In `fullscreen` mode Pi
  already owns mouse reporting, so the page implements `handleMouse` and takes
  normalized events from the host instead of touching terminal modes. Wheel-up
  pauses following like keyboard scrolling. `TakeoverView` and
  `WorkflowDashboard` forward focus and mouse events and dispose the page so
  reporting cannot leak past the overlay.

Two existing tests encoded the old open-at-end behavior (`doesNotMatch(/↓/)`,
and `match(/line 39/)` + `doesNotMatch(/line 0/)`). They were updated to the new
contract while keeping what they were really guarding: a paused reading anchor
is not pushed by appended rows, `G` resumes following, and the indicator rides
its rule without changing overlay height.

## Validation

Windows, Node 24.16.0:

- `biome format .` — clean
- `biome lint . --error-on-warnings` — clean
- `tsc --noEmit` — clean
- `node scripts/check-config-contract.mjs` — ✓ 15 persisted fields
- `node scripts/check-discipline-ledger.mjs` — ✓ 12 append-only rows
- Vitest, all `tests/**/*.spec.ts` — **9 files, 130 tests, all pass**
- Node, all `tests/**/*.test.ts` except `background-terminals` —
  **1377 tests, 1366 pass, 2 fail, 9 skipped**
- The four suites owning this code
  (`agent-session-page`, `transcript-viewport`, `subagents/takeover`,
  `workflows/dashboard`) — **54/54 pass**

The 2 Node failures are pre-existing and unrelated, verified by reverting the
changed files to `origin/main` and re-running: identical failures.

- `file-mutation-display/index.test.ts` — "overrides all seven activity renderers"
- `git-info/process.test.ts` — "captures output and tolerates command failures"
  (`process.exitCode = 7` observed as `-1`)

New tests cover: hidden rows reported in both directions and zero when the
transcript fits; a long answer opening at its start with the question visible;
a live child still following streaming output; a busy child opening at the start
and resuming follow on `G`; regular-mode wheel capture enabled only while
focused and restored on blur/dispose (idempotent, and not re-enabled after
dispose); and fullscreen-mode `handleMouse` scrolling without writing terminal
modes.

`tests/extensions/background-terminals/manager.test.ts` was excluded because it
does not terminate on this machine, and this was diagnosed rather than assumed.
Driving `TerminalManager` directly reports:

```
Process-tree termination could not be confirmed: taskkill exited 128;
taskkill timed out after 400ms; helper closed after SIGKILL;
stdio did not close after termination
```

`taskkill /T /F` exits 128 because the `cmd.exe` wrapper has already gone while
its orphaned `node.exe` grandchild survives; after `runtime.dispose()` one
`ChildProcess` and two stdio `Socket` handles stay open, so the Node test runner
cannot exit. Reverting this branch's files reproduces the same 7 failures and
the same hang, so it is pre-existing and independent of this change. It is worth
a separate issue, since CI runs this suite on `windows-latest`.

Manual confirmation of the reported scenario: `/btw` with a two-question answer
now opens showing the question and the first heading, with `↓ N` for the
remainder; wheel scrolling stays inside the page and no longer reveals the
parent conversation.

## Impact

- **User-visible behavior:** child session pages (`/btw`, Direct Subagent
  takeover, Workflow child transcripts) open at the start of output that
  predates them, report hidden output as `↑ N` / `↓ N`, and consume wheel
  scrolling instead of moving terminal history. Live children still follow
  streaming output.
- **Model-visible context/tools:** none.
- **Runtime/lifecycle:** in regular TUI mode a focused child page toggles SGR
  mouse reporting and restores it on blur and dispose; `TakeoverView` and
  `WorkflowDashboard` dispose the page on close so the mode cannot leak.
- **Persisted config/data:** none.
- **Compatibility/risk:** low-to-moderate. Terminal mouse modes are host state,
  so it is scoped to `mode === "regular"`, made idempotent, and restored on
  every exit path, with tests pinning both modes. Overlay height is unchanged
  and asserted.
