### PR TITLE
fix(setup): pin Effect prerelease cohort

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,10 @@
     "": {
       "name": "@tt-a1i/openpi",
       "dependencies": {
-        "@effect/platform-node": "^4.0.0-beta.99",
+        "@effect/platform-node": "4.0.0-beta.103",
+        "@effect/platform-node-shared": "4.0.0-beta.103",
         "acorn": "^8.17.0",
-        "effect": "^4.0.0-beta.99",
+        "effect": "4.0.0-beta.103",
         "jiti": "2.7.0",
         "undici": "8.9.0",
       },
@@ -20,7 +21,7 @@
         "@earendil-works/pi-coding-agent": "^0.85.1",
         "@earendil-works/pi-tui": "^0.85.1",
         "@effect/tsgo": "^0.24.2",
-        "@effect/vitest": "^4.0.0-beta.99",
+        "@effect/vitest": "4.0.0-beta.103",
         "@playwright/test": "1.62.1",
         "@stylexjs/stylex": "0.19.0",
         "@tailwindcss/vite": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -54,9 +54,10 @@
     "image": "https://raw.githubusercontent.com/openpi-dev/openpi/main/assets/openpi-package.png"
   },
   "dependencies": {
-    "@effect/platform-node": "^4.0.0-beta.99",
+    "@effect/platform-node": "4.0.0-beta.103",
+    "@effect/platform-node-shared": "4.0.0-beta.103",
     "acorn": "^8.17.0",
-    "effect": "^4.0.0-beta.99",
+    "effect": "4.0.0-beta.103",
     "jiti": "2.7.0",
     "undici": "8.9.0"
   },
@@ -69,7 +70,7 @@
     "@earendil-works/pi-coding-agent": "^0.85.1",
     "@earendil-works/pi-tui": "^0.85.1",
     "@effect/tsgo": "^0.24.2",
-    "@effect/vitest": "^4.0.0-beta.99",
+    "@effect/vitest": "4.0.0-beta.103",
     "@playwright/test": "1.62.1",
     "@stylexjs/stylex": "0.19.0",
     "@tailwindcss/vite": "4.3.3",

--- a/tests/effect-cohort.test.ts
+++ b/tests/effect-cohort.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+const effectCohort = "4.0.0-beta.103";
+
+test("Effect packages stay on one published prerelease cohort", () => {
+  const dependencies = {
+    ...packageJson.dependencies,
+    ...packageJson.devDependencies,
+  };
+
+  for (const packageName of [
+    "effect",
+    "@effect/platform-node",
+    "@effect/platform-node-shared",
+    "@effect/vitest",
+  ]) {
+    assert.equal(dependencies[packageName], effectCohort, packageName);
+  }
+});


### PR DESCRIPTION
## Problem

`npm install` from the packed OpenPI package resolves `@effect/platform-node@4.0.0-rc.114`, whose peer dependency requires `effect@^4.0.0-rc.114`. That `effect` version is not published, so packed installs fail with `ETARGET` (#533). Bun's lockfile already resolves the tested `4.0.0-beta.103` cohort, but npm does not consume `bun.lock`.

## Value

Keep published-package installation reproducible and unblock downstream PRs whose CI fails before running their own tests.

## Approach

- Pin `effect`, `@effect/platform-node`, and `@effect/platform-node-shared` to the published `4.0.0-beta.103` cohort.
- Pin `@effect/vitest` to the same cohort for local validation.
- Update `bun.lock` and add a regression test that rejects cohort drift.

## Validation

- `node --test --experimental-strip-types tests/effect-cohort.test.ts` — pass.
- `bun install --frozen-lockfile` — pass.
- `bun run check` — pass.
- Packed-package smoke install with `npm pack --ignore-scripts` followed by `npm install --ignore-scripts --no-audit --no-fund` — pass; installed `effect`, `@effect/platform-node`, and `@effect/platform-node-shared` are all `4.0.0-beta.103`.
- `bun run test` — 1,414 passed, 10 skipped, 5 failed. The failures are in existing git-info/setup/workflows tests and do not touch the files changed by this PR; no new cohort test failed.

## Impact

- User-visible behavior: packed npm installation no longer requests the unavailable `effect@4.0.0-rc.114`.
- Runtime behavior: none beyond dependency resolution.
- Compatibility: the Effect packages are intentionally kept on one published prerelease cohort; moving cohorts should be a coordinated dependency update.

Fixes #533